### PR TITLE
Remove redundant conditional judgement in rbtree deletion

### DIFF
--- a/src/core/ngx_rbtree.c
+++ b/src/core/ngx_rbtree.c
@@ -174,12 +174,7 @@ ngx_rbtree_delete(ngx_rbtree_t *tree, ngx_rbtree_node_t *node)
 
     } else {
         subst = ngx_rbtree_min(node->right, sentinel);
-
-        if (subst->left != sentinel) {
-            temp = subst->left;
-        } else {
-            temp = subst->right;
-        }
+        temp = subst->right;
     }
 
     if (subst == *root) {


### PR DESCRIPTION
In a binary tree deletion, as its defination, first we need to find the
minimal node of its right sub-tree to replace the location of the node
to be deleted when it has both its left and right children. Then we shall
trace its sub-tree to find the minimal node in `ngx_rbtree_min`. Since
the terminal condition of the tracing loop has already been set as
`node->left == sentinel`, there is no need to leave the following
if-condition judging whether the minimal node's left child is the sentinel
any more because the code will never run here. And the program
will be cleaner as well as run faster in some situations after removing
the redundant conditional branch.

By the way, in C++ SGI STL `stl_tree.c` source, we can see there is no if-
condition judgement in rbtree deletion:
https://github.com/dutor/stl/blob/master/sgi/stl_tree.h#L317

Signed-off-by: Leo Ma <begeekmyfriend@gmail.com>