### PR TITLE
Update ngx_conf_file.c

### DIFF
--- a/src/core/ngx_conf_file.c
+++ b/src/core/ngx_conf_file.c
@@ -680,7 +680,7 @@ ngx_conf_read_token(ngx_conf_t *cf)
                     return NGX_ERROR;
                 }
 
-                word->data = ngx_pnalloc(cf->pool, b->pos - start + 1);
+                word->data = ngx_pnalloc(cf->pool, b->pos - start);
                 if (word->data == NULL) {
                     return NGX_ERROR;
                 }


### PR DESCRIPTION
try the following command
test_cmd   arg opt

b->pos point to next "arg", start points to "test_cmd"
b->pos - start = 9(strlen("test_cmd")+strlen(SPACE))

the  old code alloc b->pos - start + 1 = 10bytes, but we only need 9bytes to store "test_cmd" and '\0'
so "+1" is a waste of memory
________________________________________________
modified nginx.conf, that only contain the following configuration
 worker_processes 4

and I added some log and print to monitor like this:

nginx: [emerg] Out LOOP start:08A848A8, b->pos:08A848B9, alloc:18 bytes, word->data:worker_processes,len(word->data):16 in /usr/local/nginx/conf/nginx.conf:3
 nginx: [emerg] Out LOOP start:08A848BA, b->pos:08A848BC, alloc:3 bytes, word->data:4,len(word->data):1 in /usr/local/nginx/conf/nginx.conf:3

"worker_processes" need 16+1 bytes, but alloced 18bytes
 "4" need 1+1 bytes, byt alloced 3 bytes