### PR TITLE
Compile PCRE without cpp

### DIFF
--- a/auto/lib/pcre/make
+++ b/auto/lib/pcre/make
@@ -53,7 +53,7 @@ $PCRE/Makefile:	$NGX_MAKEFILE
 	cd $PCRE \\
 	&& if [ -f Makefile ]; then \$(MAKE) distclean; fi \\
 	&& CC="\$(CC)" CFLAGS="$PCRE_OPT" \\
-	./configure --disable-shared $PCRE_CONF_OPT
+	./configure --disable-shared --disable-cpp $PCRE_CONF_OPT
 
 $PCRE/.libs/libpcre.a:	$PCRE/Makefile
 	cd $PCRE \\


### PR DESCRIPTION
This helps when compiling nginx against musl libc.
