### PR TITLE
server_names will be free if temp_pool be destroyed.

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -3431,7 +3431,7 @@ ngx_http_core_create_srv_conf(ngx_conf_t *cf)
      *     conf->client_large_buffers.num = 0;
      */
 
-    if (ngx_array_init(&cscf->server_names, cf->temp_pool, 4,
+    if (ngx_array_init(&cscf->server_names, cf->pool, 4,
                        sizeof(ngx_http_server_name_t))
         != NGX_OK)
     {


### PR DESCRIPTION
First of all, I just know a part nginx source code. the issue occur when I use source code to dump configuration to json.

then,  I find out  then server_names is zero if i call ngx_pcalloc sometimes.  

finally, I gdb the Nginx and catch the root cause that the server_names be assign in wrong pool. 

I don't know whether the solution is the best. Just throw the issue. thanks.