### PR TITLE
fix a bug that in the function ngx_http_subrequest, it will make the …

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -2274,7 +2274,8 @@ ngx_http_subrequest(ngx_http_request_t *r,
     sr->pool = r->pool;
 
     sr->headers_in = r->headers_in;
-
+    sr->headers_in.headers.last = &sr->headers_in.headers.part;
+    
     ngx_http_clear_content_length(sr);
     ngx_http_clear_accept_ranges(sr);
     ngx_http_clear_last_modified(sr);


### PR DESCRIPTION
…headers_in.headers  incorrect，and it will cause many problems

//sr->headers_in = r->headers_in; 
This line of code copy the headers  but make the struct  mistake that  sr->headers_in.headers.last  mismatch &sr->headers_in.headers.part， if somewhere use  sr->headers_in.headers.last ，it will cause assert or some other problems。fx：in the function ngx_http_headers_more_assert 
so I update for this.