### PR TITLE
fix a bug that in the function ngx_http_subrequest, it will make the …

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -2274,7 +2274,7 @@ ngx_http_subrequest(ngx_http_request_t *r,
     sr->pool = r->pool;
 
     sr->headers_in = r->headers_in;
-    if (sr->headers_in.headers.part->next == NULL) {
+    if (sr->headers_in.headers.part.next == NULL) {
         sr->headers_in.headers.last = &sr->headers_in.headers.part;
     }
 

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -2274,6 +2274,9 @@ ngx_http_subrequest(ngx_http_request_t *r,
     sr->pool = r->pool;
 
     sr->headers_in = r->headers_in;
+    if (sr->headers_in.headers.part->next == NULL) {
+        sr->headers_in.headers.last = &sr->headers_in.headers.part;
+    }
 
     ngx_http_clear_content_length(sr);
     ngx_http_clear_accept_ranges(sr);


### PR DESCRIPTION
…headers_in.headers  incorrect，and it will cause many problems

//sr->headers_in = r->headers_in; 
This line of code copy the headers  ,but it  maybe make the struct  mistake that  sr->headers_in.headers.last  mismatch &sr->headers_in.headers.part, when only one part be copied, the mismatch happen. if somewhere use  sr->headers_in.headers.last ，it will cause assert or some other problems。fx：in the function ngx_http_headers_more_assert 
so  only when there is only one part, the  mismatch happen  , and I update for this.  
By the way thanks for RaymondSchnyder ,  i got a mistake with code  in previous pull request, he find it