### PR TITLE
fix proxy_protocol udp bug

### DIFF
--- a/src/core/ngx_proxy_protocol.c
+++ b/src/core/ngx_proxy_protocol.c
@@ -33,7 +33,7 @@ ngx_proxy_protocol_read(ngx_connection_t *c, u_char *buf, u_char *last)
         goto skip;
     }
 
-    if (len < 5 || ngx_strncmp(p, "TCP", 3) != 0
+    if (len < 5 || (ngx_strncmp(p, "TCP", 3) != 0 && ngx_strncmp(p, "UDP", 3) != 0)
         || (p[3] != '4' && p[3] != '6') || p[4] != ' ')
     {
         goto invalid;
@@ -140,12 +140,20 @@ ngx_proxy_protocol_write(ngx_connection_t *c, u_char *buf, u_char *last)
     switch (c->sockaddr->sa_family) {
 
     case AF_INET:
-        buf = ngx_cpymem(buf, "PROXY TCP4 ", sizeof("PROXY TCP4 ") - 1);
+        if (c->type == SOCK_STREAM) {
+            buf = ngx_cpymem(buf, "PROXY TCP4 ", sizeof("PROXY TCP4 ") - 1);
+        } else {
+            buf = ngx_cpymem(buf, "PROXY UDP4 ", sizeof("PROXY UDP4 ") - 1);
+        }
         break;
 
 #if (NGX_HAVE_INET6)
     case AF_INET6:
-        buf = ngx_cpymem(buf, "PROXY TCP6 ", sizeof("PROXY TCP6 ") - 1);
+        if (c->type == SOCK_STREAM) {
+            buf = ngx_cpymem(buf, "PROXY TCP6 ", sizeof("PROXY TCP6 ") - 1);
+        } else {
+            buf = ngx_cpymem(buf, "PROXY UDP6 ", sizeof("PROXY UDP6 ") - 1);
+        }
         break;
 #endif
 


### PR DESCRIPTION
fix proxy_protocol udp bug;When I use proxy_protocol with udp, the result of packet capture is “”PROXY TCP4......”;So, I increase udp of proxy_protocol;Of course, you can also increase unix socket. 