### PR TITLE
Fix problem with compiler use C89/90

### DIFF
--- a/auto/cc/gcc
+++ b/auto/cc/gcc
@@ -171,6 +171,9 @@ CFLAGS="$CFLAGS -Werror"
 # debug
 CFLAGS="$CFLAGS -g"
 
+# C99
+CFLAGS="$CFLAGS -std=99"
+
 # DragonFly's gcc3 generates DWARF
 #CFLAGS="$CFLAGS -g -gstabs"
 


### PR DESCRIPTION
  ERROR:‘for’ loop initial declarations are only allowed in C99 mode