### PR TITLE
Add image/heic to mime.types

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -20,6 +20,7 @@ types {
     image/tiff                                       tif tiff;
     image/vnd.wap.wbmp                               wbmp;
     image/webp                                       webp;
+    image/heic                                       heic;
     image/x-icon                                     ico;
     image/x-jng                                      jng;
     image/x-ms-bmp                                   bmp;


### PR DESCRIPTION
In Apple's implementation, for single images they have chosen the latter .heic filename extension as the only one they will produce for photos, which indicates clearly that it went through HEVC encoding.
https://en.wikipedia.org/wiki/High_Efficiency_Image_File_Format