### PR TITLE
Update ngx_event_pipe.c

### DIFF
--- a/src/event/ngx_event_pipe.c
+++ b/src/event/ngx_event_pipe.c
@@ -262,7 +262,7 @@ ngx_event_pipe_read_upstream(ngx_event_pipe_t *p)
                 break;
 
             } else if (p->cacheable
-                       || p->temp_file->offset < p->max_temp_file_size)
+                       && p->temp_file->offset < p->max_temp_file_size)
             {
 
                 /*


### PR DESCRIPTION
Using '&&’  instead of '||'  when  do file size comparison.