### PR TITLE
Adeed "apk" as application/vnd.android.package-archive

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -28,6 +28,7 @@ types {
     font/woff2                                       woff2;
 
     application/java-archive                         jar war ear;
+    application/vnd.android.package-archive          apk;
     application/json                                 json;
     application/mac-binhex40                         hqx;
     application/msword                               doc;


### PR DESCRIPTION
Since ".apk" extension is not managed by nginx, added to mime.types.
I have tested it on my nginx/1.15.8 and .apk files are correctly downloaded. Before, without ".apk" in  mime.types, nginx sent .apk as "text".