### PR TITLE
Patch for the HT problem (#1752)

### DIFF
--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -996,6 +996,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_space_before_value:
             switch (ch) {
             case ' ':
+            case '\x9':
                 break;
             case CR:
                 r->header_start = p;
@@ -1019,6 +1020,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_value:
             switch (ch) {
             case ' ':
+            case '\x9':
                 r->header_end = p;
                 state = sw_space_after_value;
                 break;
@@ -1038,6 +1040,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_space_after_value:
             switch (ch) {
             case ' ':
+            case '\x9':
                 break;
             case CR:
                 state = sw_almost_done;


### PR DESCRIPTION
This is a PR that addresses an issue I've discovered in Nginx (https://trac.nginx.org/nginx/ticket/1752) when using custom equipment. The equipment's FW is not modifiable and according to HTTP RFC the way it sends the content-length header value is Ok.
 