### PR TITLE
skip apply "ngx_http_upstream_process_accel_expires" when a request responeded by cache

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -4776,6 +4776,10 @@ ngx_http_upstream_process_accel_expires(ngx_http_request_t *r,
         return NGX_OK;
     }
 
+    if (r->cached == 1) {
+        return NGX_OK;
+    }
+
     len = h->value.len;
     p = h->value.data;
 


### PR DESCRIPTION
"ngx_http_upstream_process_accel_expires" is calculate and set valid_date value when a request will responded by a cache, even though it will never use in response.
So, this patch can skip unnecessary process.

On the other hands, this has good side effect to can get TRUE valid_date value of the cache in "header filter" and "log" hook handler.