### PR TITLE
Accept4() support `SOCK_CLOEXEC` flag

### DIFF
--- a/auto/unix
+++ b/auto/unix
@@ -510,7 +510,7 @@ ngx_feature_run=no
 ngx_feature_incs="#include <sys/socket.h>"
 ngx_feature_path=
 ngx_feature_libs=
-ngx_feature_test="accept4(0, NULL, NULL, SOCK_NONBLOCK)"
+ngx_feature_test="accept4(0, NULL, NULL, SOCK_NONBLOCK | SOCK_CLOEXEC)"
 . auto/feature
 
 if [ $NGX_FILE_AIO = YES ]; then

--- a/src/event/ngx_event_accept.c
+++ b/src/event/ngx_event_accept.c
@@ -57,7 +57,7 @@ ngx_event_accept(ngx_event_t *ev)
 
 #if (NGX_HAVE_ACCEPT4)
         if (use_accept4) {
-            s = accept4(lc->fd, &sa.sockaddr, &socklen, SOCK_NONBLOCK);
+            s = accept4(lc->fd, &sa.sockaddr, &socklen, SOCK_NONBLOCK | SOCK_CLOEXEC);
         } else {
             s = accept(lc->fd, &sa.sockaddr, &socklen);
         }


### PR DESCRIPTION
As [man page](https://www.freebsd.org/cgi/man.cgi?query=accept4&sektion=2) says: **"the close-on-exec flag	on the new file	descriptor can be set via the SOCK_CLOEXEC flag in the flags argument."**