### PR TITLE
Add WebAssembly header to default mime.types list

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -68,6 +68,7 @@ types {
     application/x-xpinstall                          xpi;
     application/xhtml+xml                            xhtml;
     application/xspf+xml                             xspf;
+    application/wasm                                 wasm;
     application/zip                                  zip;
 
     application/octet-stream                         bin exe dll;


### PR DESCRIPTION
Setting `Content-Type` to `application/wasm` is required for browsers using [`WebAssembly.instantiateStreaming`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming).

Submitting this PR so I don't have to remember to configure this