### PR TITLE
Enable HTTPS for FastCGI

### DIFF
--- a/conf/fastcgi.conf
+++ b/conf/fastcgi.conf
@@ -11,7 +11,7 @@ fastcgi_param  DOCUMENT_URI       $document_uri;
 fastcgi_param  DOCUMENT_ROOT      $document_root;
 fastcgi_param  SERVER_PROTOCOL    $server_protocol;
 fastcgi_param  REQUEST_SCHEME     $scheme;
-fastcgi_param  HTTPS              $https if_not_empty;
+fastcgi_param  HTTPS              $https;
 
 fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
 fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;

--- a/conf/fastcgi_params
+++ b/conf/fastcgi_params
@@ -10,7 +10,7 @@ fastcgi_param  DOCUMENT_URI       $document_uri;
 fastcgi_param  DOCUMENT_ROOT      $document_root;
 fastcgi_param  SERVER_PROTOCOL    $server_protocol;
 fastcgi_param  REQUEST_SCHEME     $scheme;
-fastcgi_param  HTTPS              $https if_not_empty;
+fastcgi_param  HTTPS              $https;
 
 fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
 fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;


### PR DESCRIPTION
If the intention is to have FastCGI param for HTTPS enabled by default then remove the if_not_empty I had to remove this to get mine to work correctly.
Also looking at this link the default for Ubuntu/Debian is to not check if_not_empty
Link: https://www.nginx.com/resources/wiki/start/topics/examples/phpfcgi/