### PR TITLE
Reword referrer in error logs

### DIFF
--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -3889,7 +3889,7 @@ ngx_http_log_error_handler(ngx_http_request_t *r, ngx_http_request_t *sr,
     }
 
     if (r->headers_in.referer) {
-        p = ngx_snprintf(buf, len, ", referrer: \"%V\"",
+        p = ngx_snprintf(buf, len, ", referer: \"%V\"",
                          &r->headers_in.referer->value);
         buf = p;
     }


### PR DESCRIPTION
Everywhere in the codebase, referer (one r) is used except in the error log.
If we follow the documentation from [mozilla.org](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer) we should have referer (one r) everywhere to be consistent.

Signed-off-by: Jérémie Drouet <jeremie.drouet@datadoghq.com>