### PR TITLE
Add .mjs file extension to known JS mime types

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -5,7 +5,7 @@ types {
     text/xml                                         xml;
     image/gif                                        gif;
     image/jpeg                                       jpeg jpg;
-    application/javascript                           js;
+    application/javascript                           js mjs;
     application/atom+xml                             atom;
     application/rss+xml                              rss;
 


### PR DESCRIPTION
Originally proposed for node. This is supported by in various standards / ecosystems these days, E.G. https://github.com/whatwg/html/pull/3810