### PR TITLE
fix to verify entire client certificate chain

### DIFF
--- a/src/event/ngx_event_openssl_stapling.c
+++ b/src/event/ngx_event_openssl_stapling.c
@@ -986,7 +986,7 @@ ngx_ssl_ocsp_validate_next(ngx_connection_t *c)
 
     for ( ;; ) {
 
-        if (ocsp->ncert == n - 1 || (ocf->depth == 2 && ocsp->ncert == 1)) {
+        if (ocsp->ncert == n || (ocf->depth == 2 && ocsp->ncert == 1)) {
             ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
                            "ssl ocsp validated, certs:%ui", ocsp->ncert);
             rc = NGX_OK;


### PR DESCRIPTION
when ssl_ocsp is turned on, it doesn't verify the root certificate.
e.g. a certificate chain: root -> intermediate -> client
it only verifies client and intermediate.