### PR TITLE
adding worker_processes negative value from total cpu

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -1518,6 +1518,19 @@ ngx_set_worker_processes(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     ccf->worker_processes = ngx_atoi(value[1].data, value[1].len);
 
+    // Often seen pattern is where the team wants to set 1 or 2 cores aside 
+    // for other systems disposable. This simplifies the process of counting cores.
+    // One can set aside x number of cores no matter system is 32 core or 64 core 
+
+
+    if (ccf->worker_processes < 0 && ngx_abs(ccf->worker_processes) < ngx_ncpu) {
+        ccf->worker_processes = ngx_ncpu + ccf->worker_processes + 1 ;
+        return NGX_CONF_OK;
+
+    }
+
+
+
     if (ccf->worker_processes == NGX_ERROR) {
         return "invalid value";
     }

--- a/src/core/ngx_string.c
+++ b/src/core/ngx_string.c
@@ -965,8 +965,8 @@ ngx_filename_cmp(u_char *s1, u_char *s2, size_t n)
 
 ngx_int_t
 ngx_atoi(u_char *line, size_t n)
-{
-    ngx_int_t  value, cutoff, cutlim;
+{ 
+    ngx_int_t  value, cutoff, cutlim, sign = 1;
 
     if (n == 0) {
         return NGX_ERROR;
@@ -976,7 +976,7 @@ ngx_atoi(u_char *line, size_t n)
     cutlim = NGX_MAX_INT_T_VALUE % 10;
 
     for (value = 0; n--; line++) {
-        if (*line < '0' || *line > '9') {
+        if (*line != '-' &&  (*line < '0' || *line > '9' )) {
             return NGX_ERROR;
         }
 
@@ -984,8 +984,18 @@ ngx_atoi(u_char *line, size_t n)
             return NGX_ERROR;
         }
 
-        value = value * 10 + (*line - '0');
+        if (*line == '-'){
+            sign = -1;
+        } else {
+            value = value * 10 + (*line - '0');
+        }
     }
+    if (sign == -1) {
+        // to side step NGX_ERROR, we add -1 to the value
+        // -1 will be value -2
+        value = ((value + 1) * sign);
+
+    } 
 
     return value;
 }


### PR DESCRIPTION
Often nginx deployment is based on 1 or 2 free CPUs of the total. This is done so that these CPUs may serve other elements of workload, like microservices or just OS using it for handling system resources. 

By being able to to define negative value, deployment can have uniform configuration whether number of CPUs is 64 or 128. 