### PR TITLE
Add AVIF image to conf/mime.types

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -15,6 +15,7 @@ types {
     text/vnd.wap.wml                                 wml;
     text/x-component                                 htc;
 
+    image/avif                                       avif;
     image/png                                        png;
     image/svg+xml                                    svg svgz;
     image/tiff                                       tif tiff;


### PR DESCRIPTION
Broader AVIF support, and likely also adoption, is incoming:
- About 1/2 size compared to jpeg, 2/3 compared to webp, and roughly 1/1 with JPEG XL*
- Already support in stable versions of Chrome and Firefox 
    - Also unstable versions of Edge/Opera(Chromium) and Safari(Webkit)

So makes sense to add it to mime.types given it's considered a stable format already.

_* not finalized and not supported in any stable browsers_