### PR TITLE
Correct JavaScript MIME types + extensions per RFC 9239

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -5,7 +5,7 @@ types {
     text/xml                                         xml;
     image/gif                                        gif;
     image/jpeg                                       jpeg jpg;
-    application/javascript                           js;
+    text/javascript                                  js mjs;
     application/atom+xml                             atom;
     application/rss+xml                              rss;
 

--- a/src/http/modules/ngx_http_charset_filter_module.c
+++ b/src/http/modules/ngx_http_charset_filter_module.c
@@ -128,7 +128,7 @@ static ngx_str_t  ngx_http_charset_default_types[] = {
     ngx_string("text/xml"),
     ngx_string("text/plain"),
     ngx_string("text/vnd.wap.wml"),
-    ngx_string("application/javascript"),
+    ngx_string("text/javascript"),
     ngx_string("application/rss+xml"),
     ngx_null_string
 };


### PR DESCRIPTION
This patch updates the MIME type configuration per RFC 9239.
https://www.rfc-editor.org/rfc/rfc9239

First, the recommended MIME type is now `text/javascript`:

> The most widely supported media type in use is `text/javascript`; all
> others are considered historical and obsolete aliases of `text/javascript`.

Second, the `.mjs` extension is now explicitly registered:

> The `.mjs` file extension signals that the file represents a JavaScript
> module. Execution environments that rely on file extensions to
> determine how to process inputs parse `.mjs` files using the Module
> grammar of [ECMA-262].

IANA template: https://www.iana.org/assignments/media-types/text/javascript