### PR TITLE
Fix the core-dumped bug caused by executing "-s reload"

### DIFF
--- a/src/core/ngx_cycle.c
+++ b/src/core/ngx_cycle.c
@@ -1379,7 +1379,9 @@ ngx_clean_old_cycles(ngx_event_t *ev)
     cycle = ngx_old_cycles.elts;
     for (i = 0; i < ngx_old_cycles.nelts; i++) {
 
-        if (cycle[i] == NULL) {
+        if (cycle[i] == NULL
+            || cycle[i]->connections == NULL)
+        {
             continue;
         }
 


### PR DESCRIPTION
If the nginx configuration file uses "master_process off"; and then executes “-s reload” twice or more, there will be a core dumped