### PR TITLE
fix bug core dumped cause by 'key % hash->size' when hash->size == 0

### DIFF
--- a/src/core/ngx_hash.c
+++ b/src/core/ngx_hash.c
@@ -18,6 +18,9 @@ ngx_hash_find(ngx_hash_t *hash, ngx_uint_t key, u_char *name, size_t len)
 #if 0
     ngx_log_error(NGX_LOG_ALERT, ngx_cycle->log, 0, "hf:\"%*s\"", len, name);
 #endif
+    if (hash->size == 0) {
+        return NULL;
+    }
 
     elt = hash->buckets[key % hash->size];
 


### PR DESCRIPTION
Call Path is ngx_http_upstream_process_headers -> ngx_hash_find(&u->conf->hide_headers_hash, h[i].hash,h[i].lowcase_key, h[i].key.len), when hide_headers_hash->size == 0 will be core dumped