### PR TITLE
when space characters exist in querystring nginx will report 400 error, compatible with this case

### DIFF
--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -97,7 +97,7 @@ int ngx_http_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg);
 int ngx_http_ssl_certificate(ngx_ssl_conn_t *ssl_conn, void *arg);
 #endif
 
-
+ngx_int_t ngx_http_parse_the_end_of_request_line(u_char *m);
 ngx_int_t ngx_http_parse_request_line(ngx_http_request_t *r, ngx_buf_t *b);
 ngx_int_t ngx_http_parse_uri(ngx_http_request_t *r);
 ngx_int_t ngx_http_parse_complex_uri(ngx_http_request_t *r,

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -97,6 +97,18 @@ static uint32_t  usual[] = {
 
 #endif
 
+/* Parse the request line and decide if it ends with the http version */
+ngx_int_t
+ngx_http_parse_the_end_of_request_line(u_char *m)
+{
+    if (m[0] == ' ' && m[1] == 'H' && m[2] == 'T' && m[3] == 'T' && m[4] == 'P'
+        && m[5] == '/' && m[6] >= '1' && m[6] <= '9' && m[7] == '.'
+        && m[8] >= '0' && m[8] <= '9' && m[9] == CR && m[10] == LF)
+    {
+        return 1;
+    }
+    return 0;
+}
 
 /* gcc, icc, msvc and others compile these switches as an jump table */
 
@@ -607,9 +619,13 @@ ngx_http_parse_request_line(ngx_http_request_t *r, ngx_buf_t *b)
 
             switch (ch) {
             case ' ':
-                r->uri_end = p;
-                state = sw_http_09;
-                break;
+                if (ngx_http_parse_the_end_of_request_line(p) == 0) {
+                      break;
+                }else{
+                      r->uri_end = p;
+                      state = sw_http_09;
+                      break;
+                }
             case CR:
                 r->uri_end = p;
                 r->http_minor = 9;


### PR DESCRIPTION
we upgrade the version from 1.13.6 to 1.21.4 , we found that when space characters exist in query string , nginx will report  status code 400 to our client ,that will cause some problems, we suggest compatible with this case.