### PR TITLE
auto/feature: add "#include <stdio.h>" to fix error by modern compiler

### DIFF
--- a/auto/feature
+++ b/auto/feature
@@ -27,6 +27,7 @@ fi
 
 cat << END > $NGX_AUTOTEST.c
 
+#include <stdio.h>
 #include <sys/types.h>
 $NGX_INCLUDE_UNISTD_H
 $ngx_feature_incs


### PR DESCRIPTION
some module define nginx_feature_test as:
  nginx_feature_test='printf("hello");'

such as https://github.com/owasp-modsecurity/ModSecurity-nginx/blob/master/config#L16

which will cause following compilation error when compiling with modern compiler (such as clang 18):

objs/autotest.c:7:5: error: call to undeclared library function 'printf' with type 'int (const char *, ...)'; ISO C99 and later do not support Implicit function declarations [-Wimplicit-function-declaration]