### PR TITLE
Enable gzip on default

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -30,7 +30,7 @@ http {
     #keepalive_timeout  0;
     keepalive_timeout  65;
 
-    #gzip  on;
+    gzip  on;
 
     server {
         listen       80;


### PR DESCRIPTION
Hi, 

This is a small change that has the potential to make  a significant change on the environmental impact.

Enabling gzip on default as a greener default. I don't know the implications of this change and maybe there are good reasons for this default, but maybe where are good reasons to enable this.

I summed up the reason in this short article:

https://typeshare.co/ti/posts/want-to-make-your-web-service-greener-this-single-flag-in-your-nginx-configuration-decreases-your-carbon-emission

Maybe I am totally wrong about this. In this case please help me to find the flaws in my thinking so that I can learn :)

Thank you :) 