### PR TITLE
HTTP/3: limited prefixed integers encoded length.

### DIFF
--- a/src/http/v3/ngx_http_v3_parse.c
+++ b/src/http/v3/ngx_http_v3_parse.c
@@ -623,6 +623,12 @@ ngx_http_v3_parse_literal(ngx_connection_t *c, ngx_http_v3_parse_literal_t *st,
             }
 
             if (st->huffman) {
+                if (n > NGX_MAX_INT_T_VALUE / 8) {
+                    ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                                  "client sent too large field line");
+                    return NGX_HTTP_V3_ERR_EXCESSIVE_LOAD;
+                }
+
                 n = n * 8 / 5;
                 st->huffstate = 0;
             }


### PR DESCRIPTION
Similar to ngx_http_v2_module, the implementation limit is now set to 4 bytes length, see NGX_HTTP_V2_INT_OCTETS in ngx_http_v2_parse_int().

For example, this limits a maximum integer value encoded with a 7-bit prefix to 2097278, with similar limits using other prefixes.