### PR TITLE
Add MIME type for JPEG XL.

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -16,6 +16,7 @@ types {
     text/x-component                                 htc;
 
     image/avif                                       avif;
+    image/jxl                                        jxl;
     image/png                                        png;
     image/svg+xml                                    svg svgz;
     image/tiff                                       tif tiff;


### PR DESCRIPTION
Adds the official registered [IANA Media Type for the JPEG XL image format](https://www.iana.org/assignments/media-types/image/jxl) to the default `mime.types` config so that servers can properly serve JXL images by default instead of requiring manual configuration (of which many servers do not take the time to properly setup sadly).
Note: This same change was originally submitted to the mailing list and I have gotten permission from the original author to re-submit it to GitHub (https://mailman.nginx.org/pipermail/nginx-devel/2024-August/UIGU3MEWNVQQ4BAT63CJDIAXR6AETCHC.html)