### PR TITLE
GitHub: Fix link to Contributing Guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,5 @@ If this pull request addresses an issue on GitHub, make sure to reference that
 issue using one of the
 [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
 
-Before creating a pull request, make sure to comply with
-[`Contributing Guidelines`](/CONTRIBUTING.md).
+Before creating a pull request, make sure to comply with the
+[Contributing Guidelines](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
Absolute paths in links end up being rooted at `github.com`.

The contributing guidelines link is broken unless we use the full URL.

Also, remove superfluous `monospace formatting` for the link.