### PR TITLE
IP_TRANSPARENT support for listening sockets

### DIFF
--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -563,6 +563,22 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
             }
 #endif
 
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+            if (ls[i].transparent) {
+                int  transparent = 1;
+
+                if (setsockopt(s, SOL_IP, IP_TRANSPARENT,
+                               (const void *) &transparent, sizeof(int))
+                    == -1)
+                {
+                    ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
+                                "setsockopt(IP_TRANSPARENT) for %V failed, "
+                                "ignored",
+                                &ls[i].addr_text);
+                }
+            }
+#endif
+
 #if (NGX_HAVE_INET6 && defined IPV6_V6ONLY)
 
             if (ls[i].sockaddr->sa_family == AF_INET6) {

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -150,6 +150,9 @@ ngx_set_inherited_sockets(ngx_cycle_t *cycle)
 #if (NGX_HAVE_REUSEPORT)
     int                        reuseport;
 #endif
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+    int                        transparent;
+#endif
 
     ls = cycle->listening.elts;
     for (i = 0; i < cycle->listening.nelts; i++) {
@@ -416,6 +419,31 @@ ngx_set_inherited_sockets(ngx_cycle_t *cycle)
 
         ls[i].deferred_accept = 1;
 #endif
+
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+        transparent = 0;
+        olen = sizeof(int);
+        if (getsockopt(ls[i].fd, SOL_IP, IP_TRANSPARENT, &transparent, &olen)
+            == -1)
+        {
+            err = ngx_socket_errno;
+
+            if (err == NGX_EOPNOTSUPP || err == NGX_ENOPROTOOPT) {
+                continue;
+            }
+
+            ngx_log_error(NGX_LOG_NOTICE, cycle->log, err,
+                          "getsockopt(IP_TRANSPARENT) for %V failed, ignored",
+                          &ls[i].addr_text);
+            continue;
+        }
+
+        if (olen < sizeof(int) || transparent == 0) {
+            continue;
+        }
+
+        ls[i].transparent = 1;
+#endif
     }
 
     return NGX_OK;
@@ -586,6 +614,22 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
                     return NGX_ERROR;
                 }
 #endif
+            }
+#endif
+
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+            if (ls[i].transparent) {
+                int  transparent = 1;
+
+                if (setsockopt(s, SOL_IP, IP_TRANSPARENT,
+                               (const void *) &transparent, sizeof(int))
+                    == -1)
+                {
+                    ngx_log_error(NGX_LOG_EMERG, log, ngx_socket_errno,
+                                "setsockopt(IP_TRANSPARENT) for %V failed, "
+                                "ignored",
+                                &ls[i].addr_text);
+                }
             }
 #endif
 

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -78,6 +78,11 @@ struct ngx_listening_s {
     unsigned            deferred_accept:1;
     unsigned            delete_deferred:1;
     unsigned            add_deferred:1;
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+    unsigned            transparent:1;
+#else
+    unsigned            :1;
+#endif
 #if (NGX_HAVE_DEFERRED_ACCEPT && defined SO_ACCEPTFILTER)
     char               *accept_filter;
 #endif

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -81,6 +81,11 @@ struct ngx_listening_s {
     unsigned            deferred_accept:1;
     unsigned            delete_deferred:1;
     unsigned            add_deferred:1;
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+    unsigned            transparent:1;
+#else
+    unsigned            :1;
+#endif
 #if (NGX_HAVE_DEFERRED_ACCEPT && defined SO_ACCEPTFILTER)
     char               *accept_filter;
 #endif

--- a/src/event/ngx_event_accept.c
+++ b/src/event/ngx_event_accept.c
@@ -215,8 +215,21 @@ ngx_event_accept(ngx_event_t *ev)
 
         c->socklen = socklen;
         c->listening = ls;
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+        if(ls->transparent) {
+            c->local_sockaddr = NULL;
+            c->local_socklen = 0;
+            if (ngx_connection_local_sockaddr(c, NULL, 0) != NGX_OK) {
+                ngx_close_accepted_connection(c);
+                return;
+            }
+        }else{
+#endif
         c->local_sockaddr = ls->sockaddr;
         c->local_socklen = ls->socklen;
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+        }
+#endif
 
 #if (NGX_HAVE_UNIX_DOMAIN)
         if (c->sockaddr->sa_family == AF_UNIX) {

--- a/src/event/ngx_event_accept.c
+++ b/src/event/ngx_event_accept.c
@@ -232,8 +232,21 @@ ngx_event_accept(ngx_event_t *ev)
 
         c->socklen = socklen;
         c->listening = ls;
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+        if(ls->transparent) {
+            c->local_sockaddr = NULL;
+            c->local_socklen = 0;
+            if (ngx_connection_local_sockaddr(c, NULL, 0) != NGX_OK) {
+                ngx_close_accepted_connection(c);
+                return;
+            }
+        }else{
+#endif
         c->local_sockaddr = ls->sockaddr;
         c->local_socklen = ls->socklen;
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+        }
+#endif
 
 #if (NGX_HAVE_UNIX_DOMAIN)
         if (c->sockaddr->sa_family == AF_UNIX) {

--- a/src/http/ngx_http.c
+++ b/src/http/ngx_http.c
@@ -1850,6 +1850,11 @@ ngx_http_add_listening(ngx_conf_t *cf, ngx_http_conf_addr_t *addr)
     ls->sndbuf = addr->opt.sndbuf;
 
     ls->keepalive = addr->opt.so_keepalive;
+
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+    ls->transparent = addr->opt.transparent;
+#endif
+
 #if (NGX_HAVE_KEEPALIVE_TUNABLE)
     ls->keepidle = addr->opt.tcp_keepidle;
     ls->keepintvl = addr->opt.tcp_keepintvl;

--- a/src/http/ngx_http.c
+++ b/src/http/ngx_http.c
@@ -1852,6 +1852,11 @@ ngx_http_add_listening(ngx_conf_t *cf, ngx_http_conf_addr_t *addr)
     ls->sndbuf = addr->opt.sndbuf;
 
     ls->keepalive = addr->opt.so_keepalive;
+
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+    ls->transparent = addr->opt.transparent;
+#endif
+
 #if (NGX_HAVE_KEEPALIVE_TUNABLE)
     ls->keepidle = addr->opt.tcp_keepidle;
     ls->keepintvl = addr->opt.tcp_keepintvl;

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -4126,6 +4126,17 @@ ngx_http_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             continue;
         }
 
+       if (ngx_strcmp(value[n].data, "transparent") == 0) {
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+            lsopt.transparent = 1;
+#else
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "transparent mode is not supported "
+                               "on this platform, ignored");
+#endif
+            continue;
+        }
+
         if (ngx_strncmp(value[n].data, "ipv6only=o", 10) == 0) {
 #if (NGX_HAVE_INET6 && defined IPV6_V6ONLY)
             if (ngx_strcmp(&value[n].data[10], "n") == 0) {

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -4218,6 +4218,17 @@ ngx_http_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             continue;
         }
 
+       if (ngx_strcmp(value[n].data, "transparent") == 0) {
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+            lsopt.transparent = 1;
+#else
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "transparent mode is not supported "
+                               "on this platform, ignored");
+#endif
+            continue;
+        }
+
         if (ngx_strncmp(value[n].data, "ipv6only=o", 10) == 0) {
 #if (NGX_HAVE_INET6 && defined IPV6_V6ONLY)
             if (ngx_strcmp(&value[n].data[10], "n") == 0) {

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -83,6 +83,11 @@ typedef struct {
     unsigned                   reuseport:1;
     unsigned                   so_keepalive:2;
     unsigned                   proxy_protocol:1;
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+    unsigned                   transparent:1;
+#else
+    unsigned                   :1;
+#endif
 
     int                        backlog;
     int                        rcvbuf;

--- a/src/stream/ngx_stream.c
+++ b/src/stream/ngx_stream.c
@@ -1046,6 +1046,10 @@ ngx_stream_add_listening(ngx_conf_t *cf, ngx_stream_conf_addr_t *addr)
     ls->reuseport = addr->opt.reuseport;
 #endif
 
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+    ls->transparent = addr->opt.transparent;
+#endif
+
     ls->wildcard = addr->opt.wildcard;
 
     return ls;

--- a/src/stream/ngx_stream.c
+++ b/src/stream/ngx_stream.c
@@ -1045,6 +1045,10 @@ ngx_stream_add_listening(ngx_conf_t *cf, ngx_stream_conf_addr_t *addr)
     ls->reuseport = addr->opt.reuseport;
 #endif
 
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+    ls->transparent = addr->opt.transparent;
+#endif
+
     ls->wildcard = addr->opt.wildcard;
 
     return ls;

--- a/src/stream/ngx_stream.h
+++ b/src/stream/ngx_stream.h
@@ -57,6 +57,11 @@ typedef struct {
     unsigned                       reuseport:1;
     unsigned                       so_keepalive:2;
     unsigned                       proxy_protocol:1;
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+    unsigned                       transparent:1;
+#else
+    unsigned                       :1;
+#endif
 
     int                            backlog;
     int                            rcvbuf;

--- a/src/stream/ngx_stream_core_module.c
+++ b/src/stream/ngx_stream_core_module.c
@@ -930,6 +930,10 @@ ngx_stream_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     lsopt.ipv6only = 1;
 #endif
 
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+    lsopt.transparent = 0;
+#endif
+
     backlog = 0;
 
     for (i = 2; i < cf->args->nelts; i++) {
@@ -1031,6 +1035,16 @@ ngx_stream_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 return NGX_CONF_ERROR;
             }
 
+            continue;
+        }
+        if (ngx_strcmp(value[i].data, "transparent") == 0) {
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+            lsopt.transparent = 1;
+#else
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "transparent mode is not supported "
+                               "on this platform, ignored");
+#endif
             continue;
         }
 

--- a/src/stream/ngx_stream_core_module.c
+++ b/src/stream/ngx_stream_core_module.c
@@ -1031,6 +1031,10 @@ ngx_stream_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     lsopt.ipv6only = 1;
 #endif
 
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+    lsopt.transparent = 0;
+#endif
+
     backlog = 0;
 
     for (i = 2; i < cf->args->nelts; i++) {
@@ -1132,6 +1136,16 @@ ngx_stream_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 return NGX_CONF_ERROR;
             }
 
+            continue;
+        }
+        if (ngx_strcmp(value[i].data, "transparent") == 0) {
+#if (NGX_HAVE_TRANSPARENT_PROXY && defined IP_TRANSPARENT)
+            lsopt.transparent = 1;
+#else
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "transparent mode is not supported "
+                               "on this platform, ignored");
+#endif
             continue;
         }
 


### PR DESCRIPTION
### Proposed changes

This patch adds support for `IP_TRANSPARENT` support for listening sockets in the http module and stream module. Adding `transparent` to ths options of a listen directive, `IP_TRANSPARENT` will be enabled on that listening socket, allowing it to accept traffic redirected using TPROXY.

When this is enabled, the original destination IP address and port before the redirection can be fetched from the variables `$server_addr` and `$server_port`.

The original version of this patch was proposed by Stijn Tintel in <https://trac.nginx.org/nginx/ticket/287>.
