### PR TITLE
Structure and improve MIME types configuration

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -1,45 +1,72 @@
-
 types {
-    text/html                                        html htm shtml;
+
+  # Web files
+
+    text/html                                        htm html shtml;
     text/css                                         css;
-    text/xml                                         xml;
+    # https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages
+    text/javascript                                  js mjs;
+    application/wasm                                 wasm;
+
+
+  # Data interchange
+
+    application/atom+xml                             atom;
+    application/json                                 json map topojson;
+    application/ld+json                              jsonld;
+    application/rss+xml                              rss;
+    application/geo+json                             geojson;
+    application/xml                                  xml;
+    application/rdf+xml                              rdf;
+
+
+  # Manifest files
+
+    application/manifest+json                        webmanifest;
+    application/x-web-app-manifest+json              webapp;
+    text/cache-manifest                              appcache;
+
+
+  # Media files
+
+    audio/midi                                       mid midi kar;
+    audio/mp4                                        aac f4a f4b m4a;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        oga ogg opus;
+    audio/x-realaudio                                ra;
+    audio/x-wav                                      wav;
+
+    image/apng                                       apng;
+    image/avif                                       avif avifs;
+    image/bmp                                        bmp;
     image/gif                                        gif;
     image/jpeg                                       jpeg jpg;
-    application/javascript                           js;
-    application/atom+xml                             atom;
-    application/rss+xml                              rss;
-
-    text/mathml                                      mml;
-    text/plain                                       txt;
-    text/vnd.sun.j2me.app-descriptor                 jad;
-    text/vnd.wap.wml                                 wml;
-    text/x-component                                 htc;
-
-    image/avif                                       avif;
+    image/jxl                                        jxl;
+    image/jxr                                        jxr hdp wdp;
     image/png                                        png;
     image/svg+xml                                    svg svgz;
     image/tiff                                       tif tiff;
     image/vnd.wap.wbmp                               wbmp;
     image/webp                                       webp;
-    image/x-icon                                     ico;
+    image/x-icon                                     cur ico;
     image/x-jng                                      jng;
-    image/x-ms-bmp                                   bmp;
 
-    font/woff                                        woff;
-    font/woff2                                       woff2;
+    video/3gpp                                       3gp 3gpp;
+    video/mp4                                        f4p f4v m4v mp4;
+    video/mpeg                                       mpeg mpg;
+    video/ogg                                        ogv;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asf asx;
+    video/x-msvideo                                  avi;
 
-    application/java-archive                         jar war ear;
-    application/json                                 json;
-    application/mac-binhex40                         hqx;
+
+  # Document files
+
     application/msword                               doc;
-    application/pdf                                  pdf;
-    application/postscript                           ps eps ai;
-    application/rtf                                  rtf;
-    application/vnd.apple.mpegurl                    m3u8;
-    application/vnd.google-earth.kml+xml             kml;
-    application/vnd.google-earth.kmz                 kmz;
     application/vnd.ms-excel                         xls;
-    application/vnd.ms-fontobject                    eot;
     application/vnd.ms-powerpoint                    ppt;
     application/vnd.oasis.opendocument.graphics      odg;
     application/vnd.oasis.opendocument.presentation  odp;
@@ -51,49 +78,67 @@ types {
                                                      xlsx;
     application/vnd.openxmlformats-officedocument.wordprocessingml.document
                                                      docx;
+
+  # Web fonts
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/vnd.ms-fontobject                    eot;
+    font/ttf                                         ttf;
+    font/collection                                  ttc;
+    font/otf                                         otf;
+
+
+  # Other
+
+    application/java-archive                         ear jar war;
+    application/mac-binhex40                         hqx;
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+    application/octet-stream                         safariextz;
+    application/pdf                                  pdf;
+    application/postscript                           ai eps ps;
+    application/rtf                                  rtf;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
     application/vnd.wap.wmlc                         wmlc;
-    application/wasm                                 wasm;
     application/x-7z-compressed                      7z;
+    application/x-bb-appworld                        bbaw;
+    application/x-bittorrent                         torrent;
+    application/x-chrome-extension                   crx;
     application/x-cocoa                              cco;
     application/x-java-archive-diff                  jardiff;
     application/x-java-jnlp-file                     jnlp;
     application/x-makeself                           run;
+    application/x-opera-extension                    oex;
     application/x-perl                               pl pm;
-    application/x-pilot                              prc pdb;
+    application/x-pilot                              pdb prc;
     application/x-rar-compressed                     rar;
     application/x-redhat-package-manager             rpm;
     application/x-sea                                sea;
     application/x-shockwave-flash                    swf;
     application/x-stuffit                            sit;
     application/x-tcl                                tcl tk;
-    application/x-x509-ca-cert                       der pem crt;
+    application/x-x509-ca-cert                       crt der pem;
     application/x-xpinstall                          xpi;
     application/xhtml+xml                            xhtml;
-    application/xspf+xml                             xspf;
+    application/xslt+xml                             xsl;
     application/zip                                  zip;
 
-    application/octet-stream                         bin exe dll;
-    application/octet-stream                         deb;
-    application/octet-stream                         dmg;
-    application/octet-stream                         iso img;
-    application/octet-stream                         msi msp msm;
+    text/calendar                                    ics;
+    text/csv                                         csv;
+    text/markdown                                    md markdown;
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vcard                                       vcard vcf;
+    text/vnd.rim.location.xloc                       xloc;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/vtt                                         vtt;
+    text/x-component                                 htc;
 
-    audio/midi                                       mid midi kar;
-    audio/mpeg                                       mp3;
-    audio/ogg                                        ogg;
-    audio/x-m4a                                      m4a;
-    audio/x-realaudio                                ra;
-
-    video/3gpp                                       3gpp 3gp;
-    video/mp2t                                       ts;
-    video/mp4                                        mp4;
-    video/mpeg                                       mpeg mpg;
-    video/quicktime                                  mov;
-    video/webm                                       webm;
-    video/x-flv                                      flv;
-    video/x-m4v                                      m4v;
-    video/x-mng                                      mng;
-    video/x-ms-asf                                   asx asf;
-    video/x-ms-wmv                                   wmv;
-    video/x-msvideo                                  avi;
 }


### PR DESCRIPTION
### Proposed changes

Based on the work done under the project [H5BP][1] (disclaimer: I'm the maintainer), this change improves the structure of the MIME type configuration and brings the latest [standard updates][2] to its values.

All the types have been tested against the project [Media Type Database](https://github.com/jshttp/mime-db), referencing the industry standard, un-opinionated, MIME-types uses.

This change would help to deliver correct MIME types out of the box, and reduce mismatching as much as possible.

[1]: https://github.com/h5bp/server-configs-nginx
[2]: https://www.iana.org/assignments/media-types/media-types.xhtml

Closes #137
Closes #125 
