### PR TITLE
SSL: optional ssl_client_certificate for ssl_verify_client.

### DIFF
--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -787,9 +787,13 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     if (conf->verify) {
 
-        if (conf->client_certificate.len == 0 && conf->verify != 3) {
+        if (conf->verify != 3
+            && conf->client_certificate.len == 0
+            && conf->trusted_certificate.len == 0)
+        {
             ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                          "no ssl_client_certificate for ssl_verify_client");
+                          "no ssl_client_certificate or "
+                          "ssl_trusted_certificate for ssl_verify_client");
             return NGX_CONF_ERROR;
         }
 

--- a/src/mail/ngx_mail_ssl_module.c
+++ b/src/mail/ngx_mail_ssl_module.c
@@ -450,9 +450,13 @@ ngx_mail_ssl_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 
     if (conf->verify) {
 
-        if (conf->client_certificate.len == 0 && conf->verify != 3) {
+        if (conf->verify != 3
+            && conf->client_certificate.len == 0
+            && conf->trusted_certificate.len == 0)
+        {
             ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                          "no ssl_client_certificate for ssl_verify_client");
+                          "no ssl_client_certificate or "
+                          "ssl_trusted_certificate for ssl_verify_client");
             return NGX_CONF_ERROR;
         }
 

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -1008,9 +1008,13 @@ ngx_stream_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     if (conf->verify) {
 
-        if (conf->client_certificate.len == 0 && conf->verify != 3) {
+        if (conf->verify != 3
+            && conf->client_certificate.len == 0
+            && conf->trusted_certificate.len == 0)
+        {
             ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                          "no ssl_client_certificate for ssl_verify_client");
+                          "no ssl_client_certificate or "
+                          "ssl_trusted_certificate for ssl_verify_client");
             return NGX_CONF_ERROR;
         }
 


### PR DESCRIPTION


Starting from TLSv1.1 (as seen since draft-ietf-tls-rfc2246-bis-00),
the "certificate_authorities" field grammar of the CertificateRequest
message was redid to allow no distinguished names.  In TLSv1.3, with
the restructured CertificateRequest message, this can be similarly
done by optionally including the "certificate_authorities" extension.
This allows to avoid sending DNs at all.

In practice, aside from published TLS specifications, all supported
SSL/TLS libraries allow to request client certificates with an empty
DN list for any protocol version.  For instance, when operating in
TLSv1, this results in sending the "certificate_authorities" list as
a zero-length vector, which corresponds to the TLSv1.1 specification.
Such behaviour goes back to SSLeay.

The change relaxes the requirement to specify at least one trusted CA
certificate in the ssl_client_certificate directive, which resulted in
sending DNs of these certificates (closes #142).  Instead, all trusted
CA certificates can be specified now using the ssl_trusted_certificate
directive if needed.  A notable difference that certificates specified
in ssl_trusted_certificate are always loaded remains (see [3648ba](https://github.com/nginx/nginx/commit/3648ba7db833d318269daba2a8d6be42660c5b60).)


### Proposed changes

As per below RFCs, ssl_client_certificate should be optional with TLS1.1+ when ssl_verify_client is configured as on/optional:

TLS1.3: rfc8446#section-4.2.4:
```
 The server MAY send it(CA) in the  CertificateRequest message.
```

TLS1.2: rfc5246#section-7.4.4:
```
If the certificate_authorities list is empty, then the client MAY send any certificate of the appropriate ClientCertificateType, unless there is some external arrangement to the contrary.
```
TLS1.1: rfc4346#section-7.4.4:  Similar wording as TLS 1.2.

TLSv1.0: rfc2246#section-7.4.4: It was not clearly defined in v1.0, that CA list in certificate request message can be empty or not.

Also Nginx documentation seems to suggest the same:
```
The list of certificates will be sent to clients. If this is not desired, the [ssl_trusted_certificate] directive can be used."
```




**Tested with nginx-tests.
--------------------------
Verified after deploying on Debian.**
--------------------------

Relevant Config
```
       # Enable client certificate verification (mTLS)
        ssl_trusted_certificate /Users/pchere/Desktop/src_code/certs/ca.crt;  # CA cert for client certificates
        ssl_verify_client on;  # Force client certificate validation
```

With ssl_protocols TLSv1.2 TLSv1.3;
```
% sudo /usr/local/nginx/sbin/nginx -s reload

%curl -v --cert /Users/pchere/Desktop/src_code/certs/client.crt --key /Users/pchere/Desktop/src_code/certs/client.key --cacert /Users/pchere/Desktop/src_code/certs/ca.crt https://localhost/
* (304) (OUT), TLS handshake, Client hello (1):
*  CAfile: /Users/pchere/Desktop/src_code/certs/ca.crt
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Request CERT (13):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Certificate (11):
* (304) (OUT), TLS handshake, CERT verify (15):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted http/1.1
```


Comment ssl_trusted_certificate in nginx config.
```
 % sudo /usr/local/nginx/sbin/nginx -s reload
nginx: [emerg] no ssl_client_certificate or ssl_trusted_certificatefor ssl_verify_client
```