### PR TITLE
 [http_rewrite] Avoid duplicate non-cacheable variable calls for complex expressions

### DIFF
--- a/src/http/modules/ngx_http_rewrite_module.c
+++ b/src/http/modules/ngx_http_rewrite_module.c
@@ -174,6 +174,7 @@ ngx_http_rewrite_handler(ngx_http_request_t *r)
     e->quote = 1;
     e->log = rlcf->log;
     e->status = NGX_DECLINED;
+    e->flushed = 1;
 
     while (*(uintptr_t *) e->ip) {
         code = *(ngx_http_script_code_pt *) e->ip;


### PR DESCRIPTION
### Proposed changes

When defining a rewrite variable from a non-cacheable variable (set $var $computed_var), I've noticed 2 calls to $computed_var's get_handler (one to determine the total length of the created variable, the other to get the variable contents and copy them into the allocated buffer). Setting the flushed variable seems to address the problem while not breaking any existing test. This flag is already set in other parts that rely on http_script, so I think it can be safely set. Besides, this only impacts non-cacheable variables processing.

Here's the only behaviour change I could observe:
> Consider a non-cached variable $weird_var keeping track of its call numbers, 
> and returning "0" then N times the number of calls so far: 01, 022, 0333...
> Use it twice in the same directive: "set $stuff $weird_var$weird_var"
> The variable's get_handler will be called twice (which sort of makes sense 
> since the variable is referred to twice) but the resulting value is the 
> result of the last call, truncated since it doesn't fit in the allocated 
> buffer: stuff is 02202 (intuitively, it would be 01022)
> Without this patch, the result would be 03330 which is also not the expected 
> result anyway, so I doubt this would break anyone's workflow. On the other 
> side, this speeds up complex value processing as we don't make unnecessary 
> calls.

Ref: https://github.com/nginx/njs/pull/771#issuecomment-2291911309 and https://mailman.nginx.org/pipermail/nginx-devel/2024-August/P2FZL47R27U7AIHO3RIKBW6VUEOZHTJH.html
