### PR TITLE
Change MIME type of .ico to official one

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -19,9 +19,9 @@ types {
     image/png                                        png;
     image/svg+xml                                    svg svgz;
     image/tiff                                       tif tiff;
+    image/vnd.microsoft.icon                         ico;
     image/vnd.wap.wbmp                               wbmp;
     image/webp                                       webp;
-    image/x-icon                                     ico;
     image/x-jng                                      jng;
     image/x-ms-bmp                                   bmp;
 


### PR DESCRIPTION
### Proposed changes

The mime type of Nginx has been `image/x-icon`, which is unofficial and ambiguous.
The official one is `image/vnd.microsoft.icon`.
There will no one who put other types of icon image files with `.ico` extension today.

https://stackoverflow.com/questions/1444975/if-i-serve-favicon-ico-as-image-vnd-microsoft-icon-instead-of-image-x-icon-wi

