### PR TITLE
Upstream: re-resolvable servers

### DIFF
--- a/src/http/modules/ngx_http_upstream_least_conn_module.c
+++ b/src/http/modules/ngx_http_upstream_least_conn_module.c
@@ -124,6 +124,12 @@ ngx_http_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
 
     ngx_http_upstream_rr_peers_wlock(peers);
 
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    if (peers->config && rrp->config != *peers->config) {
+        goto busy;
+    }
+#endif
+
     best = NULL;
     total = 0;
 
@@ -244,6 +250,7 @@ ngx_http_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
     best->conns++;
 
     rrp->current = best;
+    ngx_http_upstream_rr_peer_ref(peers, best);
 
     n = p / (8 * sizeof(uintptr_t));
     m = (uintptr_t) 1 << p % (8 * sizeof(uintptr_t));
@@ -280,6 +287,10 @@ failed:
         ngx_http_upstream_rr_peers_wlock(peers);
     }
 
+#if (NGX_HTTP_UPSTREAM_ZONE)
+busy:
+#endif
+
     ngx_http_upstream_rr_peers_unlock(peers);
 
     pc->name = peers->name;
@@ -303,6 +314,7 @@ ngx_http_upstream_least_conn(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     uscf->peer.init_upstream = ngx_http_upstream_init_least_conn;
 
     uscf->flags = NGX_HTTP_UPSTREAM_CREATE
+                  |NGX_HTTP_UPSTREAM_MODIFY
                   |NGX_HTTP_UPSTREAM_WEIGHT
                   |NGX_HTTP_UPSTREAM_MAX_CONNS
                   |NGX_HTTP_UPSTREAM_MAX_FAILS

--- a/src/http/modules/ngx_http_upstream_random_module.c
+++ b/src/http/modules/ngx_http_upstream_random_module.c
@@ -17,6 +17,9 @@ typedef struct {
 
 typedef struct {
     ngx_uint_t                            two;
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    ngx_uint_t                            config;
+#endif
     ngx_http_upstream_random_range_t     *ranges;
 } ngx_http_upstream_random_srv_conf_t;
 
@@ -127,6 +130,11 @@ ngx_http_upstream_update_random(ngx_pool_t *pool,
 
     rcf = ngx_http_conf_upstream_srv_conf(us, ngx_http_upstream_random_module);
 
+    if (rcf->ranges) {
+        ngx_free(rcf->ranges);
+        rcf->ranges = NULL;
+    }
+
     peers = us->peer.data;
 
     size = peers->number * sizeof(ngx_http_upstream_random_range_t);
@@ -186,11 +194,15 @@ ngx_http_upstream_init_random_peer(ngx_http_request_t *r,
     ngx_http_upstream_rr_peers_rlock(rp->rrp.peers);
 
 #if (NGX_HTTP_UPSTREAM_ZONE)
-    if (rp->rrp.peers->shpool && rcf->ranges == NULL) {
+    if (rp->rrp.peers->config
+        && (rcf->ranges == NULL || rcf->config != *rp->rrp.peers->config))
+    {
         if (ngx_http_upstream_update_random(NULL, us) != NGX_OK) {
             ngx_http_upstream_rr_peers_unlock(rp->rrp.peers);
             return NGX_ERROR;
         }
+
+        rcf->config = *rp->rrp.peers->config;
     }
 #endif
 
@@ -220,10 +232,17 @@ ngx_http_upstream_get_random_peer(ngx_peer_connection_t *pc, void *data)
 
     ngx_http_upstream_rr_peers_rlock(peers);
 
-    if (rp->tries > 20 || peers->single) {
+    if (rp->tries > 20 || peers->number < 2) {
         ngx_http_upstream_rr_peers_unlock(peers);
         return ngx_http_upstream_get_round_robin_peer(pc, rrp);
     }
+
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    if (peers->config && rrp->config != *peers->config) {
+        ngx_http_upstream_rr_peers_unlock(peers);
+        return ngx_http_upstream_get_round_robin_peer(pc, rrp);
+    }
+#endif
 
     pc->cached = 0;
     pc->connection = NULL;
@@ -274,6 +293,7 @@ ngx_http_upstream_get_random_peer(ngx_peer_connection_t *pc, void *data)
     }
 
     rrp->current = peer;
+    ngx_http_upstream_rr_peer_ref(peers, peer);
 
     if (now - peer->checked > peer->fail_timeout) {
         peer->checked = now;
@@ -314,10 +334,17 @@ ngx_http_upstream_get_random2_peer(ngx_peer_connection_t *pc, void *data)
 
     ngx_http_upstream_rr_peers_wlock(peers);
 
-    if (rp->tries > 20 || peers->single) {
+    if (rp->tries > 20 || peers->number < 2) {
         ngx_http_upstream_rr_peers_unlock(peers);
         return ngx_http_upstream_get_round_robin_peer(pc, rrp);
     }
+
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    if (peers->config && rrp->config != *peers->config) {
+        ngx_http_upstream_rr_peers_unlock(peers);
+        return ngx_http_upstream_get_round_robin_peer(pc, rrp);
+    }
+#endif
 
     pc->cached = 0;
     pc->connection = NULL;
@@ -384,6 +411,7 @@ ngx_http_upstream_get_random2_peer(ngx_peer_connection_t *pc, void *data)
     }
 
     rrp->current = peer;
+    ngx_http_upstream_rr_peer_ref(peers, peer);
 
     if (now - peer->checked > peer->fail_timeout) {
         peer->checked = now;
@@ -467,6 +495,7 @@ ngx_http_upstream_random(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     uscf->peer.init_upstream = ngx_http_upstream_init_random;
 
     uscf->flags = NGX_HTTP_UPSTREAM_CREATE
+                  |NGX_HTTP_UPSTREAM_MODIFY
                   |NGX_HTTP_UPSTREAM_WEIGHT
                   |NGX_HTTP_UPSTREAM_MAX_CONNS
                   |NGX_HTTP_UPSTREAM_MAX_FAILS

--- a/src/http/modules/ngx_http_upstream_zone_module.c
+++ b/src/http/modules/ngx_http_upstream_zone_module.c
@@ -545,6 +545,8 @@ ngx_http_upstream_zone_preresolve(ngx_http_upstream_rr_peer_t *resolve,
 
                 peer->host = template->host;
 
+                template->host->valid = host->valid;
+
                 server = template->host->service.len ? &opeer->server
                                                      : &template->server;
 
@@ -626,6 +628,8 @@ ngx_http_upstream_zone_remove_peer_locked(ngx_http_upstream_rr_peers_t *peers,
 static ngx_int_t
 ngx_http_upstream_zone_init_worker(ngx_cycle_t *cycle)
 {
+    time_t                          now;
+    ngx_msec_t                      timer;
     ngx_uint_t                      i;
     ngx_event_t                    *event;
     ngx_http_upstream_rr_peer_t    *peer;
@@ -639,6 +643,7 @@ ngx_http_upstream_zone_init_worker(ngx_cycle_t *cycle)
         return NGX_OK;
     }
 
+    now = ngx_time();
     umcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_upstream_module);
 
     if (umcf == NULL) {
@@ -674,7 +679,10 @@ ngx_http_upstream_zone_init_worker(ngx_cycle_t *cycle)
                 event->log = cycle->log;
                 event->cancelable = 1;
 
-                ngx_add_timer(event, 1);
+                timer = (peer->host->valid > now)
+                        ? (ngx_msec_t) 1000 * (peer->host->valid - now) : 1;
+
+                ngx_add_timer(event, timer);
             }
 
             ngx_http_upstream_rr_peers_unlock(peers);
@@ -982,6 +990,8 @@ again:
     }
 
 done:
+
+    host->valid = ctx->valid;
 
     ngx_http_upstream_rr_peers_unlock(peers);
 

--- a/src/http/modules/ngx_http_upstream_zone_module.c
+++ b/src/http/modules/ngx_http_upstream_zone_module.c
@@ -18,6 +18,13 @@ static ngx_http_upstream_rr_peers_t *ngx_http_upstream_zone_copy_peers(
     ngx_slab_pool_t *shpool, ngx_http_upstream_srv_conf_t *uscf);
 static ngx_http_upstream_rr_peer_t *ngx_http_upstream_zone_copy_peer(
     ngx_http_upstream_rr_peers_t *peers, ngx_http_upstream_rr_peer_t *src);
+static void ngx_http_upstream_zone_set_single(
+    ngx_http_upstream_srv_conf_t *uscf);
+static void ngx_http_upstream_zone_remove_peer_locked(
+    ngx_http_upstream_rr_peers_t *peers, ngx_http_upstream_rr_peer_t *peer);
+static ngx_int_t ngx_http_upstream_zone_init_worker(ngx_cycle_t *cycle);
+static void ngx_http_upstream_zone_resolve_timer(ngx_event_t *event);
+static void ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx);
 
 
 static ngx_command_t  ngx_http_upstream_zone_commands[] = {
@@ -55,7 +62,7 @@ ngx_module_t  ngx_http_upstream_zone_module = {
     NGX_HTTP_MODULE,                       /* module type */
     NULL,                                  /* init master */
     NULL,                                  /* init module */
-    NULL,                                  /* init process */
+    ngx_http_upstream_zone_init_worker,    /* init process */
     NULL,                                  /* init thread */
     NULL,                                  /* exit thread */
     NULL,                                  /* exit process */
@@ -188,8 +195,14 @@ ngx_http_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
     ngx_http_upstream_srv_conf_t *uscf)
 {
     ngx_str_t                     *name;
+    ngx_uint_t                    *config;
     ngx_http_upstream_rr_peer_t   *peer, **peerp;
     ngx_http_upstream_rr_peers_t  *peers, *backup;
+
+    config = ngx_slab_calloc(shpool, sizeof(ngx_uint_t));
+    if (config == NULL) {
+        return NULL;
+    }
 
     peers = ngx_slab_alloc(shpool, sizeof(ngx_http_upstream_rr_peers_t));
     if (peers == NULL) {
@@ -214,6 +227,7 @@ ngx_http_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
     peers->name = name;
 
     peers->shpool = shpool;
+    peers->config = config;
 
     for (peerp = &peers->peer; *peerp; peerp = &peer->next) {
         /* pool is unlocked */
@@ -223,6 +237,17 @@ ngx_http_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
         }
 
         *peerp = peer;
+        (*peers->config)++;
+    }
+
+    for (peerp = &peers->resolve; *peerp; peerp = &peer->next) {
+        peer = ngx_http_upstream_zone_copy_peer(peers, *peerp);
+        if (peer == NULL) {
+            return NULL;
+        }
+
+        *peerp = peer;
+        (*peers->config)++;
     }
 
     if (peers->next == NULL) {
@@ -239,6 +264,7 @@ ngx_http_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
     backup->name = name;
 
     backup->shpool = shpool;
+    backup->config = config;
 
     for (peerp = &backup->peer; *peerp; peerp = &peer->next) {
         /* pool is unlocked */
@@ -248,6 +274,17 @@ ngx_http_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
         }
 
         *peerp = peer;
+        (*backup->config)++;
+    }
+
+    for (peerp = &backup->resolve; *peerp; peerp = &peer->next) {
+        peer = ngx_http_upstream_zone_copy_peer(backup, *peerp);
+        if (peer == NULL) {
+            return NULL;
+        }
+
+        *peerp = peer;
+        (*backup->config)++;
     }
 
     peers->next = backup;
@@ -279,6 +316,7 @@ ngx_http_upstream_zone_copy_peer(ngx_http_upstream_rr_peers_t *peers,
         dst->sockaddr = NULL;
         dst->name.data = NULL;
         dst->server.data = NULL;
+        dst->host = NULL;
     }
 
     dst->sockaddr = ngx_slab_calloc_locked(pool, sizeof(ngx_sockaddr_t));
@@ -301,11 +339,36 @@ ngx_http_upstream_zone_copy_peer(ngx_http_upstream_rr_peers_t *peers,
         }
 
         ngx_memcpy(dst->server.data, src->server.data, src->server.len);
+
+        if (src->host) {
+            dst->host = ngx_slab_calloc_locked(pool,
+                                             sizeof(ngx_http_upstream_host_t));
+            if (dst->host == NULL) {
+                goto failed;
+            }
+
+            dst->host->name.data = ngx_slab_alloc_locked(pool,
+                                                         src->host->name.len);
+            if (dst->host->name.data == NULL) {
+                goto failed;
+            }
+
+            dst->host->peers = peers;
+            dst->host->peer = dst;
+
+            dst->host->name.len = src->host->name.len;
+            ngx_memcpy(dst->host->name.data, src->host->name.data,
+                       src->host->name.len);
+        }
     }
 
     return dst;
 
 failed:
+
+    if (dst->host) {
+        ngx_slab_free_locked(pool, dst->host);
+    }
 
     if (dst->server.data) {
         ngx_slab_free_locked(pool, dst->server.data);
@@ -322,4 +385,301 @@ failed:
     ngx_slab_free_locked(pool, dst);
 
     return NULL;
+}
+
+
+static void
+ngx_http_upstream_zone_set_single(ngx_http_upstream_srv_conf_t *uscf)
+{
+    ngx_http_upstream_rr_peers_t  *peers;
+
+    peers = uscf->peer.data;
+
+    if (peers->number == 1
+        && (peers->next == NULL || peers->next->number == 0))
+    {
+        peers->single = 1;
+
+    } else {
+        peers->single = 0;
+    }
+}
+
+
+static void
+ngx_http_upstream_zone_remove_peer_locked(ngx_http_upstream_rr_peers_t *peers,
+    ngx_http_upstream_rr_peer_t *peer)
+{
+    peers->total_weight -= peer->weight;
+    peers->number--;
+    peers->tries -= (peer->down == 0);
+    (*peers->config)++;
+    peers->weighted = (peers->total_weight != peers->number);
+
+    ngx_http_upstream_rr_peer_free(peers, peer);
+}
+
+
+static ngx_int_t
+ngx_http_upstream_zone_init_worker(ngx_cycle_t *cycle)
+{
+    ngx_uint_t                      i;
+    ngx_event_t                    *event;
+    ngx_http_upstream_rr_peer_t    *peer;
+    ngx_http_upstream_rr_peers_t   *peers;
+    ngx_http_upstream_srv_conf_t   *uscf, **uscfp;
+    ngx_http_upstream_main_conf_t  *umcf;
+
+    if (ngx_process != NGX_PROCESS_WORKER
+        && ngx_process != NGX_PROCESS_SINGLE)
+    {
+        return NGX_OK;
+    }
+
+    umcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_upstream_module);
+
+    if (umcf == NULL) {
+        return NGX_OK;
+    }
+
+    uscfp = umcf->upstreams.elts;
+
+    for (i = 0; i < umcf->upstreams.nelts; i++) {
+
+        uscf = uscfp[i];
+
+        if (uscf->shm_zone == NULL) {
+            continue;
+        }
+
+        peers = uscf->peer.data;
+
+        do {
+            ngx_http_upstream_rr_peers_wlock(peers);
+
+            for (peer = peers->resolve; peer; peer = peer->next) {
+
+                if (peer->host->worker != ngx_worker) {
+                    continue;
+                }
+
+                event = &peer->host->event;
+                ngx_memzero(event, sizeof(ngx_event_t));
+
+                event->data = uscf;
+                event->handler = ngx_http_upstream_zone_resolve_timer;
+                event->log = cycle->log;
+                event->cancelable = 1;
+
+                ngx_add_timer(event, 1);
+            }
+
+            ngx_http_upstream_rr_peers_unlock(peers);
+
+            peers = peers->next;
+
+        } while (peers);
+    }
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_http_upstream_zone_resolve_timer(ngx_event_t *event)
+{
+    ngx_resolver_ctx_t            *ctx;
+    ngx_http_upstream_host_t      *host;
+    ngx_http_upstream_srv_conf_t  *uscf;
+
+    host = (ngx_http_upstream_host_t *) event;
+    uscf = event->data;
+
+    ctx = ngx_resolve_start(uscf->resolver, NULL);
+    if (ctx == NULL) {
+        goto retry;
+    }
+
+    if (ctx == NGX_NO_RESOLVER) {
+        ngx_log_error(NGX_LOG_ERR, event->log, 0,
+                      "no resolver defined to resolve %V", &host->name);
+        return;
+    }
+
+    ctx->name = host->name;
+    ctx->handler = ngx_http_upstream_zone_resolve_handler;
+    ctx->data = host;
+    ctx->timeout = uscf->resolver_timeout;
+    ctx->cancelable = 1;
+
+    if (ngx_resolve_name(ctx) == NGX_OK) {
+        return;
+    }
+
+retry:
+
+    ngx_add_timer(event, ngx_max(uscf->resolver_timeout, 1000));
+}
+
+
+static void
+ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
+{
+    time_t                         now;
+    in_port_t                      port;
+    ngx_msec_t                     timer;
+    ngx_uint_t                     i, j;
+    ngx_event_t                   *event;
+    ngx_resolver_addr_t           *addr;
+    ngx_http_upstream_host_t      *host;
+    ngx_http_upstream_rr_peer_t   *peer, *template, **peerp;
+    ngx_http_upstream_rr_peers_t  *peers;
+    ngx_http_upstream_srv_conf_t  *uscf;
+
+    host = ctx->data;
+    event = &host->event;
+    uscf = event->data;
+    peers = host->peers;
+    template = host->peer;
+
+    ngx_http_upstream_rr_peers_wlock(peers);
+
+    now = ngx_time();
+
+    if (ctx->state) {
+        ngx_log_error(NGX_LOG_ERR, event->log, 0,
+                      "%V could not be resolved (%i: %s)",
+                      &ctx->name, ctx->state,
+                      ngx_resolver_strerror(ctx->state));
+
+        if (ctx->state != NGX_RESOLVE_NXDOMAIN) {
+            ngx_http_upstream_rr_peers_unlock(peers);
+
+            ngx_resolve_name_done(ctx);
+
+            ngx_add_timer(event, ngx_max(uscf->resolver_timeout, 1000));
+            return;
+        }
+
+        /* NGX_RESOLVE_NXDOMAIN */
+
+        ctx->naddrs = 0;
+    }
+
+#if (NGX_DEBUG)
+    {
+    u_char  text[NGX_SOCKADDR_STRLEN];
+    size_t  len;
+
+    for (i = 0; i < ctx->naddrs; i++) {
+        len = ngx_sock_ntop(ctx->addrs[i].sockaddr, ctx->addrs[i].socklen,
+                            text, NGX_SOCKADDR_STRLEN, 0);
+
+        ngx_log_debug3(NGX_LOG_DEBUG_HTTP, event->log, 0,
+                       "name %V was resolved to %*s", &host->name, len, text);
+    }
+    }
+#endif
+
+    for (peerp = &peers->peer; *peerp; /* void */ ) {
+        peer = *peerp;
+
+        if (peer->host != host) {
+            goto next;
+        }
+
+        for (j = 0; j < ctx->naddrs; j++) {
+
+            addr = &ctx->addrs[j];
+
+            if (addr->name.len == 0
+                && ngx_cmp_sockaddr(peer->sockaddr, peer->socklen,
+                                    addr->sockaddr, addr->socklen, 0)
+                   == NGX_OK)
+            {
+                addr->name.len = 1;
+                goto next;
+            }
+        }
+
+        *peerp = peer->next;
+        ngx_http_upstream_zone_remove_peer_locked(peers, peer);
+
+        ngx_http_upstream_zone_set_single(uscf);
+
+        continue;
+
+    next:
+
+        peerp = &peer->next;
+    }
+
+    for (i = 0; i < ctx->naddrs; i++) {
+
+        addr = &ctx->addrs[i];
+
+        if (addr->name.len == 1) {
+            addr->name.len = 0;
+            continue;
+        }
+
+        ngx_shmtx_lock(&peers->shpool->mutex);
+        peer = ngx_http_upstream_zone_copy_peer(peers, NULL);
+        ngx_shmtx_unlock(&peers->shpool->mutex);
+
+        if (peer == NULL) {
+            ngx_log_error(NGX_LOG_ERR, event->log, 0,
+                          "cannot add new server to upstream \"%V\", "
+                          "memory exhausted", peers->name);
+            break;
+        }
+
+        ngx_memcpy(peer->sockaddr, addr->sockaddr, addr->socklen);
+
+        port = ((struct sockaddr_in *) template->sockaddr)->sin_port;
+
+        switch (peer->sockaddr->sa_family) {
+#if (NGX_HAVE_INET6)
+        case AF_INET6:
+            ((struct sockaddr_in6 *) peer->sockaddr)->sin6_port = port;
+            break;
+#endif
+        default: /* AF_INET */
+            ((struct sockaddr_in *) peer->sockaddr)->sin_port = port;
+        }
+
+        peer->socklen = addr->socklen;
+
+        peer->name.len = ngx_sock_ntop(peer->sockaddr, peer->socklen,
+                                       peer->name.data, NGX_SOCKADDR_STRLEN, 1);
+
+        peer->host = template->host;
+        peer->server = template->server;
+
+        peer->weight = template->weight;
+        peer->effective_weight = peer->weight;
+        peer->max_conns = template->max_conns;
+        peer->max_fails = template->max_fails;
+        peer->fail_timeout = template->fail_timeout;
+        peer->down = template->down;
+
+        *peerp = peer;
+        peerp = &peer->next;
+
+        peers->number++;
+        peers->tries += (peer->down == 0);
+        peers->total_weight += peer->weight;
+        peers->weighted = (peers->total_weight != peers->number);
+        (*peers->config)++;
+
+        ngx_http_upstream_zone_set_single(uscf);
+    }
+
+    ngx_http_upstream_rr_peers_unlock(peers);
+
+    timer = (ngx_msec_t) 1000 * (ctx->valid > now ? ctx->valid - now + 1 : 1);
+
+    ngx_resolve_name_done(ctx);
+
+    ngx_add_timer(event, timer);
 }

--- a/src/http/modules/ngx_http_upstream_zone_module.c
+++ b/src/http/modules/ngx_http_upstream_zone_module.c
@@ -359,6 +359,18 @@ ngx_http_upstream_zone_copy_peer(ngx_http_upstream_rr_peers_t *peers,
             dst->host->name.len = src->host->name.len;
             ngx_memcpy(dst->host->name.data, src->host->name.data,
                        src->host->name.len);
+
+            if (src->host->service.len) {
+                dst->host->service.data = ngx_slab_alloc_locked(pool,
+                                                        src->host->service.len);
+                if (dst->host->service.data == NULL) {
+                    goto failed;
+                }
+
+                dst->host->service.len = src->host->service.len;
+                ngx_memcpy(dst->host->service.data, src->host->service.data,
+                           src->host->service.len);
+            }
         }
     }
 
@@ -367,6 +379,10 @@ ngx_http_upstream_zone_copy_peer(ngx_http_upstream_rr_peers_t *peers,
 failed:
 
     if (dst->host) {
+        if (dst->host->name.data) {
+            ngx_slab_free_locked(pool, dst->host->name.data);
+        }
+
         ngx_slab_free_locked(pool, dst->host);
     }
 
@@ -510,6 +526,7 @@ ngx_http_upstream_zone_resolve_timer(ngx_event_t *event)
     ctx->handler = ngx_http_upstream_zone_resolve_handler;
     ctx->data = host;
     ctx->timeout = uscf->resolver_timeout;
+    ctx->service = host->service;
     ctx->cancelable = 1;
 
     if (ngx_resolve_name(ctx) == NGX_OK) {
@@ -522,15 +539,28 @@ retry:
 }
 
 
+#define ngx_http_upstream_zone_addr_marked(addr)                              \
+    ((uintptr_t) (addr)->sockaddr & 1)
+
+#define ngx_http_upstream_zone_mark_addr(addr)                                \
+    (addr)->sockaddr = (struct sockaddr *) ((uintptr_t) (addr)->sockaddr | 1)
+
+#define ngx_http_upstream_zone_unmark_addr(addr)                              \
+    (addr)->sockaddr =                                                        \
+        (struct sockaddr *) ((uintptr_t) (addr)->sockaddr & ~((uintptr_t) 1))
+
 static void
 ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
 {
     time_t                         now;
+    u_short                        min_priority;
     in_port_t                      port;
+    ngx_str_t                     *server;
     ngx_msec_t                     timer;
-    ngx_uint_t                     i, j;
+    ngx_uint_t                     i, j, backup, addr_backup;
     ngx_event_t                   *event;
     ngx_resolver_addr_t           *addr;
+    ngx_resolver_srv_name_t       *srv;
     ngx_http_upstream_host_t      *host;
     ngx_http_upstream_rr_peer_t   *peer, *template, **peerp;
     ngx_http_upstream_rr_peers_t  *peers;
@@ -546,11 +576,32 @@ ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
 
     now = ngx_time();
 
+    for (i = 0; i < ctx->nsrvs; i++) {
+        srv = &ctx->srvs[i];
+
+        if (srv->state) {
+            ngx_log_error(NGX_LOG_ERR, event->log, 0,
+                          "%V could not be resolved (%i: %s) "
+                          "while resolving service %V of %V",
+                          &srv->name, srv->state,
+                          ngx_resolver_strerror(srv->state), &ctx->service,
+                          &ctx->name);
+        }
+    }
+
     if (ctx->state) {
-        ngx_log_error(NGX_LOG_ERR, event->log, 0,
-                      "%V could not be resolved (%i: %s)",
-                      &ctx->name, ctx->state,
-                      ngx_resolver_strerror(ctx->state));
+        if (ctx->service.len) {
+            ngx_log_error(NGX_LOG_ERR, event->log, 0,
+                          "service %V of %V could not be resolved (%i: %s)",
+                          &ctx->service, &ctx->name, ctx->state,
+                          ngx_resolver_strerror(ctx->state));
+
+        } else {
+            ngx_log_error(NGX_LOG_ERR, event->log, 0,
+                          "%V could not be resolved (%i: %s)",
+                          &ctx->name, ctx->state,
+                          ngx_resolver_strerror(ctx->state));
+        }
 
         if (ctx->state != NGX_RESOLVE_NXDOMAIN) {
             ngx_http_upstream_rr_peers_unlock(peers);
@@ -566,6 +617,13 @@ ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
         ctx->naddrs = 0;
     }
 
+    backup = 0;
+    min_priority = 65535;
+
+    for (i = 0; i < ctx->naddrs; i++) {
+        min_priority = ngx_min(ctx->addrs[i].priority, min_priority);
+    }
+
 #if (NGX_DEBUG)
     {
     u_char  text[NGX_SOCKADDR_STRLEN];
@@ -573,13 +631,19 @@ ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
 
     for (i = 0; i < ctx->naddrs; i++) {
         len = ngx_sock_ntop(ctx->addrs[i].sockaddr, ctx->addrs[i].socklen,
-                            text, NGX_SOCKADDR_STRLEN, 0);
+                            text, NGX_SOCKADDR_STRLEN, 1);
 
-        ngx_log_debug3(NGX_LOG_DEBUG_HTTP, event->log, 0,
-                       "name %V was resolved to %*s", &host->name, len, text);
+        ngx_log_debug7(NGX_LOG_DEBUG_HTTP, event->log, 0,
+                       "name %V was resolved to %*s "
+                       "s:\"%V\" n:\"%V\" w:%d %s",
+                       &host->name, len, text, &host->service,
+                       &ctx->addrs[i].name, ctx->addrs[i].weight,
+                       ctx->addrs[i].priority != min_priority ? "backup" : "");
     }
     }
 #endif
+
+again:
 
     for (peerp = &peers->peer; *peerp; /* void */ ) {
         peer = *peerp;
@@ -592,14 +656,39 @@ ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
 
             addr = &ctx->addrs[j];
 
-            if (addr->name.len == 0
-                && ngx_cmp_sockaddr(peer->sockaddr, peer->socklen,
-                                    addr->sockaddr, addr->socklen, 0)
-                   == NGX_OK)
-            {
-                addr->name.len = 1;
-                goto next;
+            addr_backup = (addr->priority != min_priority);
+            if (addr_backup != backup) {
+                continue;
             }
+
+            if (ngx_http_upstream_zone_addr_marked(addr)) {
+                continue;
+            }
+
+            if (ngx_cmp_sockaddr(peer->sockaddr, peer->socklen,
+                                 addr->sockaddr, addr->socklen,
+                                 host->service.len != 0)
+                != NGX_OK)
+            {
+                continue;
+            }
+
+            if (host->service.len) {
+                if (addr->name.len != peer->server.len
+                    || ngx_strncmp(addr->name.data, peer->server.data,
+                                   addr->name.len))
+                {
+                    continue;
+                }
+
+                if (template->weight == 1 && addr->weight != peer->weight) {
+                    continue;
+                }
+            }
+
+            ngx_http_upstream_zone_mark_addr(addr);
+
+            goto next;
         }
 
         *peerp = peer->next;
@@ -618,8 +707,13 @@ ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
 
         addr = &ctx->addrs[i];
 
-        if (addr->name.len == 1) {
-            addr->name.len = 0;
+        addr_backup = (addr->priority != min_priority);
+        if (addr_backup != backup) {
+            continue;
+        }
+
+        if (ngx_http_upstream_zone_addr_marked(addr)) {
+            ngx_http_upstream_zone_unmark_addr(addr);
             continue;
         }
 
@@ -631,21 +725,14 @@ ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
             ngx_log_error(NGX_LOG_ERR, event->log, 0,
                           "cannot add new server to upstream \"%V\", "
                           "memory exhausted", peers->name);
-            break;
+            goto done;
         }
 
         ngx_memcpy(peer->sockaddr, addr->sockaddr, addr->socklen);
 
-        port = ((struct sockaddr_in *) template->sockaddr)->sin_port;
-
-        switch (peer->sockaddr->sa_family) {
-#if (NGX_HAVE_INET6)
-        case AF_INET6:
-            ((struct sockaddr_in6 *) peer->sockaddr)->sin6_port = port;
-            break;
-#endif
-        default: /* AF_INET */
-            ((struct sockaddr_in *) peer->sockaddr)->sin_port = port;
+        if (host->service.len == 0) {
+            port = ngx_inet_get_port(template->sockaddr);
+            ngx_inet_set_port(peer->sockaddr, port);
         }
 
         peer->socklen = addr->socklen;
@@ -654,9 +741,30 @@ ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
                                        peer->name.data, NGX_SOCKADDR_STRLEN, 1);
 
         peer->host = template->host;
-        peer->server = template->server;
 
-        peer->weight = template->weight;
+        server = host->service.len ? &addr->name : &template->server;
+
+        peer->server.data = ngx_slab_alloc(peers->shpool, server->len);
+        if (peer->server.data == NULL) {
+            ngx_http_upstream_rr_peer_free(peers, peer);
+
+            ngx_log_error(NGX_LOG_ERR, event->log, 0,
+                          "cannot add new server to upstream \"%V\", "
+                          "memory exhausted", peers->name);
+            goto done;
+        }
+
+        peer->server.len = server->len;
+        ngx_memcpy(peer->server.data, server->data, server->len);
+
+        if (host->service.len == 0) {
+            peer->weight = template->weight;
+
+        } else {
+            peer->weight = (template->weight != 1 ? template->weight
+                                                  : addr->weight);
+        }
+
         peer->effective_weight = peer->weight;
         peer->max_conns = template->max_conns;
         peer->max_fails = template->max_fails;
@@ -675,7 +783,24 @@ ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
         ngx_http_upstream_zone_set_single(uscf);
     }
 
+    if (host->service.len && peers->next) {
+        ngx_http_upstream_rr_peers_unlock(peers);
+
+        peers = peers->next;
+        backup = 1;
+
+        ngx_http_upstream_rr_peers_wlock(peers);
+
+        goto again;
+    }
+
+done:
+
     ngx_http_upstream_rr_peers_unlock(peers);
+
+    while (++i < ctx->naddrs) {
+        ngx_http_upstream_zone_unmark_addr(&ctx->addrs[i]);
+    }
 
     timer = (ngx_msec_t) 1000 * (ctx->valid > now ? ctx->valid - now + 1 : 1);
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -1565,6 +1565,26 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
     u->state->peer = u->peer.name;
 
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    if (u->upstream && u->upstream->shm_zone
+        && (u->upstream->flags & NGX_HTTP_UPSTREAM_MODIFY))
+    {
+        u->state->peer = ngx_palloc(r->pool,
+                                    sizeof(ngx_str_t) + u->peer.name->len);
+        if (u->state->peer == NULL) {
+            ngx_http_upstream_finalize_request(r, u,
+                                               NGX_HTTP_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        u->state->peer->len = u->peer.name->len;
+        u->state->peer->data = (u_char *) (u->state->peer + 1);
+        ngx_memcpy(u->state->peer->data, u->peer.name->data, u->peer.name->len);
+
+        u->peer.name = u->state->peer;
+    }
+#endif
+
     if (rc == NGX_BUSY) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "no live upstreams");
         ngx_http_upstream_next(r, u, NGX_HTTP_UPSTREAM_FT_NOLIVE);
@@ -6066,6 +6086,7 @@ ngx_http_upstream(ngx_conf_t *cf, ngx_command_t *cmd, void *dummy)
     u.no_port = 1;
 
     uscf = ngx_http_upstream_add(cf, &u, NGX_HTTP_UPSTREAM_CREATE
+                                         |NGX_HTTP_UPSTREAM_MODIFY
                                          |NGX_HTTP_UPSTREAM_WEIGHT
                                          |NGX_HTTP_UPSTREAM_MAX_CONNS
                                          |NGX_HTTP_UPSTREAM_MAX_FAILS
@@ -6171,6 +6192,9 @@ ngx_http_upstream_server(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_url_t                    u;
     ngx_int_t                    weight, max_conns, max_fails;
     ngx_uint_t                   i;
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    ngx_uint_t                   resolve;
+#endif
     ngx_http_upstream_server_t  *us;
 
     us = ngx_array_push(uscf->servers);
@@ -6186,6 +6210,9 @@ ngx_http_upstream_server(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     max_conns = 0;
     max_fails = 1;
     fail_timeout = 10;
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    resolve = 0;
+#endif
 
     for (i = 2; i < cf->args->nelts; i++) {
 
@@ -6274,6 +6301,13 @@ ngx_http_upstream_server(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             continue;
         }
 
+#if (NGX_HTTP_UPSTREAM_ZONE)
+        if (ngx_strcmp(value[i].data, "resolve") == 0) {
+            resolve = 1;
+            continue;
+        }
+#endif
+
         goto invalid;
     }
 
@@ -6281,6 +6315,13 @@ ngx_http_upstream_server(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     u.url = value[1];
     u.default_port = 80;
+
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    if (resolve) {
+        /* resolve at run time */
+        u.no_resolve = 1;
+    }
+#endif
 
     if (ngx_parse_url(cf->pool, &u) != NGX_OK) {
         if (u.err) {
@@ -6292,8 +6333,45 @@ ngx_http_upstream_server(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     us->name = u.url;
+
+#if (NGX_HTTP_UPSTREAM_ZONE)
+
+    if (resolve && u.naddrs == 0) {
+        ngx_addr_t  *addr;
+
+        /* save port */
+
+        addr = ngx_pcalloc(cf->pool, sizeof(ngx_addr_t));
+        if (addr == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        addr->sockaddr = ngx_palloc(cf->pool, u.socklen);
+        if (addr->sockaddr == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        ngx_memcpy(addr->sockaddr, &u.sockaddr, u.socklen);
+
+        addr->socklen = u.socklen;
+
+        us->addrs = addr;
+        us->naddrs = 1;
+
+        us->host = u.host;
+
+    } else {
+        us->addrs = u.addrs;
+        us->naddrs = u.naddrs;
+    }
+
+#else
+
     us->addrs = u.addrs;
     us->naddrs = u.naddrs;
+
+#endif
+
     us->weight = weight;
     us->max_conns = max_conns;
     us->max_fails = max_fails;

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -106,9 +106,10 @@ typedef struct {
 
 #if (NGX_HTTP_UPSTREAM_ZONE)
     ngx_str_t                        host;
+    ngx_str_t                        service;
 #endif
 
-    NGX_COMPAT_BEGIN(4)
+    NGX_COMPAT_BEGIN(2)
     NGX_COMPAT_END
 } ngx_http_upstream_server_t;
 

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -104,7 +104,11 @@ typedef struct {
 
     unsigned                         backup:1;
 
-    NGX_COMPAT_BEGIN(6)
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    ngx_str_t                        host;
+#endif
+
+    NGX_COMPAT_BEGIN(4)
     NGX_COMPAT_END
 } ngx_http_upstream_server_t;
 
@@ -115,6 +119,7 @@ typedef struct {
 #define NGX_HTTP_UPSTREAM_FAIL_TIMEOUT  0x0008
 #define NGX_HTTP_UPSTREAM_DOWN          0x0010
 #define NGX_HTTP_UPSTREAM_BACKUP        0x0020
+#define NGX_HTTP_UPSTREAM_MODIFY        0x0040
 #define NGX_HTTP_UPSTREAM_MAX_CONNS     0x0100
 
 
@@ -133,6 +138,8 @@ struct ngx_http_upstream_srv_conf_s {
 
 #if (NGX_HTTP_UPSTREAM_ZONE)
     ngx_shm_zone_t                  *shm_zone;
+    ngx_resolver_t                  *resolver;
+    ngx_msec_t                       resolver_timeout;
 #endif
 };
 

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -176,6 +176,7 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
                 }
 
                 peer[n].host->name = server[i].host;
+                peer[n].host->service = server[i].service;
 
                 peer[n].sockaddr = server[i].addrs[0].sockaddr;
                 peer[n].socklen = server[i].addrs[0].socklen;
@@ -245,7 +246,15 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
             }
         }
 
-        if (n + r == 0) {
+        if (n == 0
+#if (NGX_HTTP_UPSTREAM_ZONE)
+            && !resolve
+#endif
+        ) {
+            return NGX_OK;
+        }
+
+        if (n + r == 0 && !(us->flags & NGX_HTTP_UPSTREAM_BACKUP)) {
             return NGX_OK;
         }
 
@@ -293,6 +302,7 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
                 }
 
                 peer[n].host->name = server[i].host;
+                peer[n].host->service = server[i].service;
 
                 peer[n].sockaddr = server[i].addrs[0].sockaddr;
                 peer[n].socklen = server[i].addrs[0].socklen;

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -32,10 +32,15 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
     ngx_http_upstream_srv_conf_t *us)
 {
     ngx_url_t                      u;
-    ngx_uint_t                     i, j, n, w, t;
+    ngx_uint_t                     i, j, n, r, w, t;
     ngx_http_upstream_server_t    *server;
     ngx_http_upstream_rr_peer_t   *peer, **peerp;
     ngx_http_upstream_rr_peers_t  *peers, *backup;
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    ngx_uint_t                     resolve;
+    ngx_http_core_loc_conf_t      *clcf;
+    ngx_http_upstream_rr_peer_t  **rpeerp;
+#endif
 
     us->peer.init = ngx_http_upstream_init_round_robin_peer;
 
@@ -43,13 +48,32 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
         server = us->servers->elts;
 
         n = 0;
+        r = 0;
         w = 0;
         t = 0;
 
+#if (NGX_HTTP_UPSTREAM_ZONE)
+        resolve = 0;
+#endif
+
         for (i = 0; i < us->servers->nelts; i++) {
+
+#if (NGX_HTTP_UPSTREAM_ZONE)
+            if (server[i].host.len) {
+                resolve = 1;
+            }
+#endif
+
             if (server[i].backup) {
                 continue;
             }
+
+#if (NGX_HTTP_UPSTREAM_ZONE)
+            if (server[i].host.len) {
+                r++;
+                continue;
+            }
+#endif
 
             n += server[i].naddrs;
             w += server[i].naddrs * server[i].weight;
@@ -59,7 +83,53 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
             }
         }
 
-        if (n == 0) {
+#if (NGX_HTTP_UPSTREAM_ZONE)
+        if (us->shm_zone) {
+
+            if (resolve && !(us->flags & NGX_HTTP_UPSTREAM_MODIFY)) {
+                ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                              "load balancing method does not support"
+                              " resolving names at run time in"
+                              " upstream \"%V\" in %s:%ui",
+                              &us->host, us->file_name, us->line);
+                return NGX_ERROR;
+            }
+
+            clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
+
+            us->resolver = clcf->resolver;
+            us->resolver_timeout = clcf->resolver_timeout;
+
+            /*
+             * Without "resolver_timeout" in http{}, the value is unset.
+             * Even if we set it in ngx_http_core_merge_loc_conf(), it's
+             * still dependent on the module order and unreliable.
+             */
+            ngx_conf_init_msec_value(us->resolver_timeout, 30000);
+
+            if (resolve
+                && (us->resolver == NULL
+                    || us->resolver->connections.nelts == 0))
+            {
+                ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                              "no resolver defined to resolve names"
+                              " at run time in upstream \"%V\" in %s:%ui",
+                              &us->host, us->file_name, us->line);
+                return NGX_ERROR;
+            }
+
+        } else if (resolve) {
+
+            ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                          "resolving names at run time requires"
+                          " upstream \"%V\" in %s:%ui"
+                          " to be in shared memory",
+                          &us->host, us->file_name, us->line);
+            return NGX_ERROR;
+        }
+#endif
+
+        if (n + r == 0) {
             ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                           "no servers in upstream \"%V\" in %s:%ui",
                           &us->host, us->file_name, us->line);
@@ -71,7 +141,8 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
             return NGX_ERROR;
         }
 
-        peer = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_rr_peer_t) * n);
+        peer = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_rr_peer_t)
+                                     * (n + r));
         if (peer == NULL) {
             return NGX_ERROR;
         }
@@ -86,10 +157,45 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
         n = 0;
         peerp = &peers->peer;
 
+#if (NGX_HTTP_UPSTREAM_ZONE)
+        rpeerp = &peers->resolve;
+#endif
+
         for (i = 0; i < us->servers->nelts; i++) {
             if (server[i].backup) {
                 continue;
             }
+
+#if (NGX_HTTP_UPSTREAM_ZONE)
+            if (server[i].host.len) {
+
+                peer[n].host = ngx_pcalloc(cf->pool,
+                                           sizeof(ngx_http_upstream_host_t));
+                if (peer[n].host == NULL) {
+                    return NGX_ERROR;
+                }
+
+                peer[n].host->name = server[i].host;
+
+                peer[n].sockaddr = server[i].addrs[0].sockaddr;
+                peer[n].socklen = server[i].addrs[0].socklen;
+                peer[n].name = server[i].addrs[0].name;
+                peer[n].weight = server[i].weight;
+                peer[n].effective_weight = server[i].weight;
+                peer[n].current_weight = 0;
+                peer[n].max_conns = server[i].max_conns;
+                peer[n].max_fails = server[i].max_fails;
+                peer[n].fail_timeout = server[i].fail_timeout;
+                peer[n].down = server[i].down;
+                peer[n].server = server[i].name;
+
+                *rpeerp = &peer[n];
+                rpeerp = &peer[n].next;
+                n++;
+
+                continue;
+            }
+#endif
 
             for (j = 0; j < server[i].naddrs; j++) {
                 peer[n].sockaddr = server[i].addrs[j].sockaddr;
@@ -115,6 +221,7 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
         /* backup servers */
 
         n = 0;
+        r = 0;
         w = 0;
         t = 0;
 
@@ -122,6 +229,13 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
             if (!server[i].backup) {
                 continue;
             }
+
+#if (NGX_HTTP_UPSTREAM_ZONE)
+            if (server[i].host.len) {
+                r++;
+                continue;
+            }
+#endif
 
             n += server[i].naddrs;
             w += server[i].naddrs * server[i].weight;
@@ -131,7 +245,7 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
             }
         }
 
-        if (n == 0) {
+        if (n + r == 0) {
             return NGX_OK;
         }
 
@@ -140,12 +254,16 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
             return NGX_ERROR;
         }
 
-        peer = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_rr_peer_t) * n);
+        peer = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_rr_peer_t)
+                                     * (n + r));
         if (peer == NULL) {
             return NGX_ERROR;
         }
 
-        peers->single = 0;
+        if (n > 0) {
+            peers->single = 0;
+        }
+
         backup->single = 0;
         backup->number = n;
         backup->weighted = (w != n);
@@ -156,10 +274,45 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
         n = 0;
         peerp = &backup->peer;
 
+#if (NGX_HTTP_UPSTREAM_ZONE)
+        rpeerp = &backup->resolve;
+#endif
+
         for (i = 0; i < us->servers->nelts; i++) {
             if (!server[i].backup) {
                 continue;
             }
+
+#if (NGX_HTTP_UPSTREAM_ZONE)
+            if (server[i].host.len) {
+
+                peer[n].host = ngx_pcalloc(cf->pool,
+                                           sizeof(ngx_http_upstream_host_t));
+                if (peer[n].host == NULL) {
+                    return NGX_ERROR;
+                }
+
+                peer[n].host->name = server[i].host;
+
+                peer[n].sockaddr = server[i].addrs[0].sockaddr;
+                peer[n].socklen = server[i].addrs[0].socklen;
+                peer[n].name = server[i].addrs[0].name;
+                peer[n].weight = server[i].weight;
+                peer[n].effective_weight = server[i].weight;
+                peer[n].current_weight = 0;
+                peer[n].max_conns = server[i].max_conns;
+                peer[n].max_fails = server[i].max_fails;
+                peer[n].fail_timeout = server[i].fail_timeout;
+                peer[n].down = server[i].down;
+                peer[n].server = server[i].name;
+
+                *rpeerp = &peer[n];
+                rpeerp = &peer[n].next;
+                n++;
+
+                continue;
+            }
+#endif
 
             for (j = 0; j < server[i].naddrs; j++) {
                 peer[n].sockaddr = server[i].addrs[j].sockaddr;
@@ -273,13 +426,22 @@ ngx_http_upstream_init_round_robin_peer(ngx_http_request_t *r,
 
     rrp->peers = us->peer.data;
     rrp->current = NULL;
-    rrp->config = 0;
+
+    ngx_http_upstream_rr_peers_rlock(rrp->peers);
+
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    rrp->config = rrp->peers->config ? *rrp->peers->config : 0;
+#endif
 
     n = rrp->peers->number;
 
     if (rrp->peers->next && rrp->peers->next->number > n) {
         n = rrp->peers->next->number;
     }
+
+    r->upstream->peer.tries = ngx_http_upstream_tries(rrp->peers);
+
+    ngx_http_upstream_rr_peers_unlock(rrp->peers);
 
     if (n <= 8 * sizeof(uintptr_t)) {
         rrp->tried = &rrp->data;
@@ -296,7 +458,6 @@ ngx_http_upstream_init_round_robin_peer(ngx_http_request_t *r,
 
     r->upstream->peer.get = ngx_http_upstream_get_round_robin_peer;
     r->upstream->peer.free = ngx_http_upstream_free_round_robin_peer;
-    r->upstream->peer.tries = ngx_http_upstream_tries(rrp->peers);
 #if (NGX_HTTP_SSL)
     r->upstream->peer.set_session =
                                ngx_http_upstream_set_round_robin_peer_session;
@@ -446,6 +607,12 @@ ngx_http_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
     peers = rrp->peers;
     ngx_http_upstream_rr_peers_wlock(peers);
 
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    if (peers->config && rrp->config != *peers->config) {
+        goto busy;
+    }
+#endif
+
     if (peers->single) {
         peer = peers->peer;
 
@@ -458,6 +625,7 @@ ngx_http_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
         }
 
         rrp->current = peer;
+        ngx_http_upstream_rr_peer_ref(peers, peer);
 
     } else {
 
@@ -509,6 +677,10 @@ failed:
 
         ngx_http_upstream_rr_peers_wlock(peers);
     }
+
+#if (NGX_HTTP_UPSTREAM_ZONE)
+busy:
+#endif
 
     ngx_http_upstream_rr_peers_unlock(peers);
 
@@ -580,6 +752,7 @@ ngx_http_upstream_get_peer(ngx_http_upstream_rr_peer_data_t *rrp)
     }
 
     rrp->current = best;
+    ngx_http_upstream_rr_peer_ref(rrp->peers, best);
 
     n = p / (8 * sizeof(uintptr_t));
     m = (uintptr_t) 1 << p % (8 * sizeof(uintptr_t));
@@ -617,9 +790,16 @@ ngx_http_upstream_free_round_robin_peer(ngx_peer_connection_t *pc, void *data,
 
     if (rrp->peers->single) {
 
+        if (peer->fails) {
+            peer->fails = 0;
+        }
+
         peer->conns--;
 
-        ngx_http_upstream_rr_peer_unlock(rrp->peers, peer);
+        if (ngx_http_upstream_rr_peer_unref(rrp->peers, peer) == NGX_OK) {
+            ngx_http_upstream_rr_peer_unlock(rrp->peers, peer);
+        }
+
         ngx_http_upstream_rr_peers_unlock(rrp->peers);
 
         pc->tries = 0;
@@ -661,7 +841,10 @@ ngx_http_upstream_free_round_robin_peer(ngx_peer_connection_t *pc, void *data,
 
     peer->conns--;
 
-    ngx_http_upstream_rr_peer_unlock(rrp->peers, peer);
+    if (ngx_http_upstream_rr_peer_unref(rrp->peers, peer) == NGX_OK) {
+        ngx_http_upstream_rr_peer_unlock(rrp->peers, peer);
+    }
+
     ngx_http_upstream_rr_peers_unlock(rrp->peers);
 
     if (pc->tries) {

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -97,15 +97,15 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
 
             clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 
-            us->resolver = clcf->resolver;
-            us->resolver_timeout = clcf->resolver_timeout;
+            if (us->resolver == NULL) {
+                us->resolver = clcf->resolver;
+            }
 
             /*
-             * Without "resolver_timeout" in http{}, the value is unset.
-             * Even if we set it in ngx_http_core_merge_loc_conf(), it's
-             * still dependent on the module order and unreliable.
+             * Without "resolver_timeout" in http{} the merged value is unset.
              */
-            ngx_conf_init_msec_value(us->resolver_timeout, 30000);
+            ngx_conf_merge_msec_value(us->resolver_timeout,
+                                      clcf->resolver_timeout, 30000);
 
             if (resolve
                 && (us->resolver == NULL

--- a/src/http/ngx_http_upstream_round_robin.h
+++ b/src/http/ngx_http_upstream_round_robin.h
@@ -24,6 +24,7 @@ typedef struct {
     ngx_event_t                     event;         /* must be first */
     ngx_uint_t                      worker;
     ngx_str_t                       name;
+    ngx_str_t                       service;
     ngx_http_upstream_rr_peers_t   *peers;
     ngx_http_upstream_rr_peer_t    *peer;
 } ngx_http_upstream_host_t;
@@ -150,7 +151,7 @@ ngx_http_upstream_rr_peer_free_locked(ngx_http_upstream_rr_peers_t *peers,
     ngx_slab_free_locked(peers->shpool, peer->sockaddr);
     ngx_slab_free_locked(peers->shpool, peer->name.data);
 
-    if (peer->server.data && (peer->host == NULL || peer->host->peer == peer)) {
+    if (peer->server.data) {
         ngx_slab_free_locked(peers->shpool, peer->server.data);
     }
 

--- a/src/http/ngx_http_upstream_round_robin.h
+++ b/src/http/ngx_http_upstream_round_robin.h
@@ -25,6 +25,7 @@ typedef struct {
     ngx_uint_t                      worker;
     ngx_str_t                       name;
     ngx_str_t                       service;
+    time_t                          valid;
     ngx_http_upstream_rr_peers_t   *peers;
     ngx_http_upstream_rr_peer_t    *peer;
 } ngx_http_upstream_host_t;

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -742,6 +742,25 @@ ngx_stream_proxy_connect(ngx_stream_session_t *s)
 
     u->state->peer = u->peer.name;
 
+#if (NGX_STREAM_UPSTREAM_ZONE)
+    if (u->upstream && u->upstream->shm_zone
+        && (u->upstream->flags & NGX_STREAM_UPSTREAM_MODIFY))
+    {
+        u->state->peer = ngx_palloc(s->connection->pool,
+                                    sizeof(ngx_str_t) + u->peer.name->len);
+        if (u->state->peer == NULL) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        u->state->peer->len = u->peer.name->len;
+        u->state->peer->data = (u_char *) (u->state->peer + 1);
+        ngx_memcpy(u->state->peer->data, u->peer.name->data, u->peer.name->len);
+
+        u->peer.name = u->state->peer;
+    }
+#endif
+
     if (rc == NGX_BUSY) {
         ngx_log_error(NGX_LOG_ERR, c->log, 0, "no live upstreams");
         ngx_stream_proxy_finalize(s, NGX_STREAM_BAD_GATEWAY);

--- a/src/stream/ngx_stream_upstream.c
+++ b/src/stream/ngx_stream_upstream.c
@@ -22,6 +22,11 @@ static char *ngx_stream_upstream(ngx_conf_t *cf, ngx_command_t *cmd,
     void *dummy);
 static char *ngx_stream_upstream_server(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+#if (NGX_STREAM_UPSTREAM_ZONE)
+static char *ngx_stream_upstream_resolver(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+#endif
+
 static void *ngx_stream_upstream_create_main_conf(ngx_conf_t *cf);
 static char *ngx_stream_upstream_init_main_conf(ngx_conf_t *cf, void *conf);
 
@@ -41,6 +46,24 @@ static ngx_command_t  ngx_stream_upstream_commands[] = {
       NGX_STREAM_SRV_CONF_OFFSET,
       0,
       NULL },
+
+#if (NGX_STREAM_UPSTREAM_ZONE)
+
+    { ngx_string("resolver"),
+      NGX_STREAM_UPS_CONF|NGX_CONF_1MORE,
+      ngx_stream_upstream_resolver,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("resolver_timeout"),
+      NGX_STREAM_UPS_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_upstream_srv_conf_t, resolver_timeout),
+      NULL },
+
+#endif
 
       ngx_null_command
 };
@@ -661,6 +684,32 @@ not_supported:
 }
 
 
+#if (NGX_STREAM_UPSTREAM_ZONE)
+
+static char *
+ngx_stream_upstream_resolver(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_stream_upstream_srv_conf_t  *uscf = conf;
+
+    ngx_str_t  *value;
+
+    if (uscf->resolver) {
+        return "is duplicate";
+    }
+
+    value = cf->args->elts;
+
+    uscf->resolver = ngx_resolver_create(cf, &value[1], cf->args->nelts - 1);
+    if (uscf->resolver == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+#endif
+
+
 ngx_stream_upstream_srv_conf_t *
 ngx_stream_upstream_add(ngx_conf_t *cf, ngx_url_t *u, ngx_uint_t flags)
 {
@@ -739,6 +788,9 @@ ngx_stream_upstream_add(ngx_conf_t *cf, ngx_url_t *u, ngx_uint_t flags)
     uscf->line = cf->conf_file->line;
     uscf->port = u->port;
     uscf->no_port = u->no_port;
+#if (NGX_STREAM_UPSTREAM_ZONE)
+    uscf->resolver_timeout = NGX_CONF_UNSET_MSEC;
+#endif
 
     if (u->naddrs == 1 && (u->port || u->family == AF_UNIX)) {
         uscf->servers = ngx_array_create(cf->pool, 1,

--- a/src/stream/ngx_stream_upstream.h
+++ b/src/stream/ngx_stream_upstream.h
@@ -21,6 +21,7 @@
 #define NGX_STREAM_UPSTREAM_FAIL_TIMEOUT  0x0008
 #define NGX_STREAM_UPSTREAM_DOWN          0x0010
 #define NGX_STREAM_UPSTREAM_BACKUP        0x0020
+#define NGX_STREAM_UPSTREAM_MODIFY        0x0040
 #define NGX_STREAM_UPSTREAM_MAX_CONNS     0x0100
 
 
@@ -62,7 +63,11 @@ typedef struct {
 
     unsigned                           backup:1;
 
-    NGX_COMPAT_BEGIN(4)
+#if (NGX_STREAM_UPSTREAM_ZONE)
+    ngx_str_t                          host;
+#endif
+
+    NGX_COMPAT_BEGIN(2)
     NGX_COMPAT_END
 } ngx_stream_upstream_server_t;
 
@@ -83,6 +88,8 @@ struct ngx_stream_upstream_srv_conf_s {
 
 #if (NGX_STREAM_UPSTREAM_ZONE)
     ngx_shm_zone_t                    *shm_zone;
+    ngx_resolver_t                    *resolver;
+    ngx_msec_t                         resolver_timeout;
 #endif
 };
 

--- a/src/stream/ngx_stream_upstream.h
+++ b/src/stream/ngx_stream_upstream.h
@@ -65,10 +65,8 @@ typedef struct {
 
 #if (NGX_STREAM_UPSTREAM_ZONE)
     ngx_str_t                          host;
+    ngx_str_t                          service;
 #endif
-
-    NGX_COMPAT_BEGIN(2)
-    NGX_COMPAT_END
 } ngx_stream_upstream_server_t;
 
 

--- a/src/stream/ngx_stream_upstream_round_robin.c
+++ b/src/stream/ngx_stream_upstream_round_robin.c
@@ -183,6 +183,7 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
                 }
 
                 peer[n].host->name = server[i].host;
+                peer[n].host->service = server[i].service;
 
                 peer[n].sockaddr = server[i].addrs[0].sockaddr;
                 peer[n].socklen = server[i].addrs[0].socklen;
@@ -251,7 +252,15 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
             }
         }
 
-        if (n + r == 0) {
+        if (n == 0
+#if (NGX_STREAM_UPSTREAM_ZONE)
+            && !resolve
+#endif
+        ) {
+            return NGX_OK;
+        }
+
+        if (n + r == 0 && !(us->flags & NGX_STREAM_UPSTREAM_BACKUP)) {
             return NGX_OK;
         }
 
@@ -299,6 +308,7 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
                 }
 
                 peer[n].host->name = server[i].host;
+                peer[n].host->service = server[i].service;
 
                 peer[n].sockaddr = server[i].addrs[0].sockaddr;
                 peer[n].socklen = server[i].addrs[0].socklen;

--- a/src/stream/ngx_stream_upstream_round_robin.c
+++ b/src/stream/ngx_stream_upstream_round_robin.c
@@ -38,10 +38,15 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
     ngx_stream_upstream_srv_conf_t *us)
 {
     ngx_url_t                        u;
-    ngx_uint_t                       i, j, n, w, t;
+    ngx_uint_t                       i, j, n, r, w, t;
     ngx_stream_upstream_server_t    *server;
     ngx_stream_upstream_rr_peer_t   *peer, **peerp;
     ngx_stream_upstream_rr_peers_t  *peers, *backup;
+#if (NGX_STREAM_UPSTREAM_ZONE)
+    ngx_uint_t                       resolve;
+    ngx_stream_core_srv_conf_t      *cscf;
+    ngx_stream_upstream_rr_peer_t  **rpeerp;
+#endif
 
     us->peer.init = ngx_stream_upstream_init_round_robin_peer;
 
@@ -49,13 +54,32 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
         server = us->servers->elts;
 
         n = 0;
+        r = 0;
         w = 0;
         t = 0;
 
+#if (NGX_STREAM_UPSTREAM_ZONE)
+        resolve = 0;
+#endif
+
         for (i = 0; i < us->servers->nelts; i++) {
+
+#if (NGX_STREAM_UPSTREAM_ZONE)
+            if (server[i].host.len) {
+                resolve = 1;
+            }
+#endif
+
             if (server[i].backup) {
                 continue;
             }
+
+#if (NGX_STREAM_UPSTREAM_ZONE)
+            if (server[i].host.len) {
+                r++;
+                continue;
+            }
+#endif
 
             n += server[i].naddrs;
             w += server[i].naddrs * server[i].weight;
@@ -65,7 +89,54 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
             }
         }
 
-        if (n == 0) {
+#if (NGX_STREAM_UPSTREAM_ZONE)
+        if (us->shm_zone) {
+
+            if (resolve && !(us->flags & NGX_STREAM_UPSTREAM_MODIFY)) {
+                ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                              "load balancing method does not support"
+                              " resolving names at run time in"
+                              " upstream \"%V\" in %s:%ui",
+                              &us->host, us->file_name, us->line);
+                return NGX_ERROR;
+            }
+
+            cscf = ngx_stream_conf_get_module_srv_conf(cf,
+                                                       ngx_stream_core_module);
+
+            us->resolver = cscf->resolver;
+            us->resolver_timeout = cscf->resolver_timeout;
+
+            /*
+             * Without "resolver_timeout" in stream{}, the value is unset.
+             * Even if we set it in ngx_stream_core_merge_srv_conf(), it's
+             * still dependent on the module order and unreliable.
+             */
+            ngx_conf_init_msec_value(us->resolver_timeout, 30000);
+
+            if (resolve
+                && (us->resolver == NULL
+                    || us->resolver->connections.nelts == 0))
+            {
+                ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                              "no resolver defined to resolve names"
+                              " at run time in upstream \"%V\" in %s:%ui",
+                              &us->host, us->file_name, us->line);
+                return NGX_ERROR;
+            }
+
+        } else if (resolve) {
+
+            ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                          "resolving names at run time requires"
+                          " upstream \"%V\" in %s:%ui"
+                          " to be in shared memory",
+                          &us->host, us->file_name, us->line);
+            return NGX_ERROR;
+        }
+#endif
+
+        if (n + r == 0) {
             ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                           "no servers in upstream \"%V\" in %s:%ui",
                           &us->host, us->file_name, us->line);
@@ -77,7 +148,8 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
             return NGX_ERROR;
         }
 
-        peer = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_rr_peer_t) * n);
+        peer = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_rr_peer_t)
+                                     * (n + r));
         if (peer == NULL) {
             return NGX_ERROR;
         }
@@ -92,10 +164,44 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
         n = 0;
         peerp = &peers->peer;
 
+#if (NGX_STREAM_UPSTREAM_ZONE)
+        rpeerp = &peers->resolve;
+#endif
+
         for (i = 0; i < us->servers->nelts; i++) {
             if (server[i].backup) {
                 continue;
             }
+
+#if (NGX_STREAM_UPSTREAM_ZONE)
+            if (server[i].host.len) {
+
+                peer[n].host = ngx_pcalloc(cf->pool,
+                                           sizeof(ngx_stream_upstream_host_t));
+                if (peer[n].host == NULL) {
+                    return NGX_ERROR;
+                }
+
+                peer[n].host->name = server[i].host;
+
+                peer[n].sockaddr = server[i].addrs[0].sockaddr;
+                peer[n].socklen = server[i].addrs[0].socklen;
+                peer[n].name = server[i].addrs[0].name;
+                peer[n].weight = server[i].weight;
+                peer[n].effective_weight = server[i].weight;
+                peer[n].current_weight = 0;
+                peer[n].max_conns = server[i].max_conns;
+                peer[n].max_fails = server[i].max_fails;
+                peer[n].fail_timeout = server[i].fail_timeout;
+                peer[n].down = server[i].down;
+                peer[n].server = server[i].name;
+                *rpeerp = &peer[n];
+                rpeerp = &peer[n].next;
+                n++;
+
+                continue;
+            }
+#endif
 
             for (j = 0; j < server[i].naddrs; j++) {
                 peer[n].sockaddr = server[i].addrs[j].sockaddr;
@@ -121,6 +227,7 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
         /* backup servers */
 
         n = 0;
+        r = 0;
         w = 0;
         t = 0;
 
@@ -128,6 +235,13 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
             if (!server[i].backup) {
                 continue;
             }
+
+#if (NGX_STREAM_UPSTREAM_ZONE)
+            if (server[i].host.len) {
+                r++;
+                continue;
+            }
+#endif
 
             n += server[i].naddrs;
             w += server[i].naddrs * server[i].weight;
@@ -137,7 +251,7 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
             }
         }
 
-        if (n == 0) {
+        if (n + r == 0) {
             return NGX_OK;
         }
 
@@ -146,12 +260,16 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
             return NGX_ERROR;
         }
 
-        peer = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_rr_peer_t) * n);
+        peer = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_rr_peer_t)
+                                     * (n + r));
         if (peer == NULL) {
             return NGX_ERROR;
         }
 
-        peers->single = 0;
+        if (n > 0) {
+            peers->single = 0;
+        }
+
         backup->single = 0;
         backup->number = n;
         backup->weighted = (w != n);
@@ -162,10 +280,44 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
         n = 0;
         peerp = &backup->peer;
 
+#if (NGX_STREAM_UPSTREAM_ZONE)
+        rpeerp = &backup->resolve;
+#endif
+
         for (i = 0; i < us->servers->nelts; i++) {
             if (!server[i].backup) {
                 continue;
             }
+
+#if (NGX_STREAM_UPSTREAM_ZONE)
+            if (server[i].host.len) {
+
+                peer[n].host = ngx_pcalloc(cf->pool,
+                                           sizeof(ngx_stream_upstream_host_t));
+                if (peer[n].host == NULL) {
+                    return NGX_ERROR;
+                }
+
+                peer[n].host->name = server[i].host;
+
+                peer[n].sockaddr = server[i].addrs[0].sockaddr;
+                peer[n].socklen = server[i].addrs[0].socklen;
+                peer[n].name = server[i].addrs[0].name;
+                peer[n].weight = server[i].weight;
+                peer[n].effective_weight = server[i].weight;
+                peer[n].current_weight = 0;
+                peer[n].max_conns = server[i].max_conns;
+                peer[n].max_fails = server[i].max_fails;
+                peer[n].fail_timeout = server[i].fail_timeout;
+                peer[n].down = server[i].down;
+                peer[n].server = server[i].name;
+                *rpeerp = &peer[n];
+                rpeerp = &peer[n].next;
+                n++;
+
+                continue;
+            }
+#endif
 
             for (j = 0; j < server[i].naddrs; j++) {
                 peer[n].sockaddr = server[i].addrs[j].sockaddr;
@@ -280,13 +432,22 @@ ngx_stream_upstream_init_round_robin_peer(ngx_stream_session_t *s,
 
     rrp->peers = us->peer.data;
     rrp->current = NULL;
-    rrp->config = 0;
+
+    ngx_stream_upstream_rr_peers_rlock(rrp->peers);
+
+#if (NGX_STREAM_UPSTREAM_ZONE)
+    rrp->config = rrp->peers->config ? *rrp->peers->config : 0;
+#endif
 
     n = rrp->peers->number;
 
     if (rrp->peers->next && rrp->peers->next->number > n) {
         n = rrp->peers->next->number;
     }
+
+    s->upstream->peer.tries = ngx_stream_upstream_tries(rrp->peers);
+
+    ngx_stream_upstream_rr_peers_unlock(rrp->peers);
 
     if (n <= 8 * sizeof(uintptr_t)) {
         rrp->tried = &rrp->data;
@@ -304,7 +465,7 @@ ngx_stream_upstream_init_round_robin_peer(ngx_stream_session_t *s,
     s->upstream->peer.get = ngx_stream_upstream_get_round_robin_peer;
     s->upstream->peer.free = ngx_stream_upstream_free_round_robin_peer;
     s->upstream->peer.notify = ngx_stream_upstream_notify_round_robin_peer;
-    s->upstream->peer.tries = ngx_stream_upstream_tries(rrp->peers);
+
 #if (NGX_STREAM_SSL)
     s->upstream->peer.set_session =
                              ngx_stream_upstream_set_round_robin_peer_session;
@@ -455,6 +616,12 @@ ngx_stream_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
     peers = rrp->peers;
     ngx_stream_upstream_rr_peers_wlock(peers);
 
+#if (NGX_STREAM_UPSTREAM_ZONE)
+    if (peers->config && rrp->config != *peers->config) {
+        goto busy;
+    }
+#endif
+
     if (peers->single) {
         peer = peers->peer;
 
@@ -467,6 +634,7 @@ ngx_stream_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
         }
 
         rrp->current = peer;
+        ngx_stream_upstream_rr_peer_ref(peers, peer);
 
     } else {
 
@@ -518,6 +686,10 @@ failed:
 
         ngx_stream_upstream_rr_peers_wlock(peers);
     }
+
+#if (NGX_STREAM_UPSTREAM_ZONE)
+busy:
+#endif
 
     ngx_stream_upstream_rr_peers_unlock(peers);
 
@@ -589,6 +761,7 @@ ngx_stream_upstream_get_peer(ngx_stream_upstream_rr_peer_data_t *rrp)
     }
 
     rrp->current = best;
+    ngx_stream_upstream_rr_peer_ref(rrp->peers, best);
 
     n = p / (8 * sizeof(uintptr_t));
     m = (uintptr_t) 1 << p % (8 * sizeof(uintptr_t));
@@ -623,9 +796,17 @@ ngx_stream_upstream_free_round_robin_peer(ngx_peer_connection_t *pc, void *data,
     ngx_stream_upstream_rr_peer_lock(rrp->peers, peer);
 
     if (rrp->peers->single) {
+
+        if (peer->fails) {
+            peer->fails = 0;
+        }
+
         peer->conns--;
 
-        ngx_stream_upstream_rr_peer_unlock(rrp->peers, peer);
+        if (ngx_stream_upstream_rr_peer_unref(rrp->peers, peer) == NGX_OK) {
+            ngx_stream_upstream_rr_peer_unlock(rrp->peers, peer);
+        }
+
         ngx_stream_upstream_rr_peers_unlock(rrp->peers);
 
         pc->tries = 0;
@@ -667,7 +848,10 @@ ngx_stream_upstream_free_round_robin_peer(ngx_peer_connection_t *pc, void *data,
 
     peer->conns--;
 
-    ngx_stream_upstream_rr_peer_unlock(rrp->peers, peer);
+    if (ngx_stream_upstream_rr_peer_unref(rrp->peers, peer) == NGX_OK) {
+        ngx_stream_upstream_rr_peer_unlock(rrp->peers, peer);
+    }
+
     ngx_stream_upstream_rr_peers_unlock(rrp->peers);
 
     if (pc->tries) {

--- a/src/stream/ngx_stream_upstream_round_robin.c
+++ b/src/stream/ngx_stream_upstream_round_robin.c
@@ -104,15 +104,15 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
             cscf = ngx_stream_conf_get_module_srv_conf(cf,
                                                        ngx_stream_core_module);
 
-            us->resolver = cscf->resolver;
-            us->resolver_timeout = cscf->resolver_timeout;
+            if (us->resolver == NULL) {
+                us->resolver = cscf->resolver;
+            }
 
             /*
-             * Without "resolver_timeout" in stream{}, the value is unset.
-             * Even if we set it in ngx_stream_core_merge_srv_conf(), it's
-             * still dependent on the module order and unreliable.
+             * Without "resolver_timeout" in stream{} the merged value is unset.
              */
-            ngx_conf_init_msec_value(us->resolver_timeout, 30000);
+            ngx_conf_merge_msec_value(us->resolver_timeout,
+                                      cscf->resolver_timeout, 30000);
 
             if (resolve
                 && (us->resolver == NULL

--- a/src/stream/ngx_stream_upstream_round_robin.h
+++ b/src/stream/ngx_stream_upstream_round_robin.h
@@ -24,6 +24,7 @@ typedef struct {
     ngx_event_t                      event;         /* must be first */
     ngx_uint_t                       worker;
     ngx_str_t                        name;
+    ngx_str_t                        service;
     ngx_stream_upstream_rr_peers_t  *peers;
     ngx_stream_upstream_rr_peer_t   *peer;
 } ngx_stream_upstream_host_t;
@@ -148,7 +149,7 @@ ngx_stream_upstream_rr_peer_free_locked(ngx_stream_upstream_rr_peers_t *peers,
     ngx_slab_free_locked(peers->shpool, peer->sockaddr);
     ngx_slab_free_locked(peers->shpool, peer->name.data);
 
-    if (peer->server.data && (peer->host == NULL || peer->host->peer == peer)) {
+    if (peer->server.data) {
         ngx_slab_free_locked(peers->shpool, peer->server.data);
     }
 

--- a/src/stream/ngx_stream_upstream_round_robin.h
+++ b/src/stream/ngx_stream_upstream_round_robin.h
@@ -25,6 +25,7 @@ typedef struct {
     ngx_uint_t                       worker;
     ngx_str_t                        name;
     ngx_str_t                        service;
+    time_t                           valid;
     ngx_stream_upstream_rr_peers_t  *peers;
     ngx_stream_upstream_rr_peer_t   *peer;
 } ngx_stream_upstream_host_t;

--- a/src/stream/ngx_stream_upstream_round_robin.h
+++ b/src/stream/ngx_stream_upstream_round_robin.h
@@ -14,7 +14,22 @@
 #include <ngx_stream.h>
 
 
+typedef struct ngx_stream_upstream_rr_peers_s  ngx_stream_upstream_rr_peers_t;
 typedef struct ngx_stream_upstream_rr_peer_s   ngx_stream_upstream_rr_peer_t;
+
+
+#if (NGX_STREAM_UPSTREAM_ZONE)
+
+typedef struct {
+    ngx_event_t                      event;         /* must be first */
+    ngx_uint_t                       worker;
+    ngx_str_t                        name;
+    ngx_stream_upstream_rr_peers_t  *peers;
+    ngx_stream_upstream_rr_peer_t   *peer;
+} ngx_stream_upstream_host_t;
+
+#endif
+
 
 struct ngx_stream_upstream_rr_peer_s {
     struct sockaddr                 *sockaddr;
@@ -44,17 +59,19 @@ struct ngx_stream_upstream_rr_peer_s {
     int                              ssl_session_len;
 
 #if (NGX_STREAM_UPSTREAM_ZONE)
+    unsigned                         zombie:1;
+
     ngx_atomic_t                     lock;
+    ngx_uint_t                       refs;
+    ngx_stream_upstream_host_t      *host;
 #endif
 
     ngx_stream_upstream_rr_peer_t   *next;
 
-    NGX_COMPAT_BEGIN(25)
+    NGX_COMPAT_BEGIN(14)
     NGX_COMPAT_END
 };
 
-
-typedef struct ngx_stream_upstream_rr_peers_s  ngx_stream_upstream_rr_peers_t;
 
 struct ngx_stream_upstream_rr_peers_s {
     ngx_uint_t                       number;
@@ -62,6 +79,8 @@ struct ngx_stream_upstream_rr_peers_s {
 #if (NGX_STREAM_UPSTREAM_ZONE)
     ngx_slab_pool_t                 *shpool;
     ngx_atomic_t                     rwlock;
+    ngx_uint_t                      *config;
+    ngx_stream_upstream_rr_peer_t   *resolve;
     ngx_stream_upstream_rr_peers_t  *zone_next;
 #endif
 
@@ -112,6 +131,65 @@ struct ngx_stream_upstream_rr_peers_s {
         ngx_rwlock_unlock(&peer->lock);                                       \
     }
 
+
+#define ngx_stream_upstream_rr_peer_ref(peers, peer)                          \
+    (peer)->refs++;
+
+
+static ngx_inline void
+ngx_stream_upstream_rr_peer_free_locked(ngx_stream_upstream_rr_peers_t *peers,
+    ngx_stream_upstream_rr_peer_t *peer)
+{
+    if (peer->refs) {
+        peer->zombie = 1;
+        return;
+    }
+
+    ngx_slab_free_locked(peers->shpool, peer->sockaddr);
+    ngx_slab_free_locked(peers->shpool, peer->name.data);
+
+    if (peer->server.data && (peer->host == NULL || peer->host->peer == peer)) {
+        ngx_slab_free_locked(peers->shpool, peer->server.data);
+    }
+
+#if (NGX_STREAM_SSL)
+    if (peer->ssl_session) {
+        ngx_slab_free_locked(peers->shpool, peer->ssl_session);
+    }
+#endif
+
+    ngx_slab_free_locked(peers->shpool, peer);
+}
+
+
+static ngx_inline void
+ngx_stream_upstream_rr_peer_free(ngx_stream_upstream_rr_peers_t *peers,
+    ngx_stream_upstream_rr_peer_t *peer)
+{
+    ngx_shmtx_lock(&peers->shpool->mutex);
+    ngx_stream_upstream_rr_peer_free_locked(peers, peer);
+    ngx_shmtx_unlock(&peers->shpool->mutex);
+}
+
+
+static ngx_inline ngx_int_t
+ngx_stream_upstream_rr_peer_unref(ngx_stream_upstream_rr_peers_t *peers,
+    ngx_stream_upstream_rr_peer_t *peer)
+{
+    peer->refs--;
+
+    if (peers->shpool == NULL) {
+        return NGX_OK;
+    }
+
+    if (peer->refs == 0 && peer->zombie) {
+        ngx_stream_upstream_rr_peer_free(peers, peer);
+        return NGX_DONE;
+    }
+
+    return NGX_OK;
+}
+
 #else
 
 #define ngx_stream_upstream_rr_peers_rlock(peers)
@@ -119,6 +197,8 @@ struct ngx_stream_upstream_rr_peers_s {
 #define ngx_stream_upstream_rr_peers_unlock(peers)
 #define ngx_stream_upstream_rr_peer_lock(peers, peer)
 #define ngx_stream_upstream_rr_peer_unlock(peers, peer)
+#define ngx_stream_upstream_rr_peer_ref(peers, peer)
+#define ngx_stream_upstream_rr_peer_unref(peers, peer)  NGX_OK
 
 #endif
 

--- a/src/stream/ngx_stream_upstream_zone_module.c
+++ b/src/stream/ngx_stream_upstream_zone_module.c
@@ -15,9 +15,15 @@ static char *ngx_stream_upstream_zone(ngx_conf_t *cf, ngx_command_t *cmd,
 static ngx_int_t ngx_stream_upstream_init_zone(ngx_shm_zone_t *shm_zone,
     void *data);
 static ngx_stream_upstream_rr_peers_t *ngx_stream_upstream_zone_copy_peers(
-    ngx_slab_pool_t *shpool, ngx_stream_upstream_srv_conf_t *uscf);
+    ngx_slab_pool_t *shpool, ngx_stream_upstream_srv_conf_t *uscf,
+    ngx_stream_upstream_srv_conf_t *ouscf);
 static ngx_stream_upstream_rr_peer_t *ngx_stream_upstream_zone_copy_peer(
     ngx_stream_upstream_rr_peers_t *peers, ngx_stream_upstream_rr_peer_t *src);
+static ngx_int_t ngx_stream_upstream_zone_preresolve(
+    ngx_stream_upstream_rr_peer_t *resolve,
+    ngx_stream_upstream_rr_peers_t *peers,
+    ngx_stream_upstream_rr_peer_t *oresolve,
+    ngx_stream_upstream_rr_peers_t *opeers);
 static void ngx_stream_upstream_zone_set_single(
     ngx_stream_upstream_srv_conf_t *uscf);
 static void ngx_stream_upstream_zone_remove_peer_locked(
@@ -125,11 +131,11 @@ static ngx_int_t
 ngx_stream_upstream_init_zone(ngx_shm_zone_t *shm_zone, void *data)
 {
     size_t                            len;
-    ngx_uint_t                        i;
+    ngx_uint_t                        i, j;
     ngx_slab_pool_t                  *shpool;
     ngx_stream_upstream_rr_peers_t   *peers, **peersp;
-    ngx_stream_upstream_srv_conf_t   *uscf, **uscfp;
-    ngx_stream_upstream_main_conf_t  *umcf;
+    ngx_stream_upstream_srv_conf_t   *uscf, *ouscf, **uscfp, **ouscfp;
+    ngx_stream_upstream_main_conf_t  *umcf, *oumcf;
 
     shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
     umcf = shm_zone->data;
@@ -166,6 +172,7 @@ ngx_stream_upstream_init_zone(ngx_shm_zone_t *shm_zone, void *data)
     /* copy peers to shared memory */
 
     peersp = (ngx_stream_upstream_rr_peers_t **) (void *) &shpool->data;
+    oumcf = data;
 
     for (i = 0; i < umcf->upstreams.nelts; i++) {
         uscf = uscfp[i];
@@ -174,7 +181,38 @@ ngx_stream_upstream_init_zone(ngx_shm_zone_t *shm_zone, void *data)
             continue;
         }
 
-        peers = ngx_stream_upstream_zone_copy_peers(shpool, uscf);
+        ouscf = NULL;
+
+        if (oumcf) {
+            ouscfp = oumcf->upstreams.elts;
+
+            for (j = 0; j < oumcf->upstreams.nelts; j++) {
+
+                 if (ouscfp[j]->shm_zone == NULL) {
+                     continue;
+                 }
+
+                 if (ouscfp[j]->shm_zone->shm.name.len != shm_zone->shm.name.len
+                     || ngx_memcmp(ouscfp[j]->shm_zone->shm.name.data,
+                                   shm_zone->shm.name.data,
+                                   shm_zone->shm.name.len)
+                        != 0)
+                 {
+                     continue;
+                 }
+
+                 if (ouscfp[j]->host.len == uscf->host.len
+                     && ngx_memcmp(ouscfp[j]->host.data, uscf->host.data,
+                                   uscf->host.len)
+                        == 0)
+                 {
+                     ouscf = ouscfp[j];
+                     break;
+                 }
+            }
+        }
+
+        peers = ngx_stream_upstream_zone_copy_peers(shpool, uscf, ouscf);
         if (peers == NULL) {
             return NGX_ERROR;
         }
@@ -189,12 +227,14 @@ ngx_stream_upstream_init_zone(ngx_shm_zone_t *shm_zone, void *data)
 
 static ngx_stream_upstream_rr_peers_t *
 ngx_stream_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
-    ngx_stream_upstream_srv_conf_t *uscf)
+    ngx_stream_upstream_srv_conf_t *uscf, ngx_stream_upstream_srv_conf_t *ouscf)
 {
     ngx_str_t                       *name;
     ngx_uint_t                      *config;
     ngx_stream_upstream_rr_peer_t   *peer, **peerp;
-    ngx_stream_upstream_rr_peers_t  *peers, *backup;
+    ngx_stream_upstream_rr_peers_t  *peers, *opeers, *backup;
+
+    opeers = (ouscf ? ouscf->peer.data : NULL);
 
     config = ngx_slab_calloc(shpool, sizeof(ngx_uint_t));
     if (config == NULL) {
@@ -247,6 +287,16 @@ ngx_stream_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
         (*peers->config)++;
     }
 
+    if (opeers) {
+
+        if (ngx_stream_upstream_zone_preresolve(peers->resolve, peers,
+                                                opeers->resolve, opeers)
+            != NGX_OK)
+        {
+            return NULL;
+        }
+    }
+
     if (peers->next == NULL) {
         goto done;
     }
@@ -286,9 +336,29 @@ ngx_stream_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
 
     peers->next = backup;
 
+    if (opeers && opeers->next) {
+
+        if (ngx_stream_upstream_zone_preresolve(peers->resolve, backup,
+                                                opeers->resolve, opeers->next)
+            != NGX_OK)
+        {
+            return NULL;
+        }
+
+        if (ngx_stream_upstream_zone_preresolve(backup->resolve, backup,
+                                                opeers->next->resolve,
+                                                opeers->next)
+            != NGX_OK)
+        {
+            return NULL;
+        }
+    }
+
 done:
 
     uscf->peer.data = peers;
+
+    ngx_stream_upstream_zone_set_single(uscf);
 
     return peers;
 }
@@ -398,6 +468,123 @@ failed:
     ngx_slab_free_locked(pool, dst);
 
     return NULL;
+}
+
+
+static ngx_int_t
+ngx_stream_upstream_zone_preresolve(ngx_stream_upstream_rr_peer_t *resolve,
+    ngx_stream_upstream_rr_peers_t *peers,
+    ngx_stream_upstream_rr_peer_t *oresolve,
+    ngx_stream_upstream_rr_peers_t *opeers)
+{
+    in_port_t                       port;
+    ngx_str_t                      *server;
+    ngx_stream_upstream_host_t     *host;
+    ngx_stream_upstream_rr_peer_t  *peer, *template, *opeer, **peerp;
+
+    if (resolve == NULL || oresolve == NULL) {
+        return NGX_OK;
+    }
+
+    for (peerp = &peers->peer; *peerp; peerp = &(*peerp)->next) {
+        /* void */
+    }
+
+    ngx_stream_upstream_rr_peers_rlock(opeers);
+
+    for (template = resolve; template; template = template->next) {
+        for (opeer = oresolve; opeer; opeer = opeer->next) {
+
+            if (opeer->host->name.len != template->host->name.len
+                || ngx_memcmp(opeer->host->name.data,
+                              template->host->name.data,
+                              template->host->name.len)
+                   != 0)
+            {
+                continue;
+            }
+
+            if (opeer->host->service.len != template->host->service.len
+                || ngx_memcmp(opeer->host->service.data,
+                              template->host->service.data,
+                              template->host->service.len)
+                   != 0)
+            {
+                continue;
+            }
+
+            host = opeer->host;
+
+            for (opeer = opeers->peer; opeer; opeer = opeer->next) {
+
+                if (opeer->host != host) {
+                    continue;
+                }
+
+                peer = ngx_stream_upstream_zone_copy_peer(peers, NULL);
+                if (peer == NULL) {
+                    ngx_stream_upstream_rr_peers_unlock(opeers);
+                    return NGX_ERROR;
+                }
+
+                ngx_memcpy(peer->sockaddr, opeer->sockaddr, opeer->socklen);
+
+                if (template->host->service.len == 0) {
+                    port = ngx_inet_get_port(template->sockaddr);
+                    ngx_inet_set_port(peer->sockaddr, port);
+                }
+
+                peer->socklen = opeer->socklen;
+
+                peer->name.len = ngx_sock_ntop(peer->sockaddr, peer->socklen,
+                                               peer->name.data,
+                                               NGX_SOCKADDR_STRLEN, 1);
+
+                peer->host = template->host;
+
+                server = template->host->service.len ? &opeer->server
+                                                     : &template->server;
+
+                peer->server.data = ngx_slab_alloc(peers->shpool, server->len);
+                if (peer->server.data == NULL) {
+                    ngx_stream_upstream_rr_peers_unlock(opeers);
+                    return NGX_ERROR;
+                }
+
+                ngx_memcpy(peer->server.data, server->data, server->len);
+                peer->server.len = server->len;
+
+                if (host->service.len == 0) {
+                    peer->weight = template->weight;
+
+                } else {
+                    peer->weight = (template->weight != 1 ? template->weight
+                                                          : opeer->weight);
+                }
+
+                peer->effective_weight = peer->weight;
+                peer->max_conns = template->max_conns;
+                peer->max_fails = template->max_fails;
+                peer->fail_timeout = template->fail_timeout;
+                peer->down = template->down;
+
+                (*peers->config)++;
+
+                *peerp = peer;
+                peerp = &peer->next;
+
+                peers->number++;
+                peers->tries += (peer->down == 0);
+                peers->total_weight += peer->weight;
+                peers->weighted = (peers->total_weight != peers->number);
+            }
+
+            break;
+        }
+    }
+
+    ngx_stream_upstream_rr_peers_unlock(opeers);
+    return NGX_OK;
 }
 
 

--- a/src/stream/ngx_stream_upstream_zone_module.c
+++ b/src/stream/ngx_stream_upstream_zone_module.c
@@ -18,6 +18,13 @@ static ngx_stream_upstream_rr_peers_t *ngx_stream_upstream_zone_copy_peers(
     ngx_slab_pool_t *shpool, ngx_stream_upstream_srv_conf_t *uscf);
 static ngx_stream_upstream_rr_peer_t *ngx_stream_upstream_zone_copy_peer(
     ngx_stream_upstream_rr_peers_t *peers, ngx_stream_upstream_rr_peer_t *src);
+static void ngx_stream_upstream_zone_set_single(
+    ngx_stream_upstream_srv_conf_t *uscf);
+static void ngx_stream_upstream_zone_remove_peer_locked(
+    ngx_stream_upstream_rr_peers_t *peers, ngx_stream_upstream_rr_peer_t *peer);
+static ngx_int_t ngx_stream_upstream_zone_init_worker(ngx_cycle_t *cycle);
+static void ngx_stream_upstream_zone_resolve_timer(ngx_event_t *event);
+static void ngx_stream_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx);
 
 
 static ngx_command_t  ngx_stream_upstream_zone_commands[] = {
@@ -52,7 +59,7 @@ ngx_module_t  ngx_stream_upstream_zone_module = {
     NGX_STREAM_MODULE,                     /* module type */
     NULL,                                  /* init master */
     NULL,                                  /* init module */
-    NULL,                                  /* init process */
+    ngx_stream_upstream_zone_init_worker,  /* init process */
     NULL,                                  /* init thread */
     NULL,                                  /* exit thread */
     NULL,                                  /* exit process */
@@ -185,8 +192,14 @@ ngx_stream_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
     ngx_stream_upstream_srv_conf_t *uscf)
 {
     ngx_str_t                       *name;
+    ngx_uint_t                      *config;
     ngx_stream_upstream_rr_peer_t   *peer, **peerp;
     ngx_stream_upstream_rr_peers_t  *peers, *backup;
+
+    config = ngx_slab_calloc(shpool, sizeof(ngx_uint_t));
+    if (config == NULL) {
+        return NULL;
+    }
 
     peers = ngx_slab_alloc(shpool, sizeof(ngx_stream_upstream_rr_peers_t));
     if (peers == NULL) {
@@ -211,6 +224,7 @@ ngx_stream_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
     peers->name = name;
 
     peers->shpool = shpool;
+    peers->config = config;
 
     for (peerp = &peers->peer; *peerp; peerp = &peer->next) {
         /* pool is unlocked */
@@ -220,6 +234,17 @@ ngx_stream_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
         }
 
         *peerp = peer;
+        (*peers->config)++;
+    }
+
+    for (peerp = &peers->resolve; *peerp; peerp = &peer->next) {
+        peer = ngx_stream_upstream_zone_copy_peer(peers, *peerp);
+        if (peer == NULL) {
+            return NULL;
+        }
+
+        *peerp = peer;
+        (*peers->config)++;
     }
 
     if (peers->next == NULL) {
@@ -236,6 +261,7 @@ ngx_stream_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
     backup->name = name;
 
     backup->shpool = shpool;
+    backup->config = config;
 
     for (peerp = &backup->peer; *peerp; peerp = &peer->next) {
         /* pool is unlocked */
@@ -245,6 +271,17 @@ ngx_stream_upstream_zone_copy_peers(ngx_slab_pool_t *shpool,
         }
 
         *peerp = peer;
+        (*backup->config)++;
+    }
+
+    for (peerp = &backup->resolve; *peerp; peerp = &peer->next) {
+        peer = ngx_stream_upstream_zone_copy_peer(backup, *peerp);
+        if (peer == NULL) {
+            return NULL;
+        }
+
+        *peerp = peer;
+        (*backup->config)++;
     }
 
     peers->next = backup;
@@ -276,6 +313,7 @@ ngx_stream_upstream_zone_copy_peer(ngx_stream_upstream_rr_peers_t *peers,
         dst->sockaddr = NULL;
         dst->name.data = NULL;
         dst->server.data = NULL;
+        dst->host = NULL;
     }
 
     dst->sockaddr = ngx_slab_calloc_locked(pool, sizeof(ngx_sockaddr_t));
@@ -298,11 +336,36 @@ ngx_stream_upstream_zone_copy_peer(ngx_stream_upstream_rr_peers_t *peers,
         }
 
         ngx_memcpy(dst->server.data, src->server.data, src->server.len);
+
+        if (src->host) {
+            dst->host = ngx_slab_calloc_locked(pool,
+                                            sizeof(ngx_stream_upstream_host_t));
+            if (dst->host == NULL) {
+                goto failed;
+            }
+
+            dst->host->name.data = ngx_slab_alloc_locked(pool,
+                                                         src->host->name.len);
+            if (dst->host->name.data == NULL) {
+                goto failed;
+            }
+
+            dst->host->peers = peers;
+            dst->host->peer = dst;
+
+            dst->host->name.len = src->host->name.len;
+            ngx_memcpy(dst->host->name.data, src->host->name.data,
+                       src->host->name.len);
+        }
     }
 
     return dst;
 
 failed:
+
+    if (dst->host) {
+        ngx_slab_free_locked(pool, dst->host);
+    }
 
     if (dst->server.data) {
         ngx_slab_free_locked(pool, dst->server.data);
@@ -319,4 +382,301 @@ failed:
     ngx_slab_free_locked(pool, dst);
 
     return NULL;
+}
+
+
+static void
+ngx_stream_upstream_zone_set_single(ngx_stream_upstream_srv_conf_t *uscf)
+{
+    ngx_stream_upstream_rr_peers_t  *peers;
+
+    peers = uscf->peer.data;
+
+    if (peers->number == 1
+        && (peers->next == NULL || peers->next->number == 0))
+    {
+        peers->single = 1;
+
+    } else {
+        peers->single = 0;
+    }
+}
+
+
+static void
+ngx_stream_upstream_zone_remove_peer_locked(
+    ngx_stream_upstream_rr_peers_t *peers, ngx_stream_upstream_rr_peer_t *peer)
+{
+    peers->total_weight -= peer->weight;
+    peers->number--;
+    peers->tries -= (peer->down == 0);
+    (*peers->config)++;
+    peers->weighted = (peers->total_weight != peers->number);
+
+    ngx_stream_upstream_rr_peer_free(peers, peer);
+}
+
+
+static ngx_int_t
+ngx_stream_upstream_zone_init_worker(ngx_cycle_t *cycle)
+{
+    ngx_uint_t                        i;
+    ngx_event_t                      *event;
+    ngx_stream_upstream_rr_peer_t    *peer;
+    ngx_stream_upstream_rr_peers_t   *peers;
+    ngx_stream_upstream_srv_conf_t   *uscf, **uscfp;
+    ngx_stream_upstream_main_conf_t  *umcf;
+
+    if (ngx_process != NGX_PROCESS_WORKER
+        && ngx_process != NGX_PROCESS_SINGLE)
+    {
+        return NGX_OK;
+    }
+
+    umcf = ngx_stream_cycle_get_module_main_conf(cycle,
+                                                 ngx_stream_upstream_module);
+
+    if (umcf == NULL) {
+        return NGX_OK;
+    }
+
+    uscfp = umcf->upstreams.elts;
+
+    for (i = 0; i < umcf->upstreams.nelts; i++) {
+
+        uscf = uscfp[i];
+
+        if (uscf->shm_zone == NULL) {
+            continue;
+        }
+
+        peers = uscf->peer.data;
+
+        do {
+            ngx_stream_upstream_rr_peers_wlock(peers);
+
+            for (peer = peers->resolve; peer; peer = peer->next) {
+
+                if (peer->host->worker != ngx_worker) {
+                    continue;
+                }
+
+                event = &peer->host->event;
+                ngx_memzero(event, sizeof(ngx_event_t));
+
+                event->data = uscf;
+                event->handler = ngx_stream_upstream_zone_resolve_timer;
+                event->log = cycle->log;
+                event->cancelable = 1;
+
+                ngx_add_timer(event, 1);
+            }
+
+            ngx_stream_upstream_rr_peers_unlock(peers);
+
+            peers = peers->next;
+
+        } while (peers);
+    }
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_stream_upstream_zone_resolve_timer(ngx_event_t *event)
+{
+    ngx_resolver_ctx_t              *ctx;
+    ngx_stream_upstream_host_t      *host;
+    ngx_stream_upstream_srv_conf_t  *uscf;
+
+    host = (ngx_stream_upstream_host_t *) event;
+    uscf = event->data;
+
+    ctx = ngx_resolve_start(uscf->resolver, NULL);
+    if (ctx == NULL) {
+        goto retry;
+    }
+
+    if (ctx == NGX_NO_RESOLVER) {
+        ngx_log_error(NGX_LOG_ERR, event->log, 0,
+                      "no resolver defined to resolve %V", &host->name);
+        return;
+    }
+
+    ctx->name = host->name;
+    ctx->handler = ngx_stream_upstream_zone_resolve_handler;
+    ctx->data = host;
+    ctx->timeout = uscf->resolver_timeout;
+    ctx->cancelable = 1;
+
+    if (ngx_resolve_name(ctx) == NGX_OK) {
+        return;
+    }
+
+retry:
+
+    ngx_add_timer(event, ngx_max(uscf->resolver_timeout, 1000));
+}
+
+
+static void
+ngx_stream_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
+{
+    time_t                           now;
+    in_port_t                        port;
+    ngx_msec_t                       timer;
+    ngx_uint_t                       i, j;
+    ngx_event_t                     *event;
+    ngx_resolver_addr_t             *addr;
+    ngx_stream_upstream_host_t      *host;
+    ngx_stream_upstream_rr_peer_t   *peer, *template, **peerp;
+    ngx_stream_upstream_rr_peers_t  *peers;
+    ngx_stream_upstream_srv_conf_t  *uscf;
+
+    host = ctx->data;
+    event = &host->event;
+    uscf = event->data;
+    peers = host->peers;
+    template = host->peer;
+
+    ngx_stream_upstream_rr_peers_wlock(peers);
+
+    now = ngx_time();
+
+    if (ctx->state) {
+        ngx_log_error(NGX_LOG_ERR, event->log, 0,
+                      "%V could not be resolved (%i: %s)",
+                      &ctx->name, ctx->state,
+                      ngx_resolver_strerror(ctx->state));
+
+        if (ctx->state != NGX_RESOLVE_NXDOMAIN) {
+            ngx_stream_upstream_rr_peers_unlock(peers);
+
+            ngx_resolve_name_done(ctx);
+
+            ngx_add_timer(event, ngx_max(uscf->resolver_timeout, 1000));
+            return;
+        }
+
+        /* NGX_RESOLVE_NXDOMAIN */
+
+        ctx->naddrs = 0;
+    }
+
+#if (NGX_DEBUG)
+    {
+    u_char  text[NGX_SOCKADDR_STRLEN];
+    size_t  len;
+
+    for (i = 0; i < ctx->naddrs; i++) {
+        len = ngx_sock_ntop(ctx->addrs[i].sockaddr, ctx->addrs[i].socklen,
+                            text, NGX_SOCKADDR_STRLEN, 0);
+
+        ngx_log_debug3(NGX_LOG_DEBUG_STREAM, event->log, 0,
+                       "name %V was resolved to %*s", &host->name, len, text);
+    }
+    }
+#endif
+
+    for (peerp = &peers->peer; *peerp; /* void */ ) {
+        peer = *peerp;
+
+        if (peer->host != host) {
+            goto next;
+        }
+
+        for (j = 0; j < ctx->naddrs; j++) {
+
+            addr = &ctx->addrs[j];
+
+            if (addr->name.len == 0
+                && ngx_cmp_sockaddr(peer->sockaddr, peer->socklen,
+                                    addr->sockaddr, addr->socklen, 0)
+                   == NGX_OK)
+            {
+                addr->name.len = 1;
+                goto next;
+            }
+        }
+
+        *peerp = peer->next;
+        ngx_stream_upstream_zone_remove_peer_locked(peers, peer);
+
+        ngx_stream_upstream_zone_set_single(uscf);
+
+        continue;
+
+    next:
+
+        peerp = &peer->next;
+    }
+
+    for (i = 0; i < ctx->naddrs; i++) {
+
+        addr = &ctx->addrs[i];
+
+        if (addr->name.len == 1) {
+            addr->name.len = 0;
+            continue;
+        }
+
+        ngx_shmtx_lock(&peers->shpool->mutex);
+        peer = ngx_stream_upstream_zone_copy_peer(peers, NULL);
+        ngx_shmtx_unlock(&peers->shpool->mutex);
+        if (peer == NULL) {
+            ngx_log_error(NGX_LOG_ERR, event->log, 0,
+                          "cannot add new server to upstream \"%V\", "
+                          "memory exhausted", peers->name);
+            break;
+        }
+
+        ngx_memcpy(peer->sockaddr, addr->sockaddr, addr->socklen);
+
+        port = ((struct sockaddr_in *) template->sockaddr)->sin_port;
+
+        switch (peer->sockaddr->sa_family) {
+#if (NGX_HAVE_INET6)
+        case AF_INET6:
+            ((struct sockaddr_in6 *) peer->sockaddr)->sin6_port = port;
+            break;
+#endif
+        default: /* AF_INET */
+            ((struct sockaddr_in *) peer->sockaddr)->sin_port = port;
+        }
+
+        peer->socklen = addr->socklen;
+
+        peer->name.len = ngx_sock_ntop(peer->sockaddr, peer->socklen,
+                                       peer->name.data, NGX_SOCKADDR_STRLEN, 1);
+
+        peer->host = template->host;
+        peer->server = template->server;
+
+        peer->weight = template->weight;
+        peer->effective_weight = peer->weight;
+        peer->max_conns = template->max_conns;
+        peer->max_fails = template->max_fails;
+        peer->fail_timeout = template->fail_timeout;
+        peer->down = template->down;
+
+        *peerp = peer;
+        peerp = &peer->next;
+
+        peers->number++;
+        peers->tries += (peer->down == 0);
+        peers->total_weight += peer->weight;
+        peers->weighted = (peers->total_weight != peers->number);
+        (*peers->config)++;
+
+        ngx_stream_upstream_zone_set_single(uscf);
+    }
+
+    ngx_stream_upstream_rr_peers_unlock(peers);
+
+    timer = (ngx_msec_t) 1000 * (ctx->valid > now ? ctx->valid - now + 1 : 1);
+
+    ngx_resolve_name_done(ctx);
+
+    ngx_add_timer(event, timer);
 }


### PR DESCRIPTION
v3 of the patchset, previously submitted in https://mailman.nginx.org/pipermail/nginx-devel/2024-July/MYXA5AVMTIMDNEVMA462AN7CRQ546Y7L.html

This PR adds to the open-source code DNS re-resolve and service discovery functionality from NGINX Plus.

The documentation is already available online and will be updated to reflect the availability of the directives in the open-source product after the release:
* `resolve` and `service` parameters of the [`server`](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#server) directive in the HTTP `upstream` block.
* [`resolver`](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#resolver) and [`resolver_timeout`](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#resolver_timeout) directives in the HTTP `upstream` block.
* Matching sections of the stream `upstream` block documentation: [`resolver`](https://nginx.org/en/docs/stream/ngx_stream_upstream_module.html#resolver), [`resolver_timeout`](https://nginx.org/en/docs/stream/ngx_stream_upstream_module.html#resolver_timeout) and  [`server`](https://nginx.org/en/docs/stream/ngx_stream_upstream_module.html#server)

For a higher level overview see [Using DNS for Service Discovery with NGINX and NGINX Plus](https://www.f5.com/company/blog/nginx/dns-service-discovery-nginx-plus).

