### PR TITLE
Proxy: always initialize header's chain next field

### DIFF
--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -1949,6 +1949,8 @@ ngx_http_proxy_process_header(ngx_http_request_t *r)
                 if (rc != NGX_OK) {
                     return rc;
                 }
+            } else {
+              h->next = NULL;
             }
 
             ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,


### PR DESCRIPTION
### Proposed changes

Fix `h->next` field of header's chain [left unitialized](https://github.com/nginx/nginx/blob/master/src/http/modules/ngx_http_proxy_module.c#L1946) when new header is not in `headers_in_hash`.

P.S> tests passed without regress