### PR TITLE
Add HTTP_HOST to fastcgi params

### DIFF
--- a/conf/fastcgi.conf
+++ b/conf/fastcgi.conf
@@ -22,5 +22,7 @@ fastcgi_param  SERVER_ADDR        $server_addr;
 fastcgi_param  SERVER_PORT        $server_port;
 fastcgi_param  SERVER_NAME        $server_name;
 
+fastcgi_param  HTTP_HOST          $host$is_request_port$request_port;
+
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;

--- a/conf/fastcgi_params
+++ b/conf/fastcgi_params
@@ -21,5 +21,7 @@ fastcgi_param  SERVER_ADDR        $server_addr;
 fastcgi_param  SERVER_PORT        $server_port;
 fastcgi_param  SERVER_NAME        $server_name;
 
+fastcgi_param  HTTP_HOST          $host$is_request_port$request_port;
+
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;

--- a/conf/scgi_params
+++ b/conf/scgi_params
@@ -15,3 +15,5 @@ scgi_param  REMOTE_ADDR        $remote_addr;
 scgi_param  REMOTE_PORT        $remote_port;
 scgi_param  SERVER_PORT        $server_port;
 scgi_param  SERVER_NAME        $server_name;
+
+scgi_param  HTTP_HOST          $host$is_request_port$request_port;

--- a/conf/uwsgi_params
+++ b/conf/uwsgi_params
@@ -15,3 +15,5 @@ uwsgi_param  REMOTE_ADDR        $remote_addr;
 uwsgi_param  REMOTE_PORT        $remote_port;
 uwsgi_param  SERVER_PORT        $server_port;
 uwsgi_param  SERVER_NAME        $server_name;
+
+uwsgi_param  HTTP_HOST          $host$is_request_port$request_port;


### PR DESCRIPTION
Downstream origin of request: https://salsa.debian.org/nginx-team/nginx/-/issues/21

### Proposed changes

It was indicated in a downstream 'issue' in the Debian Salsa repository for NGINX that:

> When using HTTP/3, the Host header is not sent anymore by the client, it always and only uses the :authority pseudo-header. Thus, fastcgi never receives it, and some PHP applications rely on it because it's mandatory on HTTP/1.1.
> 
> I propose to use fastcgi_param HTTP_HOST $host because as mentioned here (https://trac.nginx.org/nginx/ticket/2468#comment:1) it will use the real computed Host value from nginx.

Because changes to nginx open source are now able to be done via git PRs, etc. I have 'upstreamed' this issue to here as a PR.
