### PR TITLE
Adding missing files from recent pcre2 library

### DIFF
--- a/auto/lib/pcre/make
+++ b/auto/lib/pcre/make
@@ -36,7 +36,8 @@ if [ $PCRE_LIBRARY = PCRE2 ]; then
                        pcre2_valid_utf.c \
                        pcre2_xclass.c"
 
-        ngx_pcre_test="pcre2_convert.c \
+        ngx_pcre_test="pcre2_chkdint.c \
+                       pcre2_convert.c \
                        pcre2_extuni.c \
                        pcre2_find_bracket.c \
                        pcre2_script_run.c \


### PR DESCRIPTION
### Proposed changes

I tried to build nginx on windows with msvc. Everything went relatively well except it failed to link because of a missing symbol.
That symbol is defined in a missing file from the list of pcre2 sources.