### PR TITLE
http variable request_auto_redirect

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1031,6 +1031,8 @@ ngx_http_core_find_config_phase(ngx_http_request_t *r,
             ngx_memcpy(p, r->args.data, r->args.len);
         }
 
+        r->request_auto_redirect = 1;
+
         ngx_http_finalize_request(r, NGX_HTTP_MOVED_PERMANENTLY);
         return NGX_OK;
     }

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -542,6 +542,7 @@ struct ngx_http_request_s {
     unsigned                          error_page:1;
     unsigned                          filter_finalize:1;
     unsigned                          post_action:1;
+    unsigned                          request_auto_redirect:1;
     unsigned                          request_complete:1;
     unsigned                          request_output:1;
     unsigned                          header_sent:1;

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -93,6 +93,8 @@ static ngx_int_t ngx_http_variable_body_bytes_sent(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_variable_pipe(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_variable_request_auto_redirect(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_variable_request_completion(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_variable_request_body(ngx_http_request_t *r,
@@ -282,6 +284,10 @@ static ngx_http_variable_t  ngx_http_core_variables[] = {
       0, 0, 0 },
 
     { ngx_string("pipe"), NULL, ngx_http_variable_pipe,
+      0, 0, 0 },
+
+    { ngx_string("request_auto_redirect"), NULL,
+      ngx_http_variable_request_auto_redirect,
       0, 0, 0 },
 
     { ngx_string("request_completion"), NULL,
@@ -2085,6 +2091,20 @@ ngx_http_variable_set_limit_rate(ngx_http_request_t *r,
 
     r->limit_rate = s;
     r->limit_rate_set = 1;
+}
+
+
+static ngx_int_t
+ngx_http_variable_request_auto_redirect(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    if (r->request_auto_redirect) {
+        *v = ngx_http_variable_true_value;
+        return NGX_OK;
+    }
+
+    *v = ngx_http_variable_null_value;
+    return NGX_OK;
 }
 
 


### PR DESCRIPTION
when the request is /t, it will auto redirect to /t/, passing through only header/body filter & log phases, skipping phases like rewrite & access etc, request_auto_redirect variable can be an explict indicator of the case
