### PR TITLE
Core: change TCP keepalive from ms to seconds on DragonFly BSD

### DIFF
--- a/src/os/unix/ngx_freebsd_config.h
+++ b/src/os/unix/ngx_freebsd_config.h
@@ -103,7 +103,7 @@ typedef struct aiocb  ngx_aiocb_t;
 #define NGX_LISTEN_BACKLOG        -1
 
 
-#ifdef __DragonFly__
+#if (defined __DragonFly__ && __DragonFly_version < 500702)
 #define NGX_KEEPALIVE_FACTOR      1000
 #endif
 


### PR DESCRIPTION
### Proposed changes

DragonFly BSD has changed the time unit for TCP keep-alive from milliseconds to seconds since 5.7 development patch 2, thus setting the keepalive options in milliseconds on DragonFlyBSD 5.8+ will cause the values to be magnified by a factor of a thousand.

Fix it by distinguishing the DragonFly BSD versions and use the proper time units accordingly.

Ref:
https://mailman.nginx.org/pipermail/nginx-devel/2013-July/003980.html
https://lists.dragonflybsd.org/pipermail/commits/2019-July/719125.html
https://github.com/DragonFlyBSD/DragonFlyBSD/blob/965b380e960908836b97aa034fa2753091e0172e/sys/sys/param.h#L207
https://www.dragonflybsd.org/release58/
