### PR TITLE
Mail: handling of CAPABILITY in the LOGIN IMAP command.

### DIFF
--- a/src/mail/ngx_mail_proxy_module.c
+++ b/src/mail/ngx_mail_proxy_module.c
@@ -1019,12 +1019,36 @@ ngx_mail_proxy_read_response(ngx_mail_session_t *s, ngx_uint_t state)
             break;
 
         case ngx_imap_passwd:
+
+            /*
+             * untagged CAPABILITY response (draft-crispin-imapv-16),
+             * known to be sent by SmarterMail and Gmail
+             */
+
+            if (p[0] == '*' && p[1] == ' ') {
+                p += 2;
+
+                while (p < b->last - 1) {
+                    if (p[0] == CR && p[1] == LF) {
+                        p += 2;
+                        break;
+                    }
+
+                    p++;
+                }
+
+                if (b->last - p < 4) {
+                    return NGX_AGAIN;
+                }
+            }
+
             if (ngx_strncmp(p, s->tag.data, s->tag.len) == 0) {
                 p += s->tag.len;
                 if (p[0] == 'O' && p[1] == 'K') {
                     return NGX_OK;
                 }
             }
+
             break;
         }
 


### PR DESCRIPTION
SmarterMail IMAP server may send an optional untagged CAPABILITY response.
Previously resulted in a broken connection, now it is passed.
