### PR TITLE
Conf: Allocate directive name memory from temp-pool.

### DIFF
--- a/src/core/ngx_conf_file.c
+++ b/src/core/ngx_conf_file.c
@@ -763,7 +763,20 @@ ngx_conf_read_token(ngx_conf_t *cf)
                     return NGX_ERROR;
                 }
 
-                word->data = ngx_pnalloc(cf->pool, b->pos - 1 - start + 1);
+                /*
+                 * If no custom handler is set, the first argument is the
+                 * directive name. Since the directive name is not stored
+                 * in the modules' configuration structures, it's safe to
+                 * allocate memory for it using the temporary pool.
+                 */
+                if (cf->handler == NULL && cf->args->nelts == 1) {
+                    word->data = ngx_pnalloc(cf->temp_pool,
+                                             b->pos - 1 - start + 1);
+                } else {
+                    word->data = ngx_pnalloc(cf->pool,
+                                             b->pos - 1 - start + 1);
+                }
+
                 if (word->data == NULL) {
                     return NGX_ERROR;
                 }


### PR DESCRIPTION
### Proposed changes
The PR intends to optimize the memory consumption of Nginx.

When custom_handler is not set, the first element in conf->args is treated as the directive name and is compared against the directive names defined by the modules. Since modules typically do not store the directive name, memory for it can be allocated using a temporary pool to optimize memory usage.
