### PR TITLE
[WIP] #220: fix add wildcard server to all addr

### DIFF
--- a/src/http/ngx_http.c
+++ b/src/http/ngx_http.c
@@ -1252,14 +1252,15 @@ ngx_http_add_addresses(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
 
     addr = port->addrs.elts;
 
-    for (i = 0; i < port->addrs.nelts; i++) {
+    ngx_int_t exact_match = 1;
 
-        if (ngx_cmp_sockaddr(lsopt->sockaddr, lsopt->socklen,
-                             addr[i].opt.sockaddr,
-                             addr[i].opt.socklen, 0)
-            != NGX_OK)
-        {
-            continue;
+    for (i = 0; i < port->addrs.nelts; i++) {
+        if ( ngx_cmp_sockaddr(lsopt->sockaddr, lsopt->socklen, addr[i].opt.sockaddr, addr[i].opt.socklen, 0) != NGX_OK ) {
+            if( !lsopt->wildcard ){
+                continue;
+            }
+        } else {
+            exact_match = NGX_OK;
         }
 
         /* the address is already in the address list */
@@ -1379,6 +1380,9 @@ ngx_http_add_addresses(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
         addr[i].opt.quic = quic;
 #endif
 
+    }
+
+    if ( exact_match == NGX_OK ){
         return NGX_OK;
     }
 


### PR DESCRIPTION
This a WIP to test potential fix to https://github.com/nginx/nginx/issues/220.

The idea is that when the server block listens on a wildcard we still call `ngx_http_add_server` even if the `ngx_cmp_sockaddr` is not a match.

This mean that with the following configuration:

```conf
server {
    listen 127.0.0.1:80;
    server_name bug.lan;
    location / {
        default_type application/text;
        return 200 'Bug ?';
    }
}

server {
    listen 0.0.0.0:80 default_server;
    server_name _;
    location / {
        return 403;
    }
}

server {
    listen 0.0.0.0:80;
    server_name hello.lan;
    location / {
        default_type application/text;
        return 200 'Hello';
    }
}
```

Without the patch would return:

```bash
> curl http://hello.lan --resolve hello.lan:80:127.0.0.1
 Bug ?
> curl http://toto.lan --resolve toto.lan:80:127.0.0.1
 Bug ?
> curl http://bug.lan --resolve bug.lan:80:127.0.0.1
 Bug ?
```

Now with this fix it returns: 
```bash
> curl http://hello.lan --resolve hello.lan:80:127.0.0.1
Hello

> curl http://toto.lan --resolve toto.lan:80:127.0.0.1
<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
<hr><center>nginx/1.27.2</center>
</body>
</html>

> curl http://bug.lan --resolve bug.lan:80:127.0.0.1
 Bug ?
```

This is a WIP since I won't pretend to know if there is no unintended consequences, and it only works for now if the `wildcard` servers are defined at the end.
But before spending more time on it wanted to know if this could be a solution.

Have a nice day :).