### PR TITLE
Add http_401 to proxy_next_upstream

### DIFF
--- a/src/http/modules/ngx_http_fastcgi_module.c
+++ b/src/http/modules/ngx_http_fastcgi_module.c
@@ -212,6 +212,7 @@ static ngx_conf_bitmask_t  ngx_http_fastcgi_next_upstream_masks[] = {
     { ngx_string("non_idempotent"), NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT },
     { ngx_string("http_500"), NGX_HTTP_UPSTREAM_FT_HTTP_500 },
     { ngx_string("http_503"), NGX_HTTP_UPSTREAM_FT_HTTP_503 },
+    { ngx_string("http_401"), NGX_HTTP_UPSTREAM_FT_HTTP_401 },
     { ngx_string("http_403"), NGX_HTTP_UPSTREAM_FT_HTTP_403 },
     { ngx_string("http_404"), NGX_HTTP_UPSTREAM_FT_HTTP_404 },
     { ngx_string("http_429"), NGX_HTTP_UPSTREAM_FT_HTTP_429 },

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -227,6 +227,7 @@ static ngx_conf_bitmask_t  ngx_http_grpc_next_upstream_masks[] = {
     { ngx_string("http_502"), NGX_HTTP_UPSTREAM_FT_HTTP_502 },
     { ngx_string("http_503"), NGX_HTTP_UPSTREAM_FT_HTTP_503 },
     { ngx_string("http_504"), NGX_HTTP_UPSTREAM_FT_HTTP_504 },
+    { ngx_string("http_401"), NGX_HTTP_UPSTREAM_FT_HTTP_401 },
     { ngx_string("http_403"), NGX_HTTP_UPSTREAM_FT_HTTP_403 },
     { ngx_string("http_404"), NGX_HTTP_UPSTREAM_FT_HTTP_404 },
     { ngx_string("http_429"), NGX_HTTP_UPSTREAM_FT_HTTP_429 },

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -228,6 +228,7 @@ static ngx_conf_bitmask_t  ngx_http_grpc_next_upstream_masks[] = {
     { ngx_string("http_502"), NGX_HTTP_UPSTREAM_FT_HTTP_502 },
     { ngx_string("http_503"), NGX_HTTP_UPSTREAM_FT_HTTP_503 },
     { ngx_string("http_504"), NGX_HTTP_UPSTREAM_FT_HTTP_504 },
+    { ngx_string("http_401"), NGX_HTTP_UPSTREAM_FT_HTTP_401 },
     { ngx_string("http_403"), NGX_HTTP_UPSTREAM_FT_HTTP_403 },
     { ngx_string("http_404"), NGX_HTTP_UPSTREAM_FT_HTTP_404 },
     { ngx_string("http_429"), NGX_HTTP_UPSTREAM_FT_HTTP_429 },

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -263,6 +263,7 @@ static ngx_conf_bitmask_t  ngx_http_proxy_next_upstream_masks[] = {
     { ngx_string("http_502"), NGX_HTTP_UPSTREAM_FT_HTTP_502 },
     { ngx_string("http_503"), NGX_HTTP_UPSTREAM_FT_HTTP_503 },
     { ngx_string("http_504"), NGX_HTTP_UPSTREAM_FT_HTTP_504 },
+    { ngx_string("http_401"), NGX_HTTP_UPSTREAM_FT_HTTP_401 },
     { ngx_string("http_403"), NGX_HTTP_UPSTREAM_FT_HTTP_403 },
     { ngx_string("http_404"), NGX_HTTP_UPSTREAM_FT_HTTP_404 },
     { ngx_string("http_429"), NGX_HTTP_UPSTREAM_FT_HTTP_429 },

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -165,6 +165,7 @@ static ngx_conf_bitmask_t  ngx_http_proxy_next_upstream_masks[] = {
     { ngx_string("http_502"), NGX_HTTP_UPSTREAM_FT_HTTP_502 },
     { ngx_string("http_503"), NGX_HTTP_UPSTREAM_FT_HTTP_503 },
     { ngx_string("http_504"), NGX_HTTP_UPSTREAM_FT_HTTP_504 },
+    { ngx_string("http_401"), NGX_HTTP_UPSTREAM_FT_HTTP_401 },
     { ngx_string("http_403"), NGX_HTTP_UPSTREAM_FT_HTTP_403 },
     { ngx_string("http_404"), NGX_HTTP_UPSTREAM_FT_HTTP_404 },
     { ngx_string("http_429"), NGX_HTTP_UPSTREAM_FT_HTTP_429 },

--- a/src/http/modules/ngx_http_scgi_module.c
+++ b/src/http/modules/ngx_http_scgi_module.c
@@ -81,6 +81,7 @@ static ngx_conf_bitmask_t ngx_http_scgi_next_upstream_masks[] = {
     { ngx_string("non_idempotent"), NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT },
     { ngx_string("http_500"), NGX_HTTP_UPSTREAM_FT_HTTP_500 },
     { ngx_string("http_503"), NGX_HTTP_UPSTREAM_FT_HTTP_503 },
+    { ngx_string("http_401"), NGX_HTTP_UPSTREAM_FT_HTTP_401 },
     { ngx_string("http_403"), NGX_HTTP_UPSTREAM_FT_HTTP_403 },
     { ngx_string("http_404"), NGX_HTTP_UPSTREAM_FT_HTTP_404 },
     { ngx_string("http_429"), NGX_HTTP_UPSTREAM_FT_HTTP_429 },

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -117,6 +117,7 @@ static ngx_conf_bitmask_t ngx_http_uwsgi_next_upstream_masks[] = {
     { ngx_string("non_idempotent"), NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT },
     { ngx_string("http_500"), NGX_HTTP_UPSTREAM_FT_HTTP_500 },
     { ngx_string("http_503"), NGX_HTTP_UPSTREAM_FT_HTTP_503 },
+    { ngx_string("http_401"), NGX_HTTP_UPSTREAM_FT_HTTP_401 },
     { ngx_string("http_403"), NGX_HTTP_UPSTREAM_FT_HTTP_403 },
     { ngx_string("http_404"), NGX_HTTP_UPSTREAM_FT_HTTP_404 },
     { ngx_string("http_429"), NGX_HTTP_UPSTREAM_FT_HTTP_429 },

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -464,6 +464,7 @@ static ngx_http_upstream_next_t  ngx_http_upstream_next_errors[] = {
     { 502, NGX_HTTP_UPSTREAM_FT_HTTP_502 },
     { 503, NGX_HTTP_UPSTREAM_FT_HTTP_503 },
     { 504, NGX_HTTP_UPSTREAM_FT_HTTP_504 },
+    { 401, NGX_HTTP_UPSTREAM_FT_HTTP_401 },
     { 403, NGX_HTTP_UPSTREAM_FT_HTTP_403 },
     { 404, NGX_HTTP_UPSTREAM_FT_HTTP_404 },
     { 429, NGX_HTTP_UPSTREAM_FT_HTTP_429 },
@@ -4428,6 +4429,10 @@ ngx_http_upstream_next(ngx_http_request_t *r, ngx_http_upstream_t *u,
 
     case NGX_HTTP_UPSTREAM_FT_HTTP_503:
         status = NGX_HTTP_SERVICE_UNAVAILABLE;
+        break;
+
+    case NGX_HTTP_UPSTREAM_FT_HTTP_401:
+        status = NGX_HTTP_UNAUTHORIZED;
         break;
 
     case NGX_HTTP_UPSTREAM_FT_HTTP_403:

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -477,6 +477,7 @@ static ngx_http_upstream_next_t  ngx_http_upstream_next_errors[] = {
     { 502, NGX_HTTP_UPSTREAM_FT_HTTP_502 },
     { 503, NGX_HTTP_UPSTREAM_FT_HTTP_503 },
     { 504, NGX_HTTP_UPSTREAM_FT_HTTP_504 },
+    { 401, NGX_HTTP_UPSTREAM_FT_HTTP_401 },
     { 403, NGX_HTTP_UPSTREAM_FT_HTTP_403 },
     { 404, NGX_HTTP_UPSTREAM_FT_HTTP_404 },
     { 429, NGX_HTTP_UPSTREAM_FT_HTTP_429 },
@@ -4651,6 +4652,10 @@ ngx_http_upstream_next(ngx_http_request_t *r, ngx_http_upstream_t *u,
 
     case NGX_HTTP_UPSTREAM_FT_HTTP_503:
         status = NGX_HTTP_SERVICE_UNAVAILABLE;
+        break;
+
+    case NGX_HTTP_UPSTREAM_FT_HTTP_401:
+        status = NGX_HTTP_UNAUTHORIZED;
         break;
 
     case NGX_HTTP_UPSTREAM_FT_HTTP_403:

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -24,13 +24,14 @@
 #define NGX_HTTP_UPSTREAM_FT_HTTP_502        0x00000020
 #define NGX_HTTP_UPSTREAM_FT_HTTP_503        0x00000040
 #define NGX_HTTP_UPSTREAM_FT_HTTP_504        0x00000080
-#define NGX_HTTP_UPSTREAM_FT_HTTP_403        0x00000100
-#define NGX_HTTP_UPSTREAM_FT_HTTP_404        0x00000200
-#define NGX_HTTP_UPSTREAM_FT_HTTP_429        0x00000400
-#define NGX_HTTP_UPSTREAM_FT_UPDATING        0x00000800
-#define NGX_HTTP_UPSTREAM_FT_BUSY_LOCK       0x00001000
-#define NGX_HTTP_UPSTREAM_FT_MAX_WAITING     0x00002000
-#define NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT  0x00004000
+#define NGX_HTTP_UPSTREAM_FT_HTTP_401        0x00000100
+#define NGX_HTTP_UPSTREAM_FT_HTTP_403        0x00000200
+#define NGX_HTTP_UPSTREAM_FT_HTTP_404        0x00000400
+#define NGX_HTTP_UPSTREAM_FT_HTTP_429        0x00000800
+#define NGX_HTTP_UPSTREAM_FT_UPDATING        0x00001000
+#define NGX_HTTP_UPSTREAM_FT_BUSY_LOCK       0x00002000
+#define NGX_HTTP_UPSTREAM_FT_MAX_WAITING     0x00004000
+#define NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT  0x00008000
 #define NGX_HTTP_UPSTREAM_FT_NOLIVE          0x40000000
 #define NGX_HTTP_UPSTREAM_FT_OFF             0x80000000
 
@@ -38,6 +39,7 @@
                                              |NGX_HTTP_UPSTREAM_FT_HTTP_502  \
                                              |NGX_HTTP_UPSTREAM_FT_HTTP_503  \
                                              |NGX_HTTP_UPSTREAM_FT_HTTP_504  \
+                                             |NGX_HTTP_UPSTREAM_FT_HTTP_401  \
                                              |NGX_HTTP_UPSTREAM_FT_HTTP_403  \
                                              |NGX_HTTP_UPSTREAM_FT_HTTP_404  \
                                              |NGX_HTTP_UPSTREAM_FT_HTTP_429)


### PR DESCRIPTION
### Proposed changes

This PR tries to add `http_401` as one of values for `proxy_next_upstream` to be used, so when a server of an upstream returns 401, it can try the next server.