### PR TITLE
Core: Configurable log message limit

### DIFF
--- a/src/core/ngx_log.c
+++ b/src/core/ngx_log.c
@@ -111,17 +111,22 @@ ngx_set_error_log_buffer_size(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) {
         return NGX_CONF_ERROR;
     }
 
+    if (size < 2048) {
+        ngx_log_error(NGX_LOG_WARN, cf->log, 0,
+                      "Error log buffer size too small, using default minimum of 2 KB");
+        size = 2048;
+    }
+
     NGX_MAX_ERROR_STR = size;
 
     ngx_log_error(NGX_LOG_NOTICE, cf->log, 0,
-                  "Changed the default value of the error log buffer size to %ui", NGX_MAX_ERROR_STR);
+                  "Changed the error log buffer size to %ui", NGX_MAX_ERROR_STR);
 
     return NGX_CONF_OK;
 }
 
+
 #if (NGX_HAVE_VARIADIC_MACROS)
-
-
 
 void
 ngx_log_error_core(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,

--- a/src/core/ngx_log.h
+++ b/src/core/ngx_log.h
@@ -73,8 +73,8 @@ struct ngx_log_s {
 };
 
 
-#define NGX_MAX_ERROR_STR   2048
-
+// #define NGX_MAX_ERROR_STR   2048
+extern ngx_uint_t NGX_MAX_ERROR_STR;
 
 /*********************************/
 


### PR DESCRIPTION
**Reported difficulty in increasing the size of log messages, limiting it to 2 KB. [Issue 250](https://github.com/nginx/nginx/issues/250)**

## Proposed changes

Allowed the user to define the value of `NGX_MAX_ERROR_STR`.

In the [ngx_log.c](https://github.com/nginx/nginx/blob/master/src/core/ngx_log.c) file, a function was created with a default value of **2 KB** for `NGX_MAX_ERROR_STR`.

The option to use `error_log_buffer_size` was added to the `nginx.conf` configuration file.

## Tests

### Default value - 2 KB

Testing the default value of `NGX_MAX_ERROR_STR`. In the `nginx.conf` file nothing is defined, for now.

I'm running a test to create 10 KB logs.

Result limited to 2 KB:
```
2024/11/07 01:46:11 [notice] 83021#0: start worker processes
2024/11/07 01:46:11 [notice] 83021#0: start worker process 83022
2024/11/07 01:46:11 [notice] 83022#0: Error log buffer size is 2048
2024/11/07 01:46:11 [notice] 83022#0: Test log message: 
....
2757 /usr/local/nginx/logs/error.log
```
[Printscreen of the result - Google Drive](https://drive.google.com/file/d/18zT__oDyEeqEd4yK2nQX0LO_H8iJX1CS/view?usp=sharing)

Note that the log file is limited to a little more than 2 KB, as expected.

### Changing value in nginx.conf

Inserting `error_log_buffer_size` in the nginx.conf configuration:

```
#user  nobody;
worker_processes  1;

#error_log  logs/error.log;
#error_log  logs/error.log  notice;
#error_log  logs/error.log  info;

#pid        logs/nginx.pid;

error_log_buffer_size 4096;

events {
    worker_connections  1024;
}

http {
...
```
Expected result is 4 KB limit:

```
2024/11/07 01:57:46 [notice] 85696#0: start worker processes
2024/11/07 01:57:46 [notice] 85696#0: start worker process 85697
2024/11/07 01:57:46 [notice] 85697#0: Error log buffer size is 4096
2024/11/07 01:57:46 [notice] 85697#0: Test log message: 
... ... ... ...
5007 /usr/local/nginx/logs/error.log
```
[Printscreen example of the nginx.conf](https://drive.google.com/file/d/1qUQSBdQ3wXqVu-NxDAc_ymHs8b4i07UK/view?usp=sharing)
[Printscreen of the result - Google Drive](https://drive.google.com/file/d/1Yw2PZ7O2xYvys5z6thTxxW1XAlMAXIid/view?usp=sharing)

Note that the file has already increased in size, trying to limit it to 4 KB.

### Wrong limit set by the user

If the user sets a value lower than the default, for example 1 KB, the value set is 2 KB, following the previously defined pattern.

Setting 1 KB in `nginx.conf`:

```
#user  nobody;
worker_processes  1;

#error_log  logs/error.log;
#error_log  logs/error.log  notice;
#error_log  logs/error.log  info;

#pid        logs/nginx.pid;

error_log_buffer_size 1024;

events {
    worker_connections  1024;
}

http {
..
```
Result:

```
2024/11/07 02:12:40 [warn] 88399#0: Error log buffer size too small, using default minimum of 2 KB
2024/11/07 02:12:40 [notice] 88399#0: Changed the error log buffer size to 2048
2024/11/07 02:12:40 [notice] 88399#0: using the "epoll" event method
2024/11/07 02:12:40 [notice] 88399#0: nginx/1.27.3
2024/11/07 02:12:40 [notice] 88399#0: built by gcc 12.2.0 (Debian 12.2.0-14) 
2024/11/07 02:12:40 [notice] 88399#0: OS: Linux 6.1.0-26-amd64
2024/11/07 02:12:40 [notice] 88399#0: getrlimit(RLIMIT_NOFILE): 1024:1048576
2024/11/07 02:12:40 [notice] 88400#0: start worker processes
2024/11/07 02:12:40 [notice] 88400#0: start worker process 88401
2024/11/07 02:12:40 [notice] 88401#0: Error log buffer size is 2048
2024/11/07 02:12:40 [notice] 88401#0: Test log message: 
...
2759 /usr/local/nginx/logs/error.log
```
As expected, the default size set is 2 KB.

Also notice in the log, which displays the message `Error log buffer size too small, using default minimum of 2 KB` and then the default of 2 KB is set.

## Note

I left the logs showing the handling of the NGX_MAX_ERROR_STR values. If necessary, we can remove them.