### PR TITLE
Added "keepalive_during_shutdown" directive.

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -523,6 +523,13 @@ static ngx_command_t  ngx_http_core_commands[] = {
       offsetof(ngx_http_core_loc_conf_t, keepalive_disable),
       &ngx_http_core_keepalive_disable },
 
+    { ngx_string("keepalive_during_shutdown"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_core_loc_conf_t, keepalive_during_shutdown),
+      NULL },
+
     { ngx_string("satisfy"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_enum_slot,
@@ -3607,6 +3614,7 @@ ngx_http_core_create_loc_conf(ngx_conf_t *cf)
     clcf->keepalive_timeout = NGX_CONF_UNSET_MSEC;
     clcf->keepalive_header = NGX_CONF_UNSET;
     clcf->keepalive_requests = NGX_CONF_UNSET_UINT;
+    clcf->keepalive_during_shutdown = NGX_CONF_UNSET;
     clcf->lingering_close = NGX_CONF_UNSET_UINT;
     clcf->lingering_time = NGX_CONF_UNSET_MSEC;
     clcf->lingering_timeout = NGX_CONF_UNSET_MSEC;
@@ -3897,6 +3905,8 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->chunked_transfer_encoding,
                               prev->chunked_transfer_encoding, 1);
     ngx_conf_merge_value(conf->etag, prev->etag, 1);
+    ngx_conf_merge_value(conf->keepalive_during_shutdown,
+                              prev->keepalive_during_shutdown, 0);
 
     ngx_conf_merge_uint_value(conf->server_tokens, prev->server_tokens,
                               NGX_HTTP_SERVER_TOKENS_ON);

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -407,6 +407,7 @@ struct ngx_http_core_loc_conf_s {
     ngx_uint_t    server_tokens;           /* server_tokens */
     ngx_flag_t    chunked_transfer_encoding; /* chunked_transfer_encoding */
     ngx_flag_t    etag;                    /* etag */
+    ngx_flag_t    keepalive_during_shutdown; /* keepalive_during_shutdown */
 
 #if (NGX_HTTP_GZIP)
     ngx_flag_t    gzip_vary;               /* gzip_vary */

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -2799,7 +2799,7 @@ ngx_http_finalize_connection(ngx_http_request_t *r)
     }
 
     if (!ngx_terminate
-         && !ngx_exiting
+         && (!ngx_exiting || clcf->keepalive_during_shutdown)
          && r->keepalive
          && clcf->keepalive_timeout > 0)
     {
@@ -3300,7 +3300,10 @@ ngx_http_set_keepalive(ngx_http_request_t *r)
     r->http_state = NGX_HTTP_KEEPALIVE_STATE;
 #endif
 
-    c->idle = 1;
+    if (!clcf->keepalive_during_shutdown) {
+        c->idle = 1;
+    }
+
     ngx_reusable_connection(c, 1);
 
     ngx_add_timer(rev, clcf->keepalive_timeout);


### PR DESCRIPTION
When enabled, HTTP client keepalive connections will not be closed on graceful worker shutdown.  Such connections will be closed either on keepalive_timeout expiration, or after serving a new request.  Also, worker_shutdown_timeout may shut down the worker earlier and close the connections.

The PR allows to change the way keepalive HTTP connections are handled during worker shutdowns. With `keepalive_during_shutdown on`, such connections will not be forcefully closed. While HTTP/1.1 RFC allows servers to close keepalive connections, certain clients do not handle this well. The downside of this is longer worker shutdown time.