### PR TITLE
Add exception for upstream duplication "transfer-encoding" header error

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -5240,9 +5240,9 @@ ngx_http_upstream_process_transfer_encoding(ngx_http_request_t *r,
     u = r->upstream;
 
     if (u->headers_in.transfer_encoding 
-        && u->headers_in.transfer_encoding->value.len == h->value.len
+        && u->headers_in.transfer_encoding->value.len != h->value.len
         && ngx_strncasecmp(u->headers_in.transfer_encoding->value.data, 
-                           h->value.data, h->value.len) == 0) 
+                           h->value.data, h->value.len) != 0) 
     {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "upstream sent duplicate header line: \"%V: %V\", "

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -5239,7 +5239,10 @@ ngx_http_upstream_process_transfer_encoding(ngx_http_request_t *r,
 
     u = r->upstream;
 
-    if (u->headers_in.transfer_encoding) {
+    if (u->headers_in.transfer_encoding 
+        && u->headers_in.transfer_encoding->value.len == h->value.len
+        && ngx_strncasecmp(u->headers_in.transfer_encoding->value.data, h->value.data, h->value.len) == 0) 
+    {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "upstream sent duplicate header line: \"%V: %V\", "
                       "previous value: \"%V: %V\"",

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -5241,7 +5241,8 @@ ngx_http_upstream_process_transfer_encoding(ngx_http_request_t *r,
 
     if (u->headers_in.transfer_encoding 
         && u->headers_in.transfer_encoding->value.len == h->value.len
-        && ngx_strncasecmp(u->headers_in.transfer_encoding->value.data, h->value.data, h->value.len) == 0) 
+        && ngx_strncasecmp(u->headers_in.transfer_encoding->value.data, 
+                           h->value.data, h->value.len) == 0) 
     {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "upstream sent duplicate header line: \"%V: %V\", "


### PR DESCRIPTION
When origin server responses Transfer-Encoding headers, same value is passed.

Origin

```bash
HTTP/1.1 200 OK
Date: Fri, 08 Nov 2024 01:14:35 GMT
Content-Type: text/plain
Transfer-Encoding: chunked
Connection: keep-alive
Transfer-Encoding: chunked
```

## Current

Server

```bash
HTTP/1.1 502 Bad Gateway
```

error.log said
```log
2024/11/08 09:36:19 [error] 287658#0: *1 upstream sent duplicate header line: "Transfer-Encoding: chunked", previous value: "Transfer-Encoding: chunked" while reading response header from upstream...
```

## After

Server

```bash
HTTP/1.1 200 OK
Server: nginx/1.24.0
Date: Fri, 08 Nov 2024 01:14:35 GMT
Content-Type: text/plain
Transfer-Encoding: chunked
Connection: keep-alive
Transfer-Encoding: chunked
```
