### PR TITLE
Allowed square brackets with portless IPv6 address.

### DIFF
--- a/src/core/ngx_inet.c
+++ b/src/core/ngx_inet.c
@@ -639,7 +639,11 @@ ngx_parse_addr_port(ngx_pool_t *pool, ngx_addr_t *addr, u_char *text,
 
         p = ngx_strlchr(text, last, ']');
 
-        if (p == NULL || p == last - 1 || *++p != ':') {
+        if (p == last - 1) {
+            return ngx_parse_addr(pool, addr, text + 1, len - 2);
+        }
+
+        if (p == NULL || *++p != ':') {
             return NGX_DECLINED;
         }
 


### PR DESCRIPTION
In several places in nginx, when an address with an optional port is expected, IPv6 address could be specified without square brackets and without port, as well as both with the brackets and port.  The change allows IPv6 in square brackets and no port, which was previously considered an error.

As a reference, this format is also allowed by RFC 9110 for the "Host" header, and by RFC 7239 for "Forwarded by/for".

The change affects headers parsing in `ngx_http_realip_module`, as well as `proxy_bind` and friends.

