### PR TITLE
SSL: error message default in object caching API.

### DIFF
--- a/src/event/ngx_event_openssl_cache.c
+++ b/src/event/ngx_event_openssl_cache.c
@@ -138,6 +138,8 @@ ngx_ssl_cache_fetch(ngx_conf_t *cf, ngx_uint_t index, char **err,
     ngx_ssl_cache_type_t  *type;
     ngx_ssl_cache_node_t  *cn;
 
+    *err = NULL;
+
     if (ngx_ssl_cache_init_key(cf->pool, index, path, &id) != NGX_OK) {
         return NULL;
     }
@@ -182,6 +184,8 @@ ngx_ssl_cache_connection_fetch(ngx_pool_t *pool, ngx_uint_t index, char **err,
     ngx_str_t *path, void *data)
 {
     ngx_ssl_cache_key_t  id;
+
+    *err = NULL;
 
     if (ngx_ssl_cache_init_key(pool, index, path, &id) != NGX_OK) {
         return NULL;


### PR DESCRIPTION
This change initializes the "err" variable, used to produce a meaningful diagnostics on error path, to a good safe value.

### Proposed changes

Describe the use case and detail of the change.

If this pull request addresses an issue on GitHub, make sure to reference that
issue using one of the
[supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).

Before creating a pull request, make sure to comply with the
[Contributing Guidelines](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md).
