### PR TITLE
SSL: Add directive to support trusted OCSP responder certificates

### DIFF
--- a/contrib/vim/syntax/nginx.vim
+++ b/contrib/vim/syntax/nginx.vim
@@ -592,6 +592,7 @@ syn keyword ngxDirective contained ssl_handshake_timeout
 syn keyword ngxDirective contained ssl_ocsp
 syn keyword ngxDirective contained ssl_ocsp_cache
 syn keyword ngxDirective contained ssl_ocsp_responder
+syn keyword ngxDirective contained ssl_ocsp_responder_certificate
 syn keyword ngxDirective contained ssl_password_file
 syn keyword ngxDirective contained ssl_prefer_server_ciphers
 syn keyword ngxDirective contained ssl_preread

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -248,7 +248,7 @@ ngx_int_t ngx_ssl_stapling(ngx_conf_t *cf, ngx_ssl_t *ssl,
     ngx_str_t *file, ngx_str_t *responder, ngx_uint_t verify);
 ngx_int_t ngx_ssl_stapling_resolver(ngx_conf_t *cf, ngx_ssl_t *ssl,
     ngx_resolver_t *resolver, ngx_msec_t resolver_timeout);
-ngx_int_t ngx_ssl_ocsp(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *responder,
+ngx_int_t ngx_ssl_ocsp(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *responder, ngx_str_t *ocsp_responder_certificate,
     ngx_uint_t depth, ngx_shm_zone_t *shm_zone);
 ngx_int_t ngx_ssl_ocsp_resolver(ngx_conf_t *cf, ngx_ssl_t *ssl,
     ngx_resolver_t *resolver, ngx_msec_t resolver_timeout);

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -243,7 +243,14 @@ static ngx_command_t  ngx_http_ssl_commands[] = {
       offsetof(ngx_http_ssl_srv_conf_t, ocsp_responder),
       NULL },
 
-    { ngx_string("ssl_ocsp_cache"),
+   { ngx_string("ssl_ocsp_responder_certificate"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_ssl_srv_conf_t, ocsp_responder_certificate),
+      NULL },
+
+     { ngx_string("ssl_ocsp_cache"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
       ngx_http_ssl_ocsp_cache,
       NGX_HTTP_SRV_CONF_OFFSET,
@@ -838,7 +845,7 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
             return NGX_CONF_ERROR;
         }
 
-        if (ngx_ssl_ocsp(cf, &conf->ssl, &conf->ocsp_responder, conf->ocsp,
+        if (ngx_ssl_ocsp(cf, &conf->ssl, &conf->ocsp_responder, &conf->ocsp_responder_certificate, conf->ocsp,
                          conf->ocsp_cache_zone)
             != NGX_OK)
         {

--- a/src/http/modules/ngx_http_ssl_module.h
+++ b/src/http/modules/ngx_http_ssl_module.h
@@ -58,6 +58,7 @@ typedef struct {
 
     ngx_uint_t                      ocsp;
     ngx_str_t                       ocsp_responder;
+    ngx_str_t                       ocsp_responder_certificate;
     ngx_shm_zone_t                 *ocsp_cache_zone;
 
     ngx_flag_t                      stapling;

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -245,6 +245,13 @@ static ngx_command_t  ngx_stream_ssl_commands[] = {
       offsetof(ngx_stream_ssl_srv_conf_t, ocsp_responder),
       NULL },
 
+    { ngx_string("ssl_ocsp_responder_certificate"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_srv_conf_t, ocsp_responder_certificate),
+      NULL },
+
     { ngx_string("ssl_ocsp_cache"),
       NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
       ngx_stream_ssl_ocsp_cache,
@@ -1083,7 +1090,7 @@ ngx_stream_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
             return NGX_CONF_ERROR;
         }
 
-        if (ngx_ssl_ocsp(cf, &conf->ssl, &conf->ocsp_responder, conf->ocsp,
+        if (ngx_ssl_ocsp(cf, &conf->ssl, &conf->ocsp_responder, &conf->ocsp_responder_certificate, conf->ocsp,
                          conf->ocsp_cache_zone)
             != NGX_OK)
         {

--- a/src/stream/ngx_stream_ssl_module.h
+++ b/src/stream/ngx_stream_ssl_module.h
@@ -58,6 +58,7 @@ typedef struct {
 
     ngx_uint_t        ocsp;
     ngx_str_t         ocsp_responder;
+    ngx_str_t         ocsp_responder_certificate;
     ngx_shm_zone_t   *ocsp_cache_zone;
 
     ngx_flag_t        stapling;


### PR DESCRIPTION
### Proposed changes

This pull request introduces a new directive for Nginx to define a set of trusted PEM-encoded OCSP responder certificates.

The use case addresses scenarios where a custom OCSP responder is used to provide OCSP statuses to Nginx.

In certain environments, multiple certificate authorities (CAs) may issue certificates, but some CAs may not include the OCSP responder URL or certificate revocation lists (CRLs) in the issued certificates.
To address this, a custom OCSP responder can be deployed to handle OCSP requests for these certificates.

However, the OCSP response might not be signed by the CA of the certificate being validated but by a custom certificate. This requires Nginx to explicitly trust the custom OCSP responder's signing certificate.

The added directive mirrors the functionality of Apache's [SSLOCSPResponderCertificateFile ](https://httpd.apache.org/docs/2.4/en/mod/mod_ssl.html#sslocsprespondercertificatefile) directive (introduced in version 2.4) and allows users to configure trusted OCSP responder certificates directly in Nginx.

