### PR TITLE
Add MIME type for CSV files

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -2,6 +2,7 @@
 types {
     text/html                                        html htm shtml;
     text/css                                         css;
+    text/csv                                         csv;
     text/xml                                         xml;
     image/gif                                        gif;
     image/jpeg                                       jpeg jpg;


### PR DESCRIPTION
### Proposed changes

Add the MIME type for CSV files. CSV files are common and nginx is great at serving those.

Before creating a pull request, make sure to comply with the
[Contributing Guidelines](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md).
