### PR TITLE
Issue #330 missing double quote.

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -1347,7 +1347,7 @@ ngx_ssl_dhparam(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *file)
 
     if (SSL_CTX_set0_tmp_dh_pkey(ssl->ctx, dh) != 1) {
         ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0,
-                      "SSL_CTX_set0_tmp_dh_pkey(\%s\") failed", file->data);
+                      "SSL_CTX_set0_tmp_dh_pkey(\"%s\") failed", file->data);
 #if (OPENSSL_VERSION_NUMBER >= 0x3000001fL)
         EVP_PKEY_free(dh);
 #endif


### PR DESCRIPTION
When calling ngx_ssl_error() from ngx_ssl_dhparam(), a double quote is missing.

This issue was noted by [ericwhitmansmith](https://github.com/ericwhitmansmith).
