### PR TITLE
QUIC: prevented BIO leak in case of error.

### DIFF
--- a/src/event/quic/ngx_event_quic_openssl_compat.c
+++ b/src/event/quic/ngx_event_quic_openssl_compat.c
@@ -391,6 +391,7 @@ SSL_set_quic_method(SSL *ssl, const SSL_QUIC_METHOD *quic_method)
 
     wbio = BIO_new(BIO_s_null());
     if (wbio == NULL) {
+        BIO_free(rbio);
         return 0;
     }
 


### PR DESCRIPTION
In case of `wbio` allocation error, `rbio` leaked.
An alternative solution could be calling `SSL_set0_rbio()` and `SSL_set0_wbio()` instead of `SSL_set_bio()`.
The suggested change is a bit simpler though.