### PR TITLE
QUIC: fixed client request timeout in 0-RTT scenarios.

### DIFF
--- a/src/event/quic/ngx_event_quic.c
+++ b/src/event/quic/ngx_event_quic.c
@@ -1029,7 +1029,7 @@ ngx_quic_handle_payload(ngx_connection_t *c, ngx_quic_header_t *pkt)
          * After receiving a 1-RTT packet, servers MUST discard
          * 0-RTT keys within a short time
          */
-        ngx_quic_discard_ctx(c, ssl_encryption_early_data);
+        ngx_quic_keys_discard(qc->keys, ssl_encryption_early_data);
     }
 
     if (qc->closing) {


### PR DESCRIPTION
Since 0-RTT and 1-RTT data exist in the same packet number space, ngx_quic_discard_ctx incorrectly discards 1-RTT packets when 0-RTT keys are discarded.

The issue was introduced by 58b92177e7c3c50f77f807ab3846ad5c7bbf0ebe.