### PR TITLE
DTLS support in Stream PoC

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -11,10 +11,16 @@
 
 
 #define NGX_SSL_PASSWORD_BUFFER_SIZE  4096
+#define NGX_SSL_COOKIE_SECRET_LENGTH  32
 
 
 typedef struct {
-    ngx_uint_t  engine;   /* unsigned  engine:1; */
+    ngx_uint_t   engine;   /* unsigned  engine:1; */
+
+#if (NGX_SSL_DTLS)
+    u_char       cookie_secret[NGX_SSL_COOKIE_SECRET_LENGTH];
+    BIO_METHOD  *method;
+#endif
 } ngx_openssl_conf_t;
 
 
@@ -81,6 +87,17 @@ static time_t ngx_ssl_parse_time(
     const
 #endif
     ASN1_TIME *asn1time, ngx_log_t *log);
+
+#if (NGX_SSL_DTLS)
+static ngx_int_t ngx_ssl_try_listen(ngx_connection_t *c);
+static int ngx_ssl_shared_send(BIO *b, const char *in, int inl);
+static int ngx_ssl_shared_recv(BIO *b, char *out, int outl);
+static long ngx_ssl_shared_ctrl(BIO *b, int cmd, long num, void *ptr);
+static int ngx_ssl_generate_cookie(SSL *ssl, unsigned char *cookie,
+    unsigned int *cookie_len);
+static int ngx_ssl_verify_cookie(SSL *ssl, const unsigned char *cookie,
+    unsigned int cookie_len);
+#endif
 
 static void *ngx_openssl_create_conf(ngx_cycle_t *cycle);
 static char *ngx_openssl_engine(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
@@ -276,7 +293,18 @@ ngx_ssl_init(ngx_log_t *log)
 ngx_int_t
 ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
 {
-    ssl->ctx = SSL_CTX_new(SSLv23_method());
+    const SSL_METHOD  *method;
+
+#if (NGX_SSL_DTLS)
+    if (ssl->udp) {
+        method = DTLS_method();
+    } else
+#endif
+    {
+        method = SSLv23_method();
+    }
+
+    ssl->ctx = SSL_CTX_new(method);
 
     if (ssl->ctx == NULL) {
         ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0, "SSL_CTX_new() failed");
@@ -409,6 +437,11 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
     SSL_CTX_set_read_ahead(ssl->ctx, 1);
 
     SSL_CTX_set_info_callback(ssl->ctx, ngx_ssl_info_callback);
+
+#if (NGX_SSL_DTLS)
+    SSL_CTX_set_cookie_generate_cb(ssl->ctx, ngx_ssl_generate_cookie);
+    SSL_CTX_set_cookie_verify_cb(ssl->ctx, ngx_ssl_verify_cookie);
+#endif
 
     return NGX_OK;
 }
@@ -1615,6 +1648,28 @@ ngx_ssl_create_connection(ngx_ssl_t *ssl, ngx_connection_t *c, ngx_uint_t flags)
         return NGX_ERROR;
     }
 
+#if (NGX_SSL_DTLS)
+    if (c->shared) {
+        BIO                 *bio;
+        ngx_openssl_conf_t  *oscf;
+
+        sc->try_listen = 1;
+
+        oscf = (ngx_openssl_conf_t *) ngx_get_conf(ngx_cycle->conf_ctx,
+                                                   ngx_openssl_module);
+
+        bio = BIO_new(oscf->method);
+        if (bio == NULL) {
+            return NGX_ERROR;
+        }
+
+        BIO_set_app_data(bio, c);
+        BIO_set_init(bio, 1);
+
+        SSL_set_bio(sc->connection, bio, bio);
+
+    } else
+#endif
     if (SSL_set_fd(sc->connection, c->fd) == 0) {
         ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "SSL_set_fd() failed");
         return NGX_ERROR;
@@ -1687,6 +1742,12 @@ ngx_ssl_handshake(ngx_connection_t *c)
     int        n, sslerr;
     ngx_err_t  err;
     ngx_int_t  rc;
+
+#if (NGX_SSL_DTLS)
+    if (c->ssl->try_listen) {
+        return ngx_ssl_try_listen(c);
+    }
+#endif
 
 #ifdef SSL_READ_EARLY_DATA_SUCCESS
     if (c->ssl->try_early_data) {
@@ -5868,6 +5929,227 @@ ngx_ssl_parse_time(
 }
 
 
+#if (NGX_SSL_DTLS)
+
+static ngx_int_t
+ngx_ssl_try_listen(ngx_connection_t *c)
+{
+    int                      n, sslerr;
+    BIO                     *rbio;
+    ngx_err_t                err;
+#ifdef LIBRESSL_VERSION_NUMBER
+    static ngx_sockaddr_t    speer;
+    static struct sockaddr  *peer;
+#else
+    static BIO_ADDR         *peer;
+#endif
+
+    if (peer == NULL) {
+#ifdef LIBRESSL_VERSION_NUMBER
+        peer = &speer.sockaddr;
+#else
+        peer = BIO_ADDR_new();
+
+        if (peer == NULL) {
+            ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "BIO_ADDR_new() failed");
+            return NGX_ERROR;
+        }
+#endif
+    }
+
+    n = DTLSv1_listen(c->ssl->connection, peer);
+
+    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "DTLSv1_listen: %d", n);
+
+    if (n > 0) {
+        c->ssl->try_listen = 0;
+        return ngx_ssl_handshake(c);
+    }
+
+    if (n == 0) {
+        return NGX_ERROR;
+    }
+
+    /* n < 0 */
+
+    rbio = SSL_get_rbio(c->ssl->connection);
+    if (rbio && BIO_should_retry(rbio)) {
+        return NGX_ERROR;
+    }
+
+    sslerr = SSL_get_error(c->ssl->connection, n);
+
+    err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
+
+    c->read->error = 1;
+
+    ngx_ssl_connection_error(c, sslerr, err, "DTLSv1_listen() failed");
+
+    return NGX_ERROR;
+}
+
+
+static int
+ngx_ssl_shared_send(BIO *b, const char *in, int inl)
+{
+    ssize_t            n;
+    ngx_connection_t  *c;
+
+    c = BIO_get_app_data(b);
+
+    BIO_clear_retry_flags(b);
+
+    n = ngx_udp_send(c, (u_char *) in, inl);
+
+    if (n == NGX_ERROR) {
+        ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                       "ssl shared send failed");
+        return -1;
+    }
+
+    if (n == NGX_AGAIN) {
+        ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                       "ssl shared send not ready");
+        BIO_set_retry_write(b);
+        return -1;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "ssl shared send n:%z", n);
+
+    return n;
+}
+
+
+static int
+ngx_ssl_shared_recv(BIO *b, char *out, int outl)
+{
+    ssize_t            n;
+    ngx_buf_t         *bb;
+    ngx_connection_t  *c;
+
+    c = BIO_get_app_data(b);
+
+    n = 0;
+
+    if (out) {
+        BIO_clear_retry_flags(b);
+
+        bb = c->buffer;
+
+        if (bb && bb->pos != bb->last) {
+            /* TODO move to ngx_udp_shared_recv() */
+
+            n = ngx_min(outl, bb->last - bb->pos);
+            ngx_memcpy(out, bb->pos, n);
+            bb->pos = bb->last;
+
+            goto done;
+        }
+
+        n = ngx_udp_shared_recv(c, (u_char *) out, outl);
+
+        if (n == NGX_ERROR) {
+            ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                           "ssl shared recv failed");
+            return -1;
+        }
+
+        if (n == NGX_AGAIN) {
+            ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                           "ssl shared recv not ready");
+            BIO_set_retry_read(b);
+            return -1;
+        }
+    }
+
+done:
+
+    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "ssl shared recv n:%z", n);
+
+    return n;
+}
+
+
+static long
+ngx_ssl_shared_ctrl(BIO *b, int cmd, long num, void *ptr)
+{
+    long               ret;
+#if (NGX_DEBUG)
+    ngx_connection_t  *c;
+
+    c = BIO_get_app_data(b);
+
+    ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "ssl shared ctrl c:%d n:%l", cmd, num);
+#endif
+
+    switch (cmd) {
+    case BIO_CTRL_DGRAM_QUERY_MTU:
+    case BIO_CTRL_DGRAM_GET_MTU:
+    case BIO_CTRL_DGRAM_GET_FALLBACK_MTU:
+        /* TODO MTU discovery */
+        ret = 1200;
+        break;
+    case BIO_CTRL_FLUSH:
+        ret = 1;
+        break;
+    default:
+        ret = 0;
+        break;
+    }
+
+    return ret;
+}
+
+
+static int
+ngx_ssl_generate_cookie(SSL *ssl, unsigned char *cookie,
+    unsigned int *cookie_len)
+{
+    ngx_connection_t    *c;
+    ngx_openssl_conf_t  *oscf;
+
+    c = ngx_ssl_get_connection(ssl);
+
+    oscf = (ngx_openssl_conf_t *) ngx_get_conf(ngx_cycle->conf_ctx,
+                                               ngx_openssl_module);
+
+    /* SHA256_DIGEST_LENGTH <= DTLS1_COOKIE_LENGTH */
+
+    if (HMAC(EVP_sha256(), oscf->cookie_secret, NGX_SSL_COOKIE_SECRET_LENGTH,
+             (u_char *) c->sockaddr, c->socklen, cookie, cookie_len)
+        == NULL)
+    {
+        return 0;
+    }
+
+    return 1;
+}
+
+
+static int
+ngx_ssl_verify_cookie(SSL *ssl, const unsigned char *cookie,
+    unsigned int cookie_len)
+{
+    unsigned int  ocookie_len;
+    u_char        ocookie[DTLS1_COOKIE_LENGTH];
+
+    if (ngx_ssl_generate_cookie(ssl, ocookie, &ocookie_len) == 0) {
+        return 0;
+    }
+
+    if (cookie_len != ocookie_len
+        || ngx_memcmp(cookie, ocookie, cookie_len) != 0)
+    {
+        return 0;
+    }
+
+    return 1;
+}
+
+#endif
+
+
 static void *
 ngx_openssl_create_conf(ngx_cycle_t *cycle)
 {
@@ -5883,6 +6165,23 @@ ngx_openssl_create_conf(ngx_cycle_t *cycle)
      *
      *     oscf->engine = 0;
      */
+
+#if (NGX_SSL_DTLS)
+
+    if (!RAND_bytes(oscf->cookie_secret, NGX_SSL_COOKIE_SECRET_LENGTH)) {
+        return NULL;
+    }
+
+    oscf->method = BIO_meth_new(BIO_TYPE_DGRAM, "nginx dgram wrapper");
+    if (oscf->method == NULL) {
+        return NULL;
+    }
+
+    BIO_meth_set_write(oscf->method, ngx_ssl_shared_send);
+    BIO_meth_set_read(oscf->method, ngx_ssl_shared_recv);
+    BIO_meth_set_ctrl(oscf->method, ngx_ssl_shared_ctrl);
+
+#endif
 
     return oscf;
 }

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -63,6 +63,10 @@
 
 #endif
 
+#if (!defined OPENSSL_IS_BORINGSSL && !defined OPENSSL_NO_DTLS  \
+     && !NGX_WIN32 && OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#define NGX_SSL_DTLS            1
+#endif
 
 #define ngx_ssl_session_t       SSL_SESSION
 #define ngx_ssl_conn_t          SSL
@@ -95,6 +99,10 @@ struct ngx_ssl_s {
 
     ngx_rbtree_t                staple_rbtree;
     ngx_rbtree_node_t           staple_sentinel;
+
+#if (NGX_SSL_DTLS)
+    ngx_uint_t                  udp; /* unsigned  udp:1; */
+#endif
 };
 
 
@@ -128,6 +136,7 @@ struct ngx_ssl_connection_s {
     unsigned                    shutdown_without_free:1;
     unsigned                    handshake_buffer_set:1;
     unsigned                    session_timeout_set:1;
+    unsigned                    try_listen:1;
     unsigned                    try_early_data:1;
     unsigned                    in_early:1;
     unsigned                    in_ocsp:1;

--- a/src/event/ngx_event_openssl_cache.c
+++ b/src/event/ngx_event_openssl_cache.c
@@ -199,6 +199,10 @@ static ngx_int_t
 ngx_ssl_cache_init_key(ngx_pool_t *pool, ngx_uint_t index, ngx_str_t *path,
     ngx_ssl_cache_key_t *id)
 {
+    ngx_str_t  file;
+
+    file = *path;
+
     if (index <= NGX_SSL_CACHE_PKEY
         && ngx_strncmp(path->data, "data:", sizeof("data:") - 1) == 0)
     {
@@ -210,7 +214,8 @@ ngx_ssl_cache_init_key(ngx_pool_t *pool, ngx_uint_t index, ngx_str_t *path,
         id->type = NGX_SSL_CACHE_ENGINE;
 
     } else {
-        if (ngx_get_full_name(pool, (ngx_str_t *) &ngx_cycle->conf_prefix, path)
+        if (ngx_get_full_name(pool, (ngx_str_t *) &ngx_cycle->conf_prefix,
+                              &file)
             != NGX_OK)
         {
             return NGX_ERROR;
@@ -219,8 +224,8 @@ ngx_ssl_cache_init_key(ngx_pool_t *pool, ngx_uint_t index, ngx_str_t *path,
         id->type = NGX_SSL_CACHE_PATH;
     }
 
-    id->len = path->len;
-    id->data = path->data;
+    id->len = file.len;
+    id->data = file.data;
 
     return NGX_OK;
 }

--- a/src/event/ngx_event_udp.c
+++ b/src/event/ngx_event_udp.c
@@ -13,8 +13,6 @@
 #if !(NGX_WIN32)
 
 static void ngx_close_accepted_udp_connection(ngx_connection_t *c);
-static ssize_t ngx_udp_shared_recv(ngx_connection_t *c, u_char *buf,
-    size_t size);
 static ngx_int_t ngx_insert_udp_connection(ngx_connection_t *c);
 static ngx_connection_t *ngx_lookup_udp_connection(ngx_listening_t *ls,
     struct sockaddr *sockaddr, socklen_t socklen,
@@ -365,7 +363,7 @@ ngx_close_accepted_udp_connection(ngx_connection_t *c)
 }
 
 
-static ssize_t
+ssize_t
 ngx_udp_shared_recv(ngx_connection_t *c, u_char *buf, size_t size)
 {
     ssize_t     n;

--- a/src/event/ngx_event_udp.h
+++ b/src/event/ngx_event_udp.h
@@ -56,6 +56,7 @@ ngx_int_t ngx_get_srcaddr_cmsg(struct cmsghdr *cmsg,
 
 void ngx_event_recvmsg(ngx_event_t *ev);
 ssize_t ngx_sendmsg(ngx_connection_t *c, struct msghdr *msg, int flags);
+ssize_t ngx_udp_shared_recv(ngx_connection_t *c, u_char *buf, size_t size);
 void ngx_udp_rbtree_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
 #endif

--- a/src/stream/ngx_stream_core_module.c
+++ b/src/stream/ngx_stream_core_module.c
@@ -1237,7 +1237,7 @@ ngx_stream_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
 #endif
 
-#if (NGX_STREAM_SSL)
+#if (NGX_STREAM_SSL && !NGX_SSL_DTLS)
         if (lsopt.ssl) {
             return "\"ssl\" parameter is incompatible with \"udp\"";
         }

--- a/src/stream/ngx_stream_ssl_module.h
+++ b/src/stream/ngx_stream_ssl_module.h
@@ -21,6 +21,9 @@ typedef struct {
     ngx_flag_t       reject_handshake;
 
     ngx_ssl_t        ssl;
+#if (NGX_SSL_DTLS)
+    ngx_ssl_t        ssl_udp;
+#endif
 
     ngx_uint_t       protocols;
 


### PR DESCRIPTION
This is a proof-of-concept for DTLS (Datagram Transport Layer Security) in nginx.

Based on previous work by Vladimir Homutov, which can be found here: https://nginx.org/patches/dtls/

Example:
````
stream {
    server {
        listen 9000 udp ssl; # DTLS
        listen 9000 ssl; # TLS

        ssl_certificate certs/example.com.crt;
        ssl_certificate_key certs/example.com.key;

        return "Hello, world!\n";
    }                                   

    server {
        listen 9001 udp;
        listen 9001;

        # TLS/DTLS proxy
        proxy_ssl on;
        proxy_pass 127.0.0.1:9000;
    }
}
````

Client:
```
$ openssl s_client -connect 127.0.0.1:9000 -dtls
...
Hello, world!

$ echo | nc -u 127.0.0.1 9001
Hello, world!
```
