### PR TITLE
Correct location for `libatomic_ops.a` when using `--with-libatomic=[dir]`

### DIFF
--- a/auto/lib/libatomic/conf
+++ b/auto/lib/libatomic/conf
@@ -7,8 +7,8 @@ if [ $NGX_LIBATOMIC != YES ]; then
 
     have=NGX_HAVE_LIBATOMIC . auto/have
     CORE_INCS="$CORE_INCS $NGX_LIBATOMIC/src"
-    LINK_DEPS="$LINK_DEPS $NGX_LIBATOMIC/src/libatomic_ops.a"
-    CORE_LIBS="$CORE_LIBS $NGX_LIBATOMIC/src/libatomic_ops.a"
+    LINK_DEPS="$LINK_DEPS $NGX_LIBATOMIC/src/.libs/libatomic_ops.a"
+    CORE_LIBS="$CORE_LIBS $NGX_LIBATOMIC/src/.libs/libatomic_ops.a"
 
 else
 

--- a/auto/lib/libatomic/make
+++ b/auto/lib/libatomic/make
@@ -5,7 +5,7 @@
 
     cat << END                                            >> $NGX_MAKEFILE
 
-$NGX_LIBATOMIC/src/libatomic_ops.a:	$NGX_LIBATOMIC/Makefile
+$NGX_LIBATOMIC/src/.libs/libatomic_ops.a:	$NGX_LIBATOMIC/Makefile
 	cd $NGX_LIBATOMIC && \$(MAKE)
 
 $NGX_LIBATOMIC/Makefile:	$NGX_MAKEFILE


### PR DESCRIPTION
### Proposed changes

Compiling Nginx with `--with-libatomic=[dir]` fails with an error. File `libatomic_ops.a` is not found at `$NGX_LIBATOMIC/src/libatomic_ops.a`.

The location of `libatomic_ops.a` reportedly changed in `libatomic_ops` v7.4.0, according to the library maintainer @ivmai - please refer to:

https://github.com/ivmai/libatomic_ops/issues/35#issuecomment-382466032

This PR changes the location of `libatomic_ops.a` to reflect the changes in `libatomic_ops`. An interim workaround is to symlink `$NGX_LIBATOMIC/src/libatomic_ops.a` to `$NGX_LIBATOMIC/src/.libs/libatomic_ops.a`