### PR TITLE
SSL: the $ssl_client_sha256_fingerprint variable

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5616,7 +5616,7 @@ ngx_ssl_get_serial_number(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 
 
 ngx_int_t
-ngx_ssl_get_fingerprint(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+ngx_ssl_get_fingerprint_with_digest(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s, const EVP_MD *digest)
 {
     X509          *cert;
     unsigned int   len;
@@ -5629,7 +5629,7 @@ ngx_ssl_get_fingerprint(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
         return NGX_OK;
     }
 
-    if (!X509_digest(cert, EVP_sha1(), buf, &len)) {
+    if (!X509_digest(cert, digest, buf, &len)) {
         ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "X509_digest() failed");
         X509_free(cert);
         return NGX_ERROR;
@@ -5647,6 +5647,20 @@ ngx_ssl_get_fingerprint(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
     X509_free(cert);
 
     return NGX_OK;
+}
+
+
+ngx_int_t
+ngx_ssl_get_fingerprint(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+{
+    return ngx_ssl_get_fingerprint_with_digest(c, pool, s, EVP_sha1());
+}
+
+
+ngx_int_t
+ngx_ssl_get_sha256_fingerprint(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+{
+    return ngx_ssl_get_fingerprint_with_digest(c, pool, s, EVP_sha256());
 }
 
 

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -320,7 +320,11 @@ ngx_int_t ngx_ssl_get_issuer_dn_legacy(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_serial_number(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
+ngx_int_t ngx_ssl_get_fingerprint_with_digest(ngx_connection_t *c, ngx_pool_t *pool,
+    ngx_str_t *s, const EVP_MD *digest);
 ngx_int_t ngx_ssl_get_fingerprint(ngx_connection_t *c, ngx_pool_t *pool,
+    ngx_str_t *s);
+ngx_int_t ngx_ssl_get_sha256_fingerprint(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_client_verify(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -387,6 +387,9 @@ static ngx_http_variable_t  ngx_http_ssl_vars[] = {
     { ngx_string("ssl_client_fingerprint"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_fingerprint, NGX_HTTP_VAR_CHANGEABLE, 0 },
 
+    { ngx_string("ssl_client_sha256_fingerprint"), NULL, ngx_http_ssl_variable,
+      (uintptr_t) ngx_ssl_get_sha256_fingerprint, NGX_HTTP_VAR_CHANGEABLE, 0 },
+
     { ngx_string("ssl_client_verify"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_client_verify, NGX_HTTP_VAR_CHANGEABLE, 0 },
 

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -376,6 +376,9 @@ static ngx_stream_variable_t  ngx_stream_ssl_vars[] = {
     { ngx_string("ssl_client_fingerprint"), NULL, ngx_stream_ssl_variable,
       (uintptr_t) ngx_ssl_get_fingerprint, NGX_STREAM_VAR_CHANGEABLE, 0 },
 
+    { ngx_string("ssl_client_sha256_fingerprint"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_sha256_fingerprint, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
     { ngx_string("ssl_client_verify"), NULL, ngx_stream_ssl_variable,
       (uintptr_t) ngx_ssl_get_client_verify, NGX_STREAM_VAR_CHANGEABLE, 0 },
 


### PR DESCRIPTION
Just like $ssl_client_fingerprint but SHA256 instead of SHA1

SHA1 is insecure and its use should be discouraged, see:

https://sha-mbles.github.io/
https://shattered.io/
