### PR TITLE
Upstream: remove redundant lock in least_conn.

### DIFF
--- a/src/http/modules/ngx_http_upstream_least_conn_module.c
+++ b/src/http/modules/ngx_http_upstream_least_conn_module.c
@@ -103,7 +103,7 @@ ngx_http_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
 
     time_t                         now;
     uintptr_t                      m;
-    ngx_int_t                      rc, total;
+    ngx_int_t                      total;
     ngx_uint_t                     i, n, p, many;
     ngx_http_upstream_rr_peer_t   *peer, *best;
     ngx_http_upstream_rr_peers_t  *peers;
@@ -278,13 +278,7 @@ failed:
 
         ngx_http_upstream_rr_peers_unlock(peers);
 
-        rc = ngx_http_upstream_get_least_conn_peer(pc, rrp);
-
-        if (rc != NGX_BUSY) {
-            return rc;
-        }
-
-        ngx_http_upstream_rr_peers_wlock(peers);
+        return ngx_http_upstream_get_least_conn_peer(pc, rrp);
     }
 
 #if (NGX_HTTP_UPSTREAM_ZONE)

--- a/src/stream/ngx_stream_upstream_least_conn_module.c
+++ b/src/stream/ngx_stream_upstream_least_conn_module.c
@@ -100,7 +100,7 @@ ngx_stream_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
 
     time_t                           now;
     uintptr_t                        m;
-    ngx_int_t                        rc, total;
+    ngx_int_t                        total;
     ngx_uint_t                       i, n, p, many;
     ngx_stream_upstream_rr_peer_t   *peer, *best;
     ngx_stream_upstream_rr_peers_t  *peers;
@@ -274,13 +274,7 @@ failed:
 
         ngx_stream_upstream_rr_peers_unlock(peers);
 
-        rc = ngx_stream_upstream_get_least_conn_peer(pc, rrp);
-
-        if (rc != NGX_BUSY) {
-            return rc;
-        }
-
-        ngx_stream_upstream_rr_peers_wlock(peers);
+        return ngx_stream_upstream_get_least_conn_peer(pc, rrp);
     }
 
 #if (NGX_STREAM_UPSTREAM_ZONE)


### PR DESCRIPTION
The recursive call to `ngx_*_upstream_get_least_conn_peer` already sets the peer name on NGX_BUSY, so we can return immediately instead of locking the list of peers again.

As suggested by Roman in https://github.com/nginx/nginx/pull/208#discussion_r1813018164.