### PR TITLE
Misc: moved documentation in release tarballs.

### DIFF
--- a/misc/GNUmakefile
+++ b/misc/GNUmakefile
@@ -93,6 +93,9 @@ zip: export
 
 	mv $(TEMP)/$(NGINX)/LICENSE $(TEMP)/$(NGINX)/docs.new
 	mv $(TEMP)/$(NGINX)/README.md $(TEMP)/$(NGINX)/docs.new
+	mv $(TEMP)/$(NGINX)/CODE_OF_CONDUCT.md $(TEMP)/$(NGINX)/docs.new
+	mv $(TEMP)/$(NGINX)/CONTRIBUTING.md $(TEMP)/$(NGINX)/docs.new
+	mv $(TEMP)/$(NGINX)/SECURITY.md $(TEMP)/$(NGINX)/docs.new
 	mv $(TEMP)/$(NGINX)/docs/html $(TEMP)/$(NGINX)
 
 	rm -r $(TEMP)/$(NGINX)/docs


### PR DESCRIPTION
Switch to GitHub added unrelated files, which now pollutes the top-level archive directory.
This change moves them to the expected place, together with other files to be consistent across tarball and zip.
