### PR TITLE
Upstream: check format of CGI Status header

### DIFF
--- a/src/http/modules/ngx_http_fastcgi_module.c
+++ b/src/http/modules/ngx_http_fastcgi_module.c
@@ -2049,7 +2049,7 @@ ngx_http_fastcgi_process_header(ngx_http_request_t *r)
 
                     u->headers_in.status_n = status;
 
-                    if (status_line->len > 3) {
+                    if (status_line->len > 3 && status_line->data[3] == ' ') {
                         u->headers_in.status_line = *status_line;
                     }
 

--- a/src/http/modules/ngx_http_scgi_module.c
+++ b/src/http/modules/ngx_http_scgi_module.c
@@ -1154,7 +1154,7 @@ ngx_http_scgi_process_header(ngx_http_request_t *r)
 
                 u->headers_in.status_n = status;
 
-                if (status_line->len > 3) {
+                if (status_line->len > 3 && status_line->data[3] == ' ') {
                     u->headers_in.status_line = *status_line;
                 }
 

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -1382,7 +1382,7 @@ ngx_http_uwsgi_process_header(ngx_http_request_t *r)
 
                 u->headers_in.status_n = status;
 
-                if (status_line->len > 3) {
+                if (status_line->len > 3 && status_line->data[3] == ' ') {
                     u->headers_in.status_line = *status_line;
                 }
 


### PR DESCRIPTION
The CGI Status header is used as the HTTP status line if it has a reason-phrase: its length should be > 3.

This change validates that the 4th character is a space, the only allowed character in that position.

An addition to:
https://github.com/nginx/nginx/commit/fa46a5719924a5a4c48c515a903e0c46a4d98bcf

### Proposed changes

Use the CGI Status header as the HTTP status line if its length is greater than 3 and the 4th character is a space.

**Problem**
Nginx receives a Status header with an extra `:` (`status: 404: Not Found`) and uses as the HTTP status line. The HTTP response is invalid.

**How to reproduce**

Nginx configuration
```
events {
}

http {
    server {
        listen 8888;
        location / {
            fastcgi_param SCRIPT_FILENAME /var/www/html$fastcgi_script_name;
            fastcgi_pass 172.19.0.4:9000;
            include fastcgi_params;            
        }
    }
}
```

Test php script
```
<?php
header("status: 404: Not Found");
header("content-length: 2");
header("connection: close");
echo "a\n";
```

**Response before the change**

The status line is invalid as per the HTTP/1.1 spec.

```
$ curl localhost:8888/index.php -v
*   Trying 127.0.0.1:8888...
* Connected to localhost (127.0.0.1) port 8888 (#0)
> GET /index.php HTTP/1.1
> Host: localhost:8888
> User-Agent: curl/7.88.1
> Accept: */*           
>                     
< HTTP/1.1 404: Not Found            
< Server: nginx/1.27.4                  
< Date: Tue, 10 Dec 2024 10:22:37 GMT
< Content-Type: text/html; charset=UTF-8
< Content-Length: 2      
< Connection: keep-alive
< X-Powered-By: PHP/8.4.1
<                                            
a
```

**Response after the change**

The status line is valid and contains a reason-phrase generated by Nginx.

```
$ curl localhost:8888/index.php -v
*   Trying 127.0.0.1:8888...
* Connected to localhost (127.0.0.1) port 8888 (#0)
> GET /index.php HTTP/1.1
> Host: localhost:8888
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Server: nginx/1.27.4
< Date: Tue, 10 Dec 2024 10:42:48 GMT
< Content-Type: text/html; charset=UTF-8
< Content-Length: 2
< Connection: keep-alive
< X-Powered-By: PHP/8.4.1
< 
a
```





