### PR TITLE
MIME: add audio/x-wav type

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -83,6 +83,7 @@ types {
     audio/ogg                                        ogg;
     audio/x-m4a                                      m4a;
     audio/x-realaudio                                ra;
+    audio/x-wav                                      wav;
 
     video/3gpp                                       3gpp 3gp;
     video/mp2t                                       ts;


### PR DESCRIPTION
Hi! Would it be acceptable to use a more specific MIME type for `.wav` files? I have made a copy of `mime.types` and modified it in our setup, but thought it could benefit others as well.

Chrome and other browsers implementing Opaque Response Blocking block `<audio>` elements from playing if it cannot guess that the source is an audio file and the Content-Type header does not say it is that ([source][1]). This is currently the case for WAV files served by Nginx instances configured to use the included `mime.types` file. Chrome is unable to guess a file's type if the server responds with 206 Partial Content, which is typically the case for WAV files.

Unfortunately, there is no official MIME type for WAV files. I decided to go with `audio/x-wav` since it is used by [Apache HTTPD][2] and the [media-types Debian package][3].

[WAV files are supported][4] by browsers used by 98.01% of the world's population.

[1]: https://groups.google.com/a/chromium.org/g/blink-dev/c/ScjhKz3Z6U4/m/5i_0V7ogAwAJ
[2]: https://github.com/apache/httpd/blob/4a9cd1fccf8e79eda2132d65166af6e87e4f5fe9/docs/conf/mime.types#L1526
[3]: https://salsa.debian.org/debian/media-types/-/blob/8b715798bbebb7a43757a9845541ffa5ac113925/mime.types?page=2#L1845
[4]: https://caniuse.com/wav
