### PR TITLE
MIME: add audio/flac type

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -78,6 +78,7 @@ types {
     application/octet-stream                         iso img;
     application/octet-stream                         msi msp msm;
 
+    audio/flac                                       flac;
     audio/midi                                       mid midi kar;
     audio/mpeg                                       mp3;
     audio/ogg                                        ogg;


### PR DESCRIPTION
Hi again! Would it be acceptable to use a more specific MIME type for `.flac` files? I have made a copy of `mime.types` and modified it in our setup, but thought it could benefit others as well 🙂 

Chrome and other browsers implementing Opaque Response Blocking block `<audio>` elements from playing if it cannot guess it is an audio file and the Content-Type header does not say it is that ([source][1]). This is currently the case for FLAC files served by Nginx instances configured to use the included `mime.types` file. Chrome is unable to guess a file's type if the server responds with 206 Partial Content, which is typically the case for FLAC files.

The `audio/flac` MIME type is [officially registered by IANA][2]. FLAC files [are supported by browsers][3] used by 97.87% of the world's population.

[1]: https://groups.google.com/a/chromium.org/g/blink-dev/c/ScjhKz3Z6U4/m/5i_0V7ogAwAJ
[2]: https://www.iana.org/assignments/media-types/audio/flac
[3]: https://caniuse.com/flac