### PR TITLE
QUIC: fixed accessing deleted rbtree node when closing streams.

### DIFF
--- a/src/event/quic/ngx_event_quic.h
+++ b/src/event/quic/ngx_event_quic.h
@@ -108,6 +108,7 @@ struct ngx_quic_stream_s {
     ngx_quic_stream_recv_state_e   recv_state;
     unsigned                       cancelable:1;
     unsigned                       fin_acked:1;
+    unsigned                       destroyed:1;
 };
 
 


### PR DESCRIPTION
A decoder stream can be closed on error as part of closing request streams. Closes #369.
