### PR TITLE
Gzip: compatibility with recent zlib-ng 2.2.x versions.

### DIFF
--- a/src/http/modules/ngx_http_gzip_filter_module.c
+++ b/src/http/modules/ngx_http_gzip_filter_module.c
@@ -516,8 +516,10 @@ ngx_http_gzip_filter_memory(ngx_http_request_t *r, ngx_http_gzip_ctx_t *ctx)
         /*
          * Another zlib variant, https://github.com/zlib-ng/zlib-ng.
          * It used to force window bits to 13 for fast compression level,
-         * uses (64 + sizeof(void*)) additional space on all allocations
-         * for alignment, 16-byte padding in one of window-sized buffers,
+         * used (64 + sizeof(void*)) additional space on all allocations
+         * for alignment and 16-byte padding in one of window-sized buffers,
+         * uses a single allocation with up to 200 bytes for alignment and
+         * internal pointers, 5/4 times more memory for the pending buffer,
          * and 128K hash.
          */
 
@@ -526,7 +528,7 @@ ngx_http_gzip_filter_memory(ngx_http_request_t *r, ngx_http_gzip_ctx_t *ctx)
         }
 
         ctx->allocated = 8192 + 16 + (1 << (wbits + 2))
-                         + 131072 + (1 << (memlevel + 8))
+                         + 131072 + (5 << (memlevel + 6))
                          + 4 * (64 + sizeof(void*));
         ctx->zlib_ng = 1;
     }


### PR DESCRIPTION
It now uses 5/4 times more memory for the pending buffer.

Further, a single allocation is used, with up to 128 additional bytes for alignment.  Though, this fits into "8 * (64 + sizeof(void*))" alignment adjustment used for previous zlib-ng versions.  The comment was updated to reflect this.

Closes #263.