### PR TITLE
Updated security policy to clarify experimental features

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,8 +69,7 @@ limiting, or buffer size configurations, or applying changes is impractical.
 Availability issues excluded from the security release process:
 - Local file content or upstream response content resulting only in worker
 process termination.
-- Issues with experimental features which result only in worker process
-termination.
+- Issues with experimental features which result only in availability impact.
 
 ## Trusted Configurations and Misconfigurations
 


### PR DESCRIPTION
The original security policy language did not capture the scope as intended for experimental features and availability. This update corrects it.
