### PR TITLE
QUIC: ignore version negotiation packets.

### DIFF
--- a/src/event/quic/ngx_event_quic_transport.c
+++ b/src/event/quic/ngx_event_quic_transport.c
@@ -295,6 +295,11 @@ ngx_quic_parse_packet(ngx_quic_header_t *pkt)
         return NGX_ERROR;
     }
 
+    if (pkt->version == 0) {
+        /* version negotiation */
+        return NGX_ERROR;
+    }
+
     if (!ngx_quic_supported_version(pkt->version)) {
         return NGX_ABORT;
     }


### PR DESCRIPTION
Previously, such packets were treated as long header packets with unknown version 0, and a version negotiation packet was sent in response.  This could be used to set up an infinite traffic reflect loop with another nginx instance.

Now version negotiation packets are ignored.  This behavior fully compiles with RFC 9000.  Version negotiation packets are supposed to be sent by servers and handled by clients.

Fixes #412.