### PR TITLE
nginx as a Windows service

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -394,9 +394,9 @@ static ngx_int_t
 ngx_install_windows_service()
 {
     wchar_t *install_commandline = NULL;
-	wchar_t *i_opt_ptr = NULL;
-	SC_HANDLE ScManagerHandle = NULL;
-	SC_HANDLE NginxServiceHandle = NULL;
+    wchar_t *i_opt_ptr = NULL;
+    SC_HANDLE ScManagerHandle = NULL;
+    SC_HANDLE NginxServiceHandle = NULL;
 
     // Replace install commandline by service run commandline by
     // replacing the -i (install) option to a -w (windows service mode)
@@ -405,36 +405,36 @@ ngx_install_windows_service()
     i_opt_ptr[2] = 'w';
     printf("Installing NGINX service with commandline: %ls\n", install_commandline);
 
-	ScManagerHandle = OpenSCManagerW(NULL, NULL, SC_MANAGER_CONNECT | SC_MANAGER_CREATE_SERVICE);
-	if (ScManagerHandle == NULL) {
-		ngx_log_stderr(0, "OpenSCManagerW failed: errno == %d", ngx_errno);
-	}
+    ScManagerHandle = OpenSCManagerW(NULL, NULL, SC_MANAGER_CONNECT | SC_MANAGER_CREATE_SERVICE);
+    if (ScManagerHandle == NULL) {
+        ngx_log_stderr(0, "OpenSCManagerW failed: errno == %d", ngx_errno);
+    }
 
-	//"nginx" as service name is hardcoded is ngx_service : use a define ?
-	NginxServiceHandle = CreateServiceW(ScManagerHandle,
-											L"nginx",
-											L"Nginx server service",
-											SERVICE_ALL_ACCESS,
-											SERVICE_WIN32_OWN_PROCESS,
-											SERVICE_DEMAND_START, // Auto-start ? let user change it manually in windows interface ?
-											SERVICE_ERROR_NORMAL,
-											install_commandline,
-											NULL,
-											NULL,
-											NULL,
-											NULL, //L"NT AUTHORITY\\NetworkService", ?
-											NULL);
+    //"nginx" as service name is hardcoded is ngx_service : use a define ?
+    NginxServiceHandle = CreateServiceW(ScManagerHandle,
+                                            L"nginx",
+                                            L"Nginx server service",
+                                            SERVICE_ALL_ACCESS,
+                                            SERVICE_WIN32_OWN_PROCESS,
+                                            SERVICE_DEMAND_START, // Auto-start ? let user change it manually in windows interface ?
+                                            SERVICE_ERROR_NORMAL,
+                                            install_commandline,
+                                            NULL,
+                                            NULL,
+                                            NULL,
+                                            NULL, //L"NT AUTHORITY\\NetworkService", ?
+                                            NULL);
 
-	if (NginxServiceHandle == NULL) {
-		ngx_log_stderr(0, "CreateServiceW failed: errno == %d", ngx_errno);
-		CloseServiceHandle(ScManagerHandle);
-	} else {
-		printf("Service created !\n");
-	}
+    if (NginxServiceHandle == NULL) {
+        ngx_log_stderr(0, "CreateServiceW failed: errno == %d", ngx_errno);
+        CloseServiceHandle(ScManagerHandle);
+    } else {
+        printf("Service created !\n");
+    }
 
-	CloseServiceHandle(NginxServiceHandle);
-	CloseServiceHandle(ScManagerHandle);
-	return 0;
+    CloseServiceHandle(NginxServiceHandle);
+    CloseServiceHandle(ScManagerHandle);
+    return 0;
 }
 #endif
 
@@ -980,18 +980,18 @@ ngx_get_options(int argc, char *const *argv)
                 ngx_log_stderr(0, "invalid option: \"-s %s\"", ngx_signal);
                 return NGX_ERROR;
 
-			#ifdef NGX_WIN32
-			case 'i':
-				// TODO: remove this option if not a Windows build ?
-				ngx_install_windows_service();
-				exit(0); // Do something else ?
+            #ifdef NGX_WIN32
+            case 'i':
+                // TODO: remove this option if not a Windows build ?
+                ngx_install_windows_service();
+                exit(0); // Do something else ?
 
-			case 'w':
-				// Run as windows service
-				ngx_service = 1; // Error if other options (like -s) is provided ?
-				goto next;
+            case 'w':
+                // Run as windows service
+                ngx_service = 1; // Error if other options (like -s) is provided ?
+                goto next;
 
-			#endif
+            #endif
 
             default:
                 ngx_log_stderr(0, "invalid option: \"%c\"", *(p - 1));
@@ -1150,11 +1150,11 @@ ngx_process_options(ngx_cycle_t *cycle)
         cycle->log->log_level = NGX_LOG_INFO;
     }
 
-	#if NGX_WIN32
-	if (ngx_service) {
-		cycle->service = 1;
-	}
-	#endif
+    #if NGX_WIN32
+    if (ngx_service) {
+        cycle->service = 1;
+    }
+    #endif
 
     return NGX_OK;
 }

--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -980,18 +980,17 @@ ngx_get_options(int argc, char *const *argv)
                 ngx_log_stderr(0, "invalid option: \"-s %s\"", ngx_signal);
                 return NGX_ERROR;
 
-            #ifdef NGX_WIN32
+#ifdef NGX_WIN32
             case 'i':
-                // TODO: remove this option if not a Windows build ?
                 ngx_install_windows_service();
                 exit(0); // Do something else ?
 
             case 'w':
                 // Run as windows service
-                ngx_service = 1; // Error if other options (like -s) is provided ?
+                ngx_service = 1;
                 goto next;
 
-            #endif
+#endif
 
             default:
                 ngx_log_stderr(0, "invalid option: \"%c\"", *(p - 1));
@@ -1150,11 +1149,11 @@ ngx_process_options(ngx_cycle_t *cycle)
         cycle->log->log_level = NGX_LOG_INFO;
     }
 
-    #if NGX_WIN32
+#if NGX_WIN32
     if (ngx_service) {
         cycle->service = 1;
     }
-    #endif
+#endif
 
     return NGX_OK;
 }

--- a/src/core/ngx_cycle.c
+++ b/src/core/ngx_cycle.c
@@ -82,7 +82,7 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
     cycle->log = log;
     cycle->old_cycle = old_cycle;
 
-	cycle->service = old_cycle->service;
+    cycle->service = old_cycle->service;
 
     cycle->conf_prefix.len = old_cycle->conf_prefix.len;
     cycle->conf_prefix.data = ngx_pstrdup(pool, &old_cycle->conf_prefix);

--- a/src/core/ngx_cycle.c
+++ b/src/core/ngx_cycle.c
@@ -82,6 +82,8 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
     cycle->log = log;
     cycle->old_cycle = old_cycle;
 
+	cycle->service = old_cycle->service;
+
     cycle->conf_prefix.len = old_cycle->conf_prefix.len;
     cycle->conf_prefix.data = ngx_pstrdup(pool, &old_cycle->conf_prefix);
     if (cycle->conf_prefix.data == NULL) {

--- a/src/core/ngx_cycle.h
+++ b/src/core/ngx_cycle.h
@@ -83,7 +83,7 @@ struct ngx_cycle_s {
     ngx_str_t                 error_log;
     ngx_str_t                 lock_file;
     ngx_str_t                 hostname;
-    ngx_uint_t			      service;
+    ngx_uint_t                service;
 };
 
 

--- a/src/core/ngx_cycle.h
+++ b/src/core/ngx_cycle.h
@@ -83,6 +83,7 @@ struct ngx_cycle_s {
     ngx_str_t                 error_log;
     ngx_str_t                 lock_file;
     ngx_str_t                 hostname;
+    ngx_uint_t			      service;
 };
 
 

--- a/src/os/win32/ngx_process_cycle.c
+++ b/src/os/win32/ngx_process_cycle.c
@@ -26,7 +26,11 @@ static ngx_thread_value_t __stdcall ngx_worker_thread(void *data);
 static ngx_thread_value_t __stdcall ngx_cache_manager_thread(void *data);
 static void ngx_cache_manager_process_handler(void);
 static ngx_thread_value_t __stdcall ngx_cache_loader_thread(void *data);
+static ngx_thread_value_t __stdcall ngx_service_thread(void *data);
 
+/* TODO: ngx_service.h */
+
+ngx_int_t ngx_service(ngx_log_t *log);
 
 ngx_uint_t     ngx_process;
 ngx_uint_t     ngx_worker;
@@ -46,7 +50,7 @@ ngx_uint_t     ngx_exiting;
 HANDLE         ngx_master_process_event;
 char           ngx_master_process_event_name[NGX_PROCESS_SYNC_NAME];
 
-static HANDLE  ngx_stop_event;
+HANDLE  ngx_stop_event;
 static char    ngx_stop_event_name[NGX_PROCESS_SYNC_NAME];
 static HANDLE  ngx_quit_event;
 static char    ngx_quit_event_name[NGX_PROCESS_SYNC_NAME];
@@ -68,6 +72,7 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
     ngx_int_t   n;
     ngx_msec_t  timer;
     ngx_uint_t  live;
+    ngx_tid_t   servicetid;
     HANDLE      events[MAXIMUM_WAIT_OBJECTS];
 
     ngx_sprintf((u_char *) ngx_master_process_event_name,
@@ -115,6 +120,14 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
     events[3] = ngx_reload_event;
 
     ngx_close_listening_sockets(cycle);
+
+	if (cycle->service){
+        // Create only if this thread does not already exists ?
+		if (ngx_create_thread(&servicetid, ngx_service_thread, NULL, cycle->log) != 0) {
+            ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "Creating ngx_service_thread failed");
+			exit(2);
+		}
+	}
 
     if (ngx_start_worker_processes(cycle, NGX_PROCESS_RESPAWN) == 0) {
         exit(2);
@@ -754,7 +767,6 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, char *mevn)
     ngx_worker_process_exit(cycle);
 
 failed:
-
     exit(2);
 }
 
@@ -981,6 +993,11 @@ ngx_cache_loader_thread(void *data)
     return 0;
 }
 
+static ngx_thread_value_t __stdcall
+ngx_service_thread(void *data)
+{
+    return ngx_service((ngx_log_t*)data);
+}
 
 void
 ngx_single_process_cycle(ngx_cycle_t *cycle)

--- a/src/os/win32/ngx_process_cycle.c
+++ b/src/os/win32/ngx_process_cycle.c
@@ -121,13 +121,13 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
 
     ngx_close_listening_sockets(cycle);
 
-	if (cycle->service){
+    if (cycle->service){
         // Create only if this thread does not already exists ?
-		if (ngx_create_thread(&servicetid, ngx_service_thread, NULL, cycle->log) != 0) {
+        if (ngx_create_thread(&servicetid, ngx_service_thread, NULL, cycle->log) != 0) {
             ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "Creating ngx_service_thread failed");
-			exit(2);
-		}
-	}
+            exit(2);
+        }
+    }
 
     if (ngx_start_worker_processes(cycle, NGX_PROCESS_RESPAWN) == 0) {
         exit(2);

--- a/src/os/win32/ngx_service.c
+++ b/src/os/win32/ngx_service.c
@@ -153,5 +153,5 @@ service_handler(DWORD control, DWORD type, void *data, void *ctx)
     default:
         return ERROR_CALL_NOT_IMPLEMENTED;
     }
-    return 0;
+    return NO_ERROR;
 }

--- a/src/os/win32/ngx_service.c
+++ b/src/os/win32/ngx_service.c
@@ -4,131 +4,154 @@
  * Copyright (C) Nginx, Inc.
  */
 
-
+#include <ngx_config.h>
+#include <ngx_core.h>
 
 #define NGX_SERVICE_CONTROL_SHUTDOWN   128
 #define NGX_SERVICE_CONTROL_REOPEN     129
+HANDLE  ngx_stop_event; // Defined in src\os\win32\ngx_process_cycle.c
 
+/*
+void LpserviceMainFunctiona(
+  [in] DWORD dwNumServicesArgs,
+  [in] LPSTR *lpServiceArgVectors
+)
+*/
+void WINAPI service_main(DWORD dwNumServicesArgs, LPSTR *lpServiceArgVectors);
 
-SERVICE_TABLE_ENTRY st[] = {
-    { "nginx", service_main },
+/*
+
+DWORD LphandlerFunctionEx(
+  [in] DWORD dwControl,
+  [in] DWORD dwEventType,
+  [in] LPVOID lpEventData,
+  [in] LPVOID lpContext
+)
+
+*/
+DWORD WINAPI service_handler(DWORD control, DWORD  type, void *data, void *ctx);
+
+SERVICE_STATUS_HANDLE  service = 0; // Put this field in ngx_cycle ?
+
+SERVICE_TABLE_ENTRY service_table[] = {
+    { "nginx", service_main},
     { NULL, NULL }
 };
 
 
 ngx_int_t
-ngx_service(ngx_log_t *log)
+ngx_service()
 {
     /* primary thread */
-
     /* StartServiceCtrlDispatcher() should be called within 30 seconds */
 
-    if (StartServiceCtrlDispatcher(st) == 0) {
-        ngx_log_error(NGX_LOG_EMERG, log, ngx_errno,
+    if (StartServiceCtrlDispatcher(service_table) == 0) {
+        ngx_log_error(NGX_LOG_EMERG, ngx_cycle->log, ngx_errno,
                       "StartServiceCtrlDispatcher() failed");
         return NGX_ERROR;
     }
-
     return NGX_OK;
 }
 
 
-void
-service_main(u_int argc, char **argv)
+void WINAPI
+service_main(DWORD dwNumServicesArgs, LPSTR *lpServiceArgVectors)
 {
     SERVICE_STATUS         status;
-    SERVICE_STATUS_HANDLE  service;
 
     /* thread spawned by SCM */
-
-    service = RegisterServiceCtrlHandlerEx("nginx", service_handler, ctx);
+    service = RegisterServiceCtrlHandlerEx("nginx", service_handler, NULL);
     if (service == INVALID_HANDLE_VALUE) {
-        ngx_log_error(NGX_LOG_EMERG, log, ngx_errno,
+        ngx_log_error(NGX_LOG_EMERG, ngx_cycle->log, ngx_errno,
                       "RegisterServiceCtrlHandlerEx() failed");
         return;
     }
 
+    /* Use a more generic report_service_status ? */
     status.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
     status.dwCurrentState = SERVICE_START_PENDING;
-    status.dwControlsAccepted = SERVICE_ACCEPT_STOP
-                                |SERVICE_ACCEPT_PARAMCHANGE;
+    status.dwControlsAccepted = SERVICE_ACCEPT_STOP;
     status.dwWin32ExitCode = NO_ERROR;
     status.dwServiceSpecificExitCode = 0;
     status.dwCheckPoint = 1;
     status.dwWaitHint = 2000;
 
     /* SetServiceStatus() should be called within 80 seconds */
-
     if (SetServiceStatus(service, &status) == 0) {
-        ngx_log_error(NGX_LOG_EMERG, log, ngx_errno,
+        ngx_log_error(NGX_LOG_EMERG, ngx_cycle->log, ngx_errno,
                       "SetServiceStatus() failed");
         return;
     }
 
     /* init */
+    // Do we have any init to wait for ?
+    // Init seems preety well advanced when the service thread is created
 
     status.dwCurrentState = SERVICE_RUNNING;
     status.dwCheckPoint = 0;
     status.dwWaitHint = 0;
 
     if (SetServiceStatus(service, &status) == 0) {
-        ngx_log_error(NGX_LOG_EMERG, log, ngx_errno,
+        ngx_log_error(NGX_LOG_EMERG, ngx_cycle->log, ngx_errno,
                       "SetServiceStatus() failed");
         return;
     }
 
-    /* call master or worker loop */
+}
 
-    /*
-     * master should use event notification and look status
-     * single should use iocp to get notifications from service handler
-     */
+int report_service_stop_status(DWORD dwCurrentState)
+{
+	SERVICE_STATUS         status;
 
+    status.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
+    status.dwCurrentState = dwCurrentState;
+    status.dwControlsAccepted = 0;
+    status.dwWin32ExitCode = NO_ERROR;
+    status.dwServiceSpecificExitCode = 0;
+    status.dwCheckPoint = 0;
+    status.dwWaitHint = 0;
+
+    /* SetServiceStatus() should be called within 80 seconds */
+    if (SetServiceStatus(service, &status) == 0) {
+        return 1;
+    }
+    return 0;
 }
 
 
-u_int
-service_handler(u_int control, u_int type, void *data, void *ctx)
+
+DWORD WINAPI
+service_handler(DWORD control, DWORD type, void *data, void *ctx)
 {
-    /* primary thread */
+     switch (control) {
 
-    switch (control) {
-
-    case SERVICE_CONTROL_INTERROGATE:
-        status = NGX_IOCP_INTERROGATE;
-        break;
-
+    // case SERVICE_CONTROL_INTERROGATE:
+    //     status = NGX_IOCP_INTERROGATE;
+    //     break;
+	//
     case SERVICE_CONTROL_STOP:
-        status = NGX_IOCP_STOP;
+		report_service_stop_status(SERVICE_STOP_PENDING);
+		if (SetEvent(ngx_stop_event) == 0) {
+            ngx_log_error(NGX_LOG_EMERG, ngx_cycle->log, ngx_errno,
+                      "SetEvent(ngx_stop_event) failed");
+		}
+		report_service_stop_status(SERVICE_STOPPED);
         break;
-
-    case SERVICE_CONTROL_PARAMCHANGE:
-        status = NGX_IOCP_RECONFIGURE;
-        break;
-
-    case NGX_SERVICE_CONTROL_SHUTDOWN:
-        status = NGX_IOCP_REOPEN;
-        break;
-
-    case NGX_SERVICE_CONTROL_REOPEN:
-        status = NGX_IOCP_REOPEN;
-        break;
+	//
+    // case SERVICE_CONTROL_PARAMCHANGE:
+    //     status = NGX_IOCP_RECONFIGURE;
+    //     break;
+	//
+    // case NGX_SERVICE_CONTROL_SHUTDOWN:
+    //     status = NGX_IOCP_REOPEN;
+    //     break;
+	//
+    // case NGX_SERVICE_CONTROL_REOPEN:
+    //     status = NGX_IOCP_REOPEN;
+    //     break;
 
     default:
         return ERROR_CALL_NOT_IMPLEMENTED;
     }
-
-    if (ngx_single) {
-        if (PostQueuedCompletionStatus(iocp, ... status, ...) == 0) {
-            err = ngx_errno;
-            ngx_log_error(NGX_LOG_ALERT, log, err,
-                          "PostQueuedCompletionStatus() failed");
-            return err;
-        }
-
-    } else {
-        Event
-    }
-
-    return NO_ERROR;
+	return 0;
 }

--- a/src/os/win32/ngx_service.c
+++ b/src/os/win32/ngx_service.c
@@ -101,7 +101,7 @@ service_main(DWORD dwNumServicesArgs, LPSTR *lpServiceArgVectors)
 
 int report_service_stop_status(DWORD dwCurrentState)
 {
-	SERVICE_STATUS         status;
+    SERVICE_STATUS         status;
 
     status.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
     status.dwCurrentState = dwCurrentState;
@@ -128,24 +128,24 @@ service_handler(DWORD control, DWORD type, void *data, void *ctx)
     // case SERVICE_CONTROL_INTERROGATE:
     //     status = NGX_IOCP_INTERROGATE;
     //     break;
-	//
+    //
     case SERVICE_CONTROL_STOP:
-		report_service_stop_status(SERVICE_STOP_PENDING);
-		if (SetEvent(ngx_stop_event) == 0) {
+        report_service_stop_status(SERVICE_STOP_PENDING);
+        if (SetEvent(ngx_stop_event) == 0) {
             ngx_log_error(NGX_LOG_EMERG, ngx_cycle->log, ngx_errno,
                       "SetEvent(ngx_stop_event) failed");
-		}
-		report_service_stop_status(SERVICE_STOPPED);
+        }
+        report_service_stop_status(SERVICE_STOPPED);
         break;
-	//
+    //
     // case SERVICE_CONTROL_PARAMCHANGE:
     //     status = NGX_IOCP_RECONFIGURE;
     //     break;
-	//
+    //
     // case NGX_SERVICE_CONTROL_SHUTDOWN:
     //     status = NGX_IOCP_REOPEN;
     //     break;
-	//
+    //
     // case NGX_SERVICE_CONTROL_REOPEN:
     //     status = NGX_IOCP_REOPEN;
     //     break;
@@ -153,5 +153,5 @@ service_handler(DWORD control, DWORD type, void *data, void *ctx)
     default:
         return ERROR_CALL_NOT_IMPLEMENTED;
     }
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
### Proposed changes

This PR is a draft about allowing nginx to register and act as a Windows service.
This is a feature I have seen requested multiple time and present in the "Possible future enhancements" of https://nginx.org/en/docs/windows.html. A skeleton of this feature is already present in master: https://github.com/nginx/nginx/blob/master/src/os/win32/ngx_service.c

Having nginx acting as a service would allow simpler start at boot and restart in case of failure, the current state of the art seems to use "the Non-Sucking Service Manager" (NSSM) to achieve this goal.

As this feature may be implemented by different methods, I wanted to have a POC to start the discussions and further highlight the problems that it raises. The simple POC allows registering nginx as a service, start and stop it via the service manager.

#### Reminder on Windows Service

On Windows, services are registered in the Service Control Manager (SCM) which starts, stops and interacts with Windows service processes. The SCM is "services.exe".
When a process is started as a service, it must call `StartServiceCtrlDispatcher`.
As the MSDN says (https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-startservicectrldispatchera#remarks):

```
The main thread of a service process should make this call as soon as possible after it starts up (within 30 seconds). 
If StartServiceCtrlDispatcher succeeds, it connects the calling thread to the service control
manager and does not return until all running services in the process have entered the SERVICE_STOPPED state.

The service control manager uses this connection to send control and service start requests to the main thread of
the service process. 
The main thread acts as a dispatcher by invoking the appropriate `ServiceCtrlHandler` function
to handle control requests, or by creating a new thread to execute the appropriate ServiceMain
function when a new service is started.
```

This method allows for registering a `ServiceMain` method that will be called. This method then must call `RegisterServiceCtrlHandlerEx` that will allow registering a `ServiceCtrlHandler` function. This handle function will be called by the SCM to communicate with the service, to send `SERVICE_CONTROL_STOP` control, for example.

This means that a dedicated thread must exist for the service thread: the thread calling `StartServiceCtrlDispatcher`.

#### The draft

This simple POC allow registering nginx as a service, start and stop it via the service manager.

The first choice to do is: "How does nginx knows it is started as a service".
The draft use a new command line option `-w` to do so. Another possibility is to check if our parents is `services.exe`.

When started as a service, the information will be stored in the `ngx_cycle_t` as `cycle->service`.
I chose to create a dedicated service thread in `ngx_master_process_cycle`, just before starting the worker processes, I do not know if there should be a better place. Another choice may be to have the main thread call `StartServiceCtrlDispatcher` and the `ServiceMain` method does all the nginx initialization. IMO this would require some profound change to the architecture at the start of the process but this is a possibility.

The dedicated service thread just register the `ServiceCtrlHandler` and update the state of the service to  `SERVICE_START_PENDING` then, `SERVICE_RUNNING`. We may wait for an event between these two actions if there is a way in nginx to known when initialization is done.
In the draft, the call to `StartServiceCtrlDispatcher` seems far enough in the initialization process to works as it is.

The `ServiceCtrlHandler` only listen to `SERVICE_CONTROL_STOP` and act on it by a `SetEvent(ngx_stop_event)` and report the service as stopped.

Lastly, i also added a `-i` options that allow registering nginx as a service.
This works by using the command line passed, replace `-i` by `-w` and call `CreateServiceW`.
This allows us to create a service with custom commandline parameters, Ex:

`C:\nginx\objs\nginx.exe\nginx.exe -i -p C:\nginx\objs\` will allow to register the service as `"C:\nginx\objs\nginx.exe" -w -p C:\nginx\objs\`.

#### Open questions

This draft raises many questions about the choices that must be made to integrate the Windows Service architecture

- How does nginx know it is started as a service ?
    - Commandline arguments (currently `-w`)
    - Check if our parent is `services.exe`
    - Other ?
- Which thread calls `StartServiceCtrlDispatcher` ?
    - A dedicated thread created in the master process ?
        - Is `ngx_master_process_cycle` the good place to do so ?
        - How do we prevent a second thread creation on a reload ?
    - The starting thread ?
        - Then, we must change the start code to do its initialization in a `ServiceMain` function.
- Which information does the service thread can retrieve from the master process ?
    - When initialization is finished ?
    - When the process is about to close (for `SetEvent(ngx_stop_event)` from a `SERVICE_CONTROL_STOP`)


## Other details

I tested and compiled it on a Windows 11 (NT-10.0-22621).
Run POC:

```
PS C:\nginx> .\objs\nginx.exe -i -p C:\nginx\objs\
Installing NGINX service with commandline: "C:\nginx\objs\nginx.exe" -w -p C:\nginx\objs\
Service created !
PS C:\nginx> sc.exe query nginx

SERVICE_NAME: nginx
        TYPE               : 10  WIN32_OWN_PROCESS
        STATE              : 1  STOPPED
        WIN32_EXIT_CODE    : 1077  (0x435)
        SERVICE_EXIT_CODE  : 0  (0x0)
        CHECKPOINT         : 0x0
        WAIT_HINT          : 0x0
PS C:\nginx> sc.exe start nginx

SERVICE_NAME: nginx
        TYPE               : 10  WIN32_OWN_PROCESS
        STATE              : 4  RUNNING
                                (STOPPABLE, NOT_PAUSABLE, IGNORES_SHUTDOWN)
        WIN32_EXIT_CODE    : 0  (0x0)
        SERVICE_EXIT_CODE  : 0  (0x0)
        CHECKPOINT         : 0x0
        WAIT_HINT          : 0x0
        PID                : 10584
        FLAGS              :
PS C:\nginx> ps -Name nginx

Handles  NPM(K)    PM(K)      WS(K)     CPU(s)     Id  SI ProcessName
-------  ------    -----      -----     ------     --  -- -----------
    166      13     2052       7916       0.00   1732   0 nginx
    166      11     1636       7732       0.02  10584   0 nginx


PS C:\nginx> sc.exe stop nginx

SERVICE_NAME: nginx
        TYPE               : 10  WIN32_OWN_PROCESS
        STATE              : 1  STOPPED
        WIN32_EXIT_CODE    : 0  (0x0)
        SERVICE_EXIT_CODE  : 0  (0x0)
        CHECKPOINT         : 0x0
        WAIT_HINT          : 0x0
PS C:\nginx> ps -Name nginx
ps : Cannot find a process with the name "nginx". Verify the process name and call the cmdlet again.
At line:1 char:1
+ ps -Name nginx
+ ~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (nginx:String) [Get-Process], ProcessCommandException
    + FullyQualifiedErrorId : NoProcessFoundForGivenName,Microsoft.PowerShell.Commands.GetProcessCommand
```



As it's my first attempt to contribute to nginx I am also , I am obviously open about any feedback concerning the code, the interest to add this feature and the best way to do so.

I hope this PR will be the first step to make nginx a working service on Windows !

Thank you,
