### PR TITLE
SSL: support loading keys via OSSL_STORE.

### DIFF
--- a/src/event/ngx_event_openssl_cache.c
+++ b/src/event/ngx_event_openssl_cache.c
@@ -8,10 +8,16 @@
 #include <ngx_core.h>
 #include <ngx_event.h>
 
+#ifdef ERR_R_OSSL_STORE_LIB
+#include <openssl/store.h>
+#include <openssl/ui.h>
+#endif
+
 
 #define NGX_SSL_CACHE_PATH    0
 #define NGX_SSL_CACHE_DATA    1
 #define NGX_SSL_CACHE_ENGINE  2
+#define NGX_SSL_CACHE_STORE   3
 
 #define NGX_SSL_CACHE_DISABLED  (ngx_array_t *) (uintptr_t) -1
 
@@ -444,6 +450,11 @@ ngx_ssl_cache_init_key(ngx_pool_t *pool, ngx_uint_t index, ngx_str_t *path,
     {
         id->type = NGX_SSL_CACHE_ENGINE;
 
+    } else if (index == NGX_SSL_CACHE_PKEY
+        && ngx_strncmp(path->data, "store:", sizeof("store:") - 1) == 0)
+    {
+        id->type = NGX_SSL_CACHE_STORE;
+
     } else {
         if (ngx_get_full_name(pool, (ngx_str_t *) &ngx_cycle->conf_prefix, path)
             != NGX_OK)
@@ -714,11 +725,6 @@ ngx_ssl_cache_pkey_create(ngx_ssl_cache_key_t *id, char **err, void *data)
 #endif
     }
 
-    bio = ngx_ssl_cache_create_bio(id, err);
-    if (bio == NULL) {
-        return NULL;
-    }
-
     cb_data.encrypted = 0;
 
     if (*passwords) {
@@ -732,6 +738,76 @@ ngx_ssl_cache_pkey_create(ngx_ssl_cache_key_t *id, char **err, void *data)
         tries = 1;
         pwd = NULL;
         cb = NULL;
+    }
+
+    if (id->type == NGX_SSL_CACHE_STORE) {
+
+#ifdef ERR_R_OSSL_STORE_LIB
+
+        u_char           *uri;
+        UI_METHOD        *method;
+        OSSL_STORE_CTX   *store;
+        OSSL_STORE_INFO  *info;
+
+        method = (cb != NULL) ? UI_UTIL_wrap_read_pem_callback(cb, 0) : NULL;
+        uri = id->data + sizeof("store:") - 1;
+
+        store = OSSL_STORE_open((char *) uri, method, pwd, NULL, NULL);
+
+        if (store == NULL) {
+            *err = "OSSL_STORE_open() failed";
+
+            if (method != NULL) {
+                UI_destroy_method(method);
+            }
+
+            return NULL;
+        }
+
+        pkey = NULL;
+
+        while (pkey == NULL && !OSSL_STORE_eof(store)) {
+            info = OSSL_STORE_load(store);
+
+            if (info == NULL) {
+                continue;
+            }
+
+            if (OSSL_STORE_INFO_get_type(info) == OSSL_STORE_INFO_PKEY) {
+                pkey = OSSL_STORE_INFO_get1_PKEY(info);
+            }
+
+            OSSL_STORE_INFO_free(info);
+        }
+
+        OSSL_STORE_close(store);
+
+        if (method != NULL) {
+            UI_destroy_method(method);
+        }
+
+        if (pkey == NULL) {
+            *err = "OSSL_STORE_load() failed";
+            return NULL;
+        }
+
+        if (cb_data.encrypted) {
+            *passwords = NGX_SSL_CACHE_DISABLED;
+        }
+
+        return pkey;
+
+#else
+
+        *err = "loading \"store:...\" certificate keys is not supported";
+        return NULL;
+
+#endif
+    }
+
+    bio = ngx_ssl_cache_create_bio(id, err);
+    if (bio == NULL) {
+        return NULL;
     }
 
     for ( ;; ) {

--- a/src/event/ngx_event_openssl_cache.c
+++ b/src/event/ngx_event_openssl_cache.c
@@ -122,6 +122,8 @@ static void ngx_ssl_cache_node_insert(ngx_rbtree_node_t *temp,
 static void ngx_ssl_cache_node_free(ngx_rbtree_t *rbtree,
     ngx_ssl_cache_node_t *cn);
 
+static ngx_int_t ngx_openssl_cache_init_worker(ngx_cycle_t *cycle);
+
 
 static ngx_command_t  ngx_openssl_cache_commands[] = {
 
@@ -150,7 +152,7 @@ ngx_module_t  ngx_openssl_cache_module = {
     NGX_CORE_MODULE,                       /* module type */
     NULL,                                  /* init master */
     NULL,                                  /* init module */
-    NULL,                                  /* init process */
+    ngx_openssl_cache_init_worker,         /* init process */
     NULL,                                  /* init thread */
     NULL,                                  /* exit thread */
     NULL,                                  /* exit process */
@@ -1232,4 +1234,21 @@ ngx_ssl_cache_node_insert(ngx_rbtree_node_t *temp,
     node->left = sentinel;
     node->right = sentinel;
     ngx_rbt_red(node);
+}
+
+
+static ngx_int_t
+ngx_openssl_cache_init_worker(ngx_cycle_t *cycle)
+{
+#ifdef ERR_R_OSSL_STORE_LIB
+
+    if (ngx_process != NGX_PROCESS_WORKER) {
+        return NGX_OK;
+    }
+
+    UI_set_default_method(UI_null());
+
+#endif
+
+    return NGX_OK;
 }


### PR DESCRIPTION
A new "store:..." prefix for the "ssl_certificate_key" directive allows loading keys via the OSSL_STORE API.

The change is required to support hardware backed keys in OpenSSL 3.x using the new "provider(7ossl)" modules, such as "pkcs11-provider".  While the engine API is present in 3.x, some operating systems (notably, RHEL10) have already disabled it in their builds of OpenSSL.

Related: https://trac.nginx.org/nginx/ticket/2449

Successfully tested with:
* [pkcs11-provider](https://github.com/latchset/pkcs11-provider) and https://github.com/nginx/nginx-tests/pull/16 on:
   - AlmaLinux 10  with OpenSSL 3.2.2
   - FreeBSD 14 with OpenSSL 3.0.15
* [tpm2-openssl](https://github.com/tpm2-software/tpm2-openssl), [swtpm](https://github.com/stefanberger/swtpm) and [ssl_provider_keys_tpm2.t](https://github.com/bavshin-f5/nginx-tests/blob/ssl-provider-tpm2/ssl_provider_keys_tpm2.t) on AlmaLinux 10

It is unclear if we want to handle property query to resolve ambiguities, e.g. `-provider tpm2 -propquery '?provider=tpm2' -key file:$name.key`.