### PR TITLE
Add a toggle shutdown_close_idle_connections to control whether to close idle connections when worker processes exit.

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -132,6 +132,13 @@ static ngx_command_t  ngx_core_commands[] = {
       offsetof(ngx_core_conf_t, shutdown_timeout),
       NULL },
 
+    { ngx_string("shutdown_close_idle_connections"),
+      NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_flag_slot,
+      0,
+      offsetof(ngx_core_conf_t, shutdown_close_idle_connections),
+      NULL },  
+
     { ngx_string("working_directory"),
       NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_str_slot,
@@ -1115,6 +1122,7 @@ ngx_core_module_create_conf(ngx_cycle_t *cycle)
     ccf->master = NGX_CONF_UNSET;
     ccf->timer_resolution = NGX_CONF_UNSET_MSEC;
     ccf->shutdown_timeout = NGX_CONF_UNSET_MSEC;
+    ccf->shutdown_close_idle_connections = NGX_CONF_UNSET;
 
     ccf->worker_processes = NGX_CONF_UNSET;
     ccf->debug_points = NGX_CONF_UNSET;
@@ -1144,6 +1152,7 @@ ngx_core_module_init_conf(ngx_cycle_t *cycle, void *conf)
     ngx_conf_init_value(ccf->master, 1);
     ngx_conf_init_msec_value(ccf->timer_resolution, 0);
     ngx_conf_init_msec_value(ccf->shutdown_timeout, 0);
+    ngx_conf_init_value(ccf->shutdown_close_idle_connections, 1);
 
     ngx_conf_init_value(ccf->worker_processes, 1);
     ngx_conf_init_value(ccf->debug_points, 0);

--- a/src/core/ngx_cycle.h
+++ b/src/core/ngx_cycle.h
@@ -89,7 +89,7 @@ struct ngx_cycle_s {
 typedef struct {
     ngx_flag_t                daemon;
     ngx_flag_t                master;
-
+    ngx_flag_t                shutdown_close_idle_connections;
     ngx_msec_t                timer_resolution;
     ngx_msec_t                shutdown_timeout;
 
@@ -118,7 +118,7 @@ typedef struct {
     ngx_array_t               env;
     char                    **environment;
 
-    ngx_uint_t                transparent;  /* unsigned  transparent:1; */
+    ngx_uint_t                transparent;  /* unsigned  transparent:1; */  
 } ngx_core_conf_t;
 
 


### PR DESCRIPTION
### Proposed changes

During our investigation of the nginx reload process, we discovered occasional requests getting RESET. Through packet capture analysis and nginx code debugging, we found this occurs when old worker processes exit and directly close idle keep-alive connections. The sequence is as follows:

1. A keep-alive connection exists and is idle
2. When a client uses this connection to send a request, and simultaneously the nginx administrator initiates a reload, nginx executes ngx_close_idle_connections to close keep-alive connections, sending a FIN packet before receiving the request
3. When the request reaches nginx, since the connection has already initiated closure with a FIN packet on the nginx side, nginx immediately RESETs this request

Our testing shows that when clients receive RESET packets, Golang by default automatically retries idempotent methods like GET, but not non-idempotent methods like POST. Python's requests library doesn't retry any HTTP methods by default.

In ```Server-to-Server``` scenarios, having POST methods RESET can cause significant business disruption, and it's generally difficult to require all users to modify their client behavior accordingly.

To achieve smoother reloads, we've modified the code to allow workers to optionally maintain idle keep-alive connections during shutdown, avoiding the issues described above.

Considering that not all nginx users need this feature, we've made it configurable:
```
Syntax:	shutdown_close_idle_connections number | auto;
Default:	shutdown_close_idle_connections on;
Context:	main
```
shutdown_close_idle_connections controls whether workers directly close idle keep-alive connections during shutdown. To maintain compatibility with existing behavior, it defaults to 'on', meaning it will close idle connections. Setting it to 'off' prevents closure during shutdown.

Users might worry that not closing keep-alive connections during shutdown could cause workers to persist indefinitely. This won't happen, as these connections will automatically close under these conditions:

1. When a client makes a request using the keep-alive connection, nginx will process it and return 'Connection:close', closing the connection and removing its timer.
2. When the keep-alive timeout expires on either the client or nginx side, the connection will automatically close and its timer will be removed.

The worker will exit once all keep-alive connections are closed and no timers remain.

The potential downside is increased worker process lingering time, but it ensures smoother reloads by eliminating the risk of requests being RESET during reload.

However, it's important to note that when nginx's keepalive_timeout is set very high (including both server and upstream settings), careful consideration is needed before using this feature. Additionally, it can be used in conjunction with shutdown_worker_timeout to reduce worker lingering duration.