### PR TITLE
Change application/javascript to text/javascript to match RFC 9239

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -5,7 +5,7 @@ types {
     text/xml                                         xml;
     image/gif                                        gif;
     image/jpeg                                       jpeg jpg;
-    application/javascript                           js;
+    text/javascript                                  js;
     application/atom+xml                             atom;
     application/rss+xml                              rss;
 


### PR DESCRIPTION
### Proposed changes

application/javascript has been obsoleted by RFC 9239. The new MIME type for JavaScript  files is text/javascript. This commit will update NGINX to follow the RFC 9239 behaviour.
