### PR TITLE
CUBIC congestion control in QUIC

### DIFF
--- a/src/event/quic/ngx_event_quic.c
+++ b/src/event/quic/ngx_event_quic.c
@@ -315,6 +315,10 @@ ngx_quic_new_connection(ngx_connection_t *c, ngx_quic_conf_t *conf,
     qc->congestion.mtu = NGX_QUIC_MIN_INITIAL_SIZE;
     qc->congestion.recovery_start = ngx_current_msec - 1;
 
+    qc->max_frames = (conf->max_concurrent_streams_uni
+                      + conf->max_concurrent_streams_bidi)
+                     * conf->stream_buffer_size / 2000;
+
     if (pkt->validated && pkt->retried) {
         qc->tp.retry_scid.len = pkt->dcid.len;
         qc->tp.retry_scid.data = ngx_pstrdup(c->pool, &pkt->dcid);

--- a/src/event/quic/ngx_event_quic.c
+++ b/src/event/quic/ngx_event_quic.c
@@ -312,7 +312,7 @@ ngx_quic_new_connection(ngx_connection_t *c, ngx_quic_conf_t *conf,
                                     ngx_max(2 * NGX_QUIC_MIN_INITIAL_SIZE,
                                             14720));
     qc->congestion.ssthresh = (size_t) -1;
-    qc->congestion.recovery_start = ngx_current_msec;
+    qc->congestion.recovery_start = ngx_current_msec - 1;
 
     if (pkt->validated && pkt->retried) {
         qc->tp.retry_scid.len = pkt->dcid.len;

--- a/src/event/quic/ngx_event_quic.c
+++ b/src/event/quic/ngx_event_quic.c
@@ -312,6 +312,7 @@ ngx_quic_new_connection(ngx_connection_t *c, ngx_quic_conf_t *conf,
                                     ngx_max(2 * NGX_QUIC_MIN_INITIAL_SIZE,
                                             14720));
     qc->congestion.ssthresh = (size_t) -1;
+    qc->congestion.mtu = NGX_QUIC_MIN_INITIAL_SIZE;
     qc->congestion.recovery_start = ngx_current_msec - 1;
 
     if (pkt->validated && pkt->retried) {

--- a/src/event/quic/ngx_event_quic.c
+++ b/src/event/quic/ngx_event_quic.c
@@ -308,8 +308,8 @@ ngx_quic_new_connection(ngx_connection_t *c, ngx_quic_conf_t *conf,
     qc->streams.client_max_streams_uni = qc->tp.initial_max_streams_uni;
     qc->streams.client_max_streams_bidi = qc->tp.initial_max_streams_bidi;
 
-    qc->congestion.window = ngx_min(10 * qc->tp.max_udp_payload_size,
-                                    ngx_max(2 * qc->tp.max_udp_payload_size,
+    qc->congestion.window = ngx_min(10 * NGX_QUIC_MIN_INITIAL_SIZE,
+                                    ngx_max(2 * NGX_QUIC_MIN_INITIAL_SIZE,
                                             14720));
     qc->congestion.ssthresh = (size_t) -1;
     qc->congestion.recovery_start = ngx_current_msec;

--- a/src/event/quic/ngx_event_quic_ack.c
+++ b/src/event/quic/ngx_event_quic_ack.c
@@ -354,6 +354,14 @@ ngx_quic_congestion_ack(ngx_connection_t *c, ngx_quic_frame_t *f)
         goto done;
     }
 
+    if (cg->idle) {
+        ngx_log_debug3(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                       "quic congestion ack idle t:%M win:%uz if:%uz",
+                       now, cg->window, cg->in_flight);
+
+        goto done;
+    }
+
     if (cg->window < cg->ssthresh) {
         cg->window += f->plen;
 
@@ -374,6 +382,22 @@ done:
     if (blocked && cg->in_flight < cg->window) {
         ngx_post_event(&qc->push, &ngx_posted_events);
     }
+}
+
+
+void
+ngx_quic_congestion_idle(ngx_connection_t *c, ngx_uint_t idle)
+{
+    ngx_quic_congestion_t  *cg;
+    ngx_quic_connection_t  *qc;
+
+    qc = ngx_quic_get_connection(c);
+    cg = &qc->congestion;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "quic congestion idle:%ui", idle);
+
+    cg->idle = idle;
 }
 
 

--- a/src/event/quic/ngx_event_quic_ack.c
+++ b/src/event/quic/ngx_event_quic_ack.c
@@ -20,6 +20,10 @@
 /* RFC 9002, 7.6.1. Duration: kPersistentCongestionThreshold */
 #define NGX_QUIC_PERSISTENT_CONGESTION_THR   3
 
+/* CUBIC parameters x10 */
+#define NGX_QUIC_CUBIC_BETA                  7
+#define MGX_QUIC_CUBIC_C                     4
+
 
 /* send time of ACK'ed packets */
 typedef struct {
@@ -35,10 +39,12 @@ static void ngx_quic_rtt_sample(ngx_connection_t *c, ngx_quic_ack_frame_t *ack,
 static ngx_int_t ngx_quic_handle_ack_frame_range(ngx_connection_t *c,
     ngx_quic_send_ctx_t *ctx, uint64_t min, uint64_t max,
     ngx_quic_ack_stat_t *st);
+static size_t ngx_quic_congestion_cubic(ngx_connection_t *c);
 static void ngx_quic_drop_ack_ranges(ngx_connection_t *c,
     ngx_quic_send_ctx_t *ctx, uint64_t pn);
 static ngx_int_t ngx_quic_detect_lost(ngx_connection_t *c,
     ngx_quic_ack_stat_t *st);
+static ngx_msec_t ngx_quic_congestion_cubic_time(ngx_connection_t *c);
 static ngx_msec_t ngx_quic_pcg_duration(ngx_connection_t *c);
 static void ngx_quic_persistent_congestion(ngx_connection_t *c);
 static ngx_msec_t ngx_quic_oldest_sent_packet(ngx_connection_t *c);
@@ -314,6 +320,7 @@ ngx_quic_handle_ack_frame_range(ngx_connection_t *c, ngx_quic_send_ctx_t *ctx,
 void
 ngx_quic_congestion_ack(ngx_connection_t *c, ngx_quic_frame_t *f)
 {
+    size_t                  w_cubic;
     ngx_uint_t              blocked;
     ngx_msec_t              now, timer;
     ngx_quic_congestion_t  *cg;
@@ -370,11 +377,46 @@ ngx_quic_congestion_ack(ngx_connection_t *c, ngx_quic_frame_t *f)
                        now, cg->window, cg->ssthresh, cg->in_flight);
 
     } else {
-        cg->window += (uint64_t) qc->path->mtu * f->plen / cg->window;
 
-        ngx_log_debug3(NGX_LOG_DEBUG_EVENT, c->log, 0,
-                       "quic congestion ack reno t:%M win:%uz if:%uz",
-                       now, cg->window, cg->in_flight);
+        /* RFC 9438, 4.2. Window Increase Function */
+
+        w_cubic = ngx_quic_congestion_cubic(c);
+
+        if (cg->window < cg->w_prior) {
+            cg->w_est += (uint64_t) cg->mtu * f->plen
+                         * 3 * (10 - NGX_QUIC_CUBIC_BETA)
+                         / (10 + NGX_QUIC_CUBIC_BETA) / cg->window;
+
+        } else {
+            cg->w_est += (uint64_t) cg->mtu * f->plen / cg->window;
+        }
+
+        if (w_cubic < cg->w_est) {
+            cg->window = cg->w_est;
+
+            ngx_log_debug4(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                       "quic congestion ack reno t:%M win:%uz c:%uz if:%uz",
+                       now, cg->window, w_cubic, cg->in_flight);
+
+        } else if (w_cubic > cg->window) {
+
+            if (w_cubic >= cg->window * 3 / 2) {
+                cg->window += cg->mtu / 2;
+
+            } else {
+                cg->window += (uint64_t) cg->mtu * (w_cubic - cg->window)
+                              / cg->window;
+            }
+
+            ngx_log_debug4(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                          "quic congestion ack cubic t:%M win:%uz c:%uz if:%uz",
+                          now, cg->window, w_cubic, cg->in_flight);
+
+        } else {
+            ngx_log_debug4(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                           "quic congestion ack skip t:%M win:%uz c:%uz if:%uz",
+                           now, cg->window, w_cubic, cg->in_flight);
+        }
     }
 
 done:
@@ -385,9 +427,62 @@ done:
 }
 
 
+static size_t
+ngx_quic_congestion_cubic(ngx_connection_t *c)
+{
+    int64_t                 w, t, cc;
+    ngx_msec_t              now;
+    ngx_quic_congestion_t  *cg;
+    ngx_quic_connection_t  *qc;
+
+    qc = ngx_quic_get_connection(c);
+    cg = &qc->congestion;
+
+    ngx_quic_congestion_idle(c, cg->idle);
+
+    now = ngx_current_msec;
+    t = (ngx_msec_int_t) (now - cg->k);
+
+    if (t > 1000000) {
+        w = NGX_MAX_SIZE_T_VALUE;
+        goto done;
+    }
+
+    if (t < -1000000) {
+        w = 0;
+        goto done;
+    }
+
+    /*
+     * RFC 9438, Figure 1
+     *
+     *   w_cubic = C * (t_msec / 1000) ^ 3 * mtu + w_max
+     */
+
+    cc = 10000000000ll / (int64_t) cg->mtu / MGX_QUIC_CUBIC_C;
+    w = t * t * t / cc + (int64_t) cg->w_max;
+
+    if (w > NGX_MAX_SIZE_T_VALUE) {
+        w = NGX_MAX_SIZE_T_VALUE;
+    }
+
+    if (w < 0) {
+        w = 0;
+    }
+
+done:
+
+    ngx_log_debug3(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "quic cubic t:%L w:%L wm:%uz", t, w, cg->w_max);
+
+    return w;
+}
+
+
 void
 ngx_quic_congestion_idle(ngx_connection_t *c, ngx_uint_t idle)
 {
+    ngx_msec_t              now;
     ngx_quic_congestion_t  *cg;
     ngx_quic_connection_t  *qc;
 
@@ -396,6 +491,18 @@ ngx_quic_congestion_idle(ngx_connection_t *c, ngx_uint_t idle)
 
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
                    "quic congestion idle:%ui", idle);
+
+    if (cg->window >= cg->ssthresh) {
+        /* RFC 9438, 5.8. Behavior for Application-Limited Flows */
+
+        now = ngx_current_msec;
+
+        if (cg->idle) {
+            cg->k += now - cg->idle_start;
+        }
+
+        cg->idle_start = now;
+    }
 
     cg->idle = idle;
 }
@@ -580,8 +687,9 @@ ngx_quic_persistent_congestion(ngx_connection_t *c)
     qc = ngx_quic_get_connection(c);
     cg = &qc->congestion;
 
+    cg->mtu = qc->path->mtu;
     cg->recovery_start = ngx_quic_oldest_sent_packet(c) - 1;
-    cg->window = qc->path->mtu * 2;
+    cg->window = cg->mtu * 2;
 
     ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0,
                    "quic congestion persistent t:%M win:%uz",
@@ -763,14 +871,19 @@ ngx_quic_congestion_lost(ngx_connection_t *c, ngx_quic_frame_t *f)
         goto done;
     }
 
+    /* RFC 9438, 4.6. Multiplicative Decrease */
+
+    cg->mtu = qc->path->mtu;
     cg->recovery_start = now;
-    cg->window /= 2;
-
-    if (cg->window < qc->path->mtu * 2) {
-        cg->window = qc->path->mtu * 2;
-    }
-
-    cg->ssthresh = cg->window;
+    cg->w_prior = cg->window;
+    /* RFC 9438, 4.7. Fast Convergence */
+    cg->w_max = (cg->window < cg->w_max)
+                ? cg->window * (10 + NGX_QUIC_CUBIC_BETA) / 20 : cg->window;
+    cg->ssthresh = cg->in_flight * NGX_QUIC_CUBIC_BETA / 10;
+    cg->window = ngx_max(cg->ssthresh, cg->mtu * 2);
+    cg->w_est = cg->window;
+    cg->k = now + ngx_quic_congestion_cubic_time(c);
+    cg->idle_start = now;
 
     ngx_log_debug3(NGX_LOG_DEBUG_EVENT, c->log, 0,
                    "quic congestion lost t:%M win:%uz if:%uz",
@@ -781,6 +894,58 @@ done:
     if (blocked && cg->in_flight < cg->window) {
         ngx_post_event(&qc->push, &ngx_posted_events);
     }
+}
+
+
+static ngx_msec_t
+ngx_quic_congestion_cubic_time(ngx_connection_t *c)
+{
+    int64_t                 v, x, d, cc;
+    ngx_uint_t              n;
+    ngx_quic_congestion_t  *cg;
+    ngx_quic_connection_t  *qc;
+
+    qc = ngx_quic_get_connection(c);
+    cg = &qc->congestion;
+
+    /*
+     * RFC 9438, Figure 2
+     *
+     *   k_msec = ((w_max - cwnd_epoch) / C / mtu) ^ 1/3 * 1000
+     */
+
+    if (cg->w_max <= cg->window) {
+        return 0;
+    }
+
+    cc = 10000000000ll / (int64_t) cg->mtu / MGX_QUIC_CUBIC_C;
+    v = (int64_t) (cg->w_max - cg->window) * cc;
+
+    /*
+     * Newton-Raphson method for x ^ 3 = v:
+     *
+     *   x_next = (2 * x_prev + v / x_prev ^ 2) / 3
+     */
+
+    x = 5000;
+
+    for (n = 1; n <= 10; n++) {
+        d =  (v / x / x - x) / 3;
+        x += d;
+
+        if (ngx_abs(d) <= 100) {
+            break;
+        }
+    }
+
+    if (x > NGX_MAX_SIZE_T_VALUE) {
+        return NGX_MAX_SIZE_T_VALUE;
+    }
+
+    ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "quic cubic time:%L n:%ui", x, n);
+
+    return x;
 }
 
 

--- a/src/event/quic/ngx_event_quic_ack.c
+++ b/src/event/quic/ngx_event_quic_ack.c
@@ -353,7 +353,7 @@ ngx_quic_congestion_ack(ngx_connection_t *c, ngx_quic_frame_t *f)
                        now, cg->window, cg->ssthresh, cg->in_flight);
 
     } else {
-        cg->window += qc->tp.max_udp_payload_size * f->plen / cg->window;
+        cg->window += (uint64_t) qc->path->mtu * f->plen / cg->window;
 
         ngx_log_debug3(NGX_LOG_DEBUG_EVENT, c->log, 0,
                        "quic congestion ack reno t:%M win:%uz if:%uz",
@@ -552,7 +552,7 @@ ngx_quic_persistent_congestion(ngx_connection_t *c)
     now = ngx_current_msec;
 
     cg->recovery_start = now;
-    cg->window = qc->tp.max_udp_payload_size * 2;
+    cg->window = qc->path->mtu * 2;
 
     ngx_log_debug2(NGX_LOG_DEBUG_EVENT, c->log, 0,
                    "quic congestion persistent t:%M win:%uz", now, cg->window);
@@ -698,8 +698,8 @@ ngx_quic_congestion_lost(ngx_connection_t *c, ngx_quic_frame_t *f)
     cg->recovery_start = now;
     cg->window /= 2;
 
-    if (cg->window < qc->tp.max_udp_payload_size * 2) {
-        cg->window = qc->tp.max_udp_payload_size * 2;
+    if (cg->window < qc->path->mtu * 2) {
+        cg->window = qc->path->mtu * 2;
     }
 
     cg->ssthresh = cg->window;

--- a/src/event/quic/ngx_event_quic_ack.c
+++ b/src/event/quic/ngx_event_quic_ack.c
@@ -755,6 +755,14 @@ ngx_quic_congestion_lost(ngx_connection_t *c, ngx_quic_frame_t *f)
         goto done;
     }
 
+    if (f->ignore_loss) {
+        ngx_log_debug3(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                       "quic congestion lost ignore t:%M win:%uz if:%uz",
+                       now, cg->window, cg->in_flight);
+
+        goto done;
+    }
+
     cg->recovery_start = now;
     cg->window /= 2;
 

--- a/src/event/quic/ngx_event_quic_ack.h
+++ b/src/event/quic/ngx_event_quic_ack.h
@@ -17,6 +17,7 @@ ngx_int_t ngx_quic_handle_ack_frame(ngx_connection_t *c,
 
 void ngx_quic_congestion_ack(ngx_connection_t *c,
     ngx_quic_frame_t *frame);
+void ngx_quic_congestion_idle(ngx_connection_t *c, ngx_uint_t idle);
 void ngx_quic_resend_frames(ngx_connection_t *c, ngx_quic_send_ctx_t *ctx);
 void ngx_quic_set_lost_timer(ngx_connection_t *c);
 void ngx_quic_pto_handler(ngx_event_t *ev);

--- a/src/event/quic/ngx_event_quic_connection.h
+++ b/src/event/quic/ngx_event_quic_connection.h
@@ -168,7 +168,13 @@ typedef struct {
     size_t                            in_flight;
     size_t                            window;
     size_t                            ssthresh;
+    size_t                            w_max;
+    size_t                            w_est;
+    size_t                            w_prior;
+    size_t                            mtu;
     ngx_msec_t                        recovery_start;
+    ngx_msec_t                        idle_start;
+    ngx_msec_t                        k;
     ngx_uint_t                        idle; /* unsigned  idle:1; */
 } ngx_quic_congestion_t;
 

--- a/src/event/quic/ngx_event_quic_connection.h
+++ b/src/event/quic/ngx_event_quic_connection.h
@@ -261,6 +261,7 @@ struct ngx_quic_connection_s {
     ngx_buf_t                        *free_shadow_bufs;
 
     ngx_uint_t                        nframes;
+    ngx_uint_t                        max_frames;
 #ifdef NGX_QUIC_DEBUG_ALLOC
     ngx_uint_t                        nbufs;
     ngx_uint_t                        nshadowbufs;

--- a/src/event/quic/ngx_event_quic_connection.h
+++ b/src/event/quic/ngx_event_quic_connection.h
@@ -169,6 +169,7 @@ typedef struct {
     size_t                            window;
     size_t                            ssthresh;
     ngx_msec_t                        recovery_start;
+    ngx_uint_t                        idle; /* unsigned  idle:1; */
 } ngx_quic_congestion_t;
 
 

--- a/src/event/quic/ngx_event_quic_frames.c
+++ b/src/event/quic/ngx_event_quic_frames.c
@@ -214,7 +214,7 @@ ngx_quic_alloc_frame(ngx_connection_t *c)
                        "quic reuse frame n:%ui", qc->nframes);
 #endif
 
-    } else if (qc->nframes < 10000) {
+    } else if (qc->nframes < qc->max_frames) {
         frame = ngx_palloc(c->pool, sizeof(ngx_quic_frame_t));
         if (frame == NULL) {
             return NULL;

--- a/src/event/quic/ngx_event_quic_migration.c
+++ b/src/event/quic/ngx_event_quic_migration.c
@@ -924,6 +924,7 @@ ngx_quic_send_path_mtu_probe(ngx_connection_t *c, ngx_quic_path_t *path)
     frame->level = ssl_encryption_application;
     frame->type = NGX_QUIC_FT_PING;
     frame->ignore_loss = 1;
+    frame->ignore_congestion = 1;
 
     qc = ngx_quic_get_connection(c);
     ctx = ngx_quic_get_send_ctx(qc, ssl_encryption_application);

--- a/src/event/quic/ngx_event_quic_migration.c
+++ b/src/event/quic/ngx_event_quic_migration.c
@@ -182,8 +182,8 @@ valid:
 
         ngx_memzero(&qc->congestion, sizeof(ngx_quic_congestion_t));
 
-        qc->congestion.window = ngx_min(10 * qc->tp.max_udp_payload_size,
-                                   ngx_max(2 * qc->tp.max_udp_payload_size,
+        qc->congestion.window = ngx_min(10 * NGX_QUIC_MIN_INITIAL_SIZE,
+                                   ngx_max(2 * NGX_QUIC_MIN_INITIAL_SIZE,
                                            14720));
         qc->congestion.ssthresh = (size_t) -1;
         qc->congestion.recovery_start = ngx_current_msec;

--- a/src/event/quic/ngx_event_quic_migration.c
+++ b/src/event/quic/ngx_event_quic_migration.c
@@ -186,6 +186,7 @@ valid:
                                    ngx_max(2 * NGX_QUIC_MIN_INITIAL_SIZE,
                                            14720));
         qc->congestion.ssthresh = (size_t) -1;
+        qc->congestion.mtu = NGX_QUIC_MIN_INITIAL_SIZE;
         qc->congestion.recovery_start = ngx_current_msec - 1;
 
         ngx_quic_init_rtt(qc);

--- a/src/event/quic/ngx_event_quic_migration.c
+++ b/src/event/quic/ngx_event_quic_migration.c
@@ -923,6 +923,7 @@ ngx_quic_send_path_mtu_probe(ngx_connection_t *c, ngx_quic_path_t *path)
 
     frame->level = ssl_encryption_application;
     frame->type = NGX_QUIC_FT_PING;
+    frame->ignore_loss = 1;
 
     qc = ngx_quic_get_connection(c);
     ctx = ngx_quic_get_send_ctx(qc, ssl_encryption_application);

--- a/src/event/quic/ngx_event_quic_migration.c
+++ b/src/event/quic/ngx_event_quic_migration.c
@@ -186,7 +186,7 @@ valid:
                                    ngx_max(2 * NGX_QUIC_MIN_INITIAL_SIZE,
                                            14720));
         qc->congestion.ssthresh = (size_t) -1;
-        qc->congestion.recovery_start = ngx_current_msec;
+        qc->congestion.recovery_start = ngx_current_msec - 1;
 
         ngx_quic_init_rtt(qc);
     }

--- a/src/event/quic/ngx_event_quic_transport.h
+++ b/src/event/quic/ngx_event_quic_transport.h
@@ -271,6 +271,7 @@ struct ngx_quic_frame_s {
     unsigned                                    need_ack:1;
     unsigned                                    pkt_need_ack:1;
     unsigned                                    ignore_congestion:1;
+    unsigned                                    ignore_loss:1;
 
     ngx_chain_t                                *data;
     union {

--- a/src/http/v3/ngx_http_v3.c
+++ b/src/http/v3/ngx_http_v3.c
@@ -70,7 +70,7 @@ ngx_http_v3_keepalive_handler(ngx_event_t *ev)
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http3 keepalive handler");
 
-    ngx_http_v3_finalize_connection(c, NGX_HTTP_V3_ERR_NO_ERROR,
+    ngx_http_v3_shutdown_connection(c, NGX_HTTP_V3_ERR_NO_ERROR,
                                     "keepalive timeout");
 }
 


### PR DESCRIPTION
## Description

CUBIC congestion control is described in [RFC 9438](https://www.rfc-editor.org/rfc/rfc9438.html). Currently nginx implements Reno congestion control as described in [RFC 9002](https://www.rfc-editor.org/rfc/rfc9002.html) for QUIC. CUBIC is an improvement over Reno especially for high-BDP and high-RTT paths.

This PR includes several preparatory patches plus QUIC Congestion control patch. The first patch changes nginx debug logging to allow plotting congestion control window. Below are some congestion control graphs.

Closes #442.

## Testing environment

All testing is done on local interface with MTU 1500. Traffic is controlled by [`tc-netem`](https://man7.org/linux/man-pages/man8/tc-netem.8.html), graphs are plotted by [`gnuplot`](http://www.gnuplot.info), and [`gtlsclient`](https://github.com/ngtcp2/ngtcp2) is used as an HTTP/3 client. A 50M file is downloaded for testing.

```
$ sudo ifconfig lo mtu 1500
$ sudo tc qdisc add dev lo root netem limit 300 delay 100ms
$ gtlsclient -q --exit-on-first-stream-close 127.0.0.1 8443 https://example.com/50m 
```

nginx.conf:
```
master_process off;                                                              
daemon off;                                                                      
                                                                                 
error_log logs/error.log debug;                                                                                                                                   
                                                                                 
events {                                                                         
}                                                                                
                                                                                                                                                                  
http {                                                                           
    server {                                                                     
        listen 8443 quic;                                         
                                                                                                                                                                  
        http3_stream_buffer_size 10m;                                            
                                                                                 
        ssl_certificate certs/example.com.crt;                                   
        ssl_certificate_key certs/example.com.key;                               
                                                                                 
        location / {                                                             
            root html;                                                           
        }                                                                        
    }                                                                            
} 
```

After running a test, the following script uses `gnuplot` to generate a png with the graph.
```
#!/bin/bash

ERROR_LOG=logs/error.log
CUBIC_SCRIPT=/tmp/cubic.gnuplot
CUBIC_DATA=/tmp/cubic.dat
CUBIC_PNG=cubic.png

rm $CUBIC_PNG || true

awk 'BEGIN{t=0} /congestion ack.*win/{match($0, /ack ([^ ]+) /, s); match($0, /win:([0-9]+)/, m); match($0, / t:([0-9]+)/, n); if (t==0) {t=n[1];} print n[1]-t, m[1], s[1]}' $ERROR_LOG >$CUBIC_DATA

cat >$CUBIC_SCRIPT <<END
set title "QUIC congestion control"
set xlabel ""
set ylabel ""
set format y '%.1s%cB'
set format x '%0.0ss'
set yrange [0:]
set term png
set output "$CUBIC_PNG"

map_color(string) = (              \
    string eq 'ss'    ? 0x00ff00 : \
    string eq 'cubic' ? 0x0000ff : \
    string eq 'reno'  ? 0xff0000 : \
    string eq 'idle'  ? 0x000000 : \
    string eq 'rec'   ? 0x444444 : \
    0x888888)

plot "$CUBIC_DATA" using 1:2:(map_color(stringcolumn(3))) title "cwnd" with linespoints lc rgbcolor variable
END

gnuplot $CUBIC_SCRIPT
```

Different parts of the graph are colored according to the congestion control state:
- green: slow start
- blue: CUBIC
- red: Reno (including Reno-friendliness region in CUBIC)
- black: application-limited region
- grey: recovery

The graph plots congestion window size at any time from session start to end.

## Graphs
Current congestion control (Reno).
![original](https://github.com/user-attachments/assets/17f988a4-ee7d-4413-8b7a-e33f5fa1f2e7)

Fixed Reno aggressiveness. This was due to using the maximum UDP packet size instead of current MTU (QUIC: use path MTU in congestion window computations).
![reno](https://github.com/user-attachments/assets/9da1d1fd-41ee-4226-bc6b-09b0dbef5321)

CUBIC congestion control.
![cubic](https://github.com/user-attachments/assets/964f0ac3-d525-4e99-878a-12c0cdb620e5)
