### PR TITLE
Fixup: request cannot be cleanup sometimes.

### DIFF
--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -2715,7 +2715,7 @@ ngx_http_terminate_request(ngx_http_request_t *r, ngx_int_t rc)
                    "http terminate cleanup count:%d blk:%d",
                    mr->count, mr->blocked);
 
-    if (mr->write_event_handler) {
+    if (!mr->connection->error && mr->write_event_handler) {
 
         if (mr->blocked) {
             r = r->connection->data;


### PR DESCRIPTION
When nginx tries to write to a broken connection. It triggers an IO error, and then mark the connection as error.
If ngx_http_finalize_connection is invoked after the IO error, Current code will setup an handler to r->write_event_handler.
That will be a trouble, the newly installed handler will never be called, and the request will be leaked.
