### PR TITLE
Win32: couple of platform detection fixes

### DIFF
--- a/auto/cc/msvc
+++ b/auto/cc/msvc
@@ -26,6 +26,10 @@ ngx_msvc_ver=`echo $NGX_MSVC_VER | sed -e 's/^\([0-9]*\).*/\1/'`
 
 case "$NGX_MSVC_VER" in
 
+    *ARM64)
+        NGX_MACHINE=arm64
+    ;;
+
     *x64)
         NGX_MACHINE=amd64
     ;;

--- a/auto/lib/openssl/make
+++ b/auto/lib/openssl/make
@@ -13,6 +13,10 @@ case "$CC" in
                 OPENSSL_TARGET=VC-WIN64A
             ;;
 
+            arm64)
+                OPENSSL_TARGET=VC-WIN64-ARM
+            ;;
+
             *)
                 OPENSSL_TARGET=VC-WIN32
             ;;

--- a/src/core/ngx_config.h
+++ b/src/core/ngx_config.h
@@ -94,7 +94,7 @@ typedef intptr_t        ngx_flag_t;
 
 
 #ifndef NGX_ALIGNMENT
-#define NGX_ALIGNMENT   sizeof(unsigned long)    /* platform word */
+#define NGX_ALIGNMENT   sizeof(uintptr_t)    /* platform word */
 #endif
 
 #define ngx_align(d, a)     (((d) + (a - 1)) & ~(a - 1))


### PR DESCRIPTION
See commit messages.

The `NGX_ALIGNMENT` one is actually necessary for the Rust bindings to work on any 64-bit Windows; there are optimizations in Rust that may require pointers to be properly aligned, and thus the standard library enforces this with assertions.

The ARM64 stems from the same source, while debugging ^ I found that we pass incorrect configuration template to the OpenSSL; `VC-WIN64-ARM` is what `Configure` would pick without our meddling. Also, having an accurate `NGX_MACHINE` value helps when I needed to guess a target triple.

For reference, cl.exe version strings:
* `Microsoft (R) C/C++ Optimizing Compiler Version 19.16.27051 for ARM64` (2017, first available ARM64 toolchain)
* `Microsoft (R) C/C++ Optimizing Compiler Version 19.42.34435 for ARM64` (2022)

The change has been verified with OpenSSL 3.0-3.4 in a Win64 cross-compile environment and on a real Windows 11 ARM64 VM.

Fixes #446