### PR TITLE
Upstream: fixed passwords support for dynamic certificate loading.

### DIFF
--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -5042,6 +5042,18 @@ ngx_http_grpc_set_ssl(ngx_conf_t *cf, ngx_http_grpc_loc_conf_t *glcf)
     ngx_pool_cleanup_t  *cln;
 
     if (glcf->upstream.ssl->ctx) {
+        if (glcf->upstream.ssl_certificate
+            && glcf->upstream.ssl_certificate->value.len
+            && (glcf->upstream.ssl_certificate->lengths
+                || glcf->upstream.ssl_certificate_key->lengths))
+        {
+            glcf->upstream.ssl_passwords =
+                  ngx_ssl_preserve_passwords(cf, glcf->upstream.ssl_passwords);
+            if (glcf->upstream.ssl_passwords == NULL) {
+                return NGX_ERROR;
+            }
+        }
+
         return NGX_OK;
     }
 

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -5302,6 +5302,18 @@ ngx_http_proxy_set_ssl(ngx_conf_t *cf, ngx_http_proxy_loc_conf_t *plcf)
     ngx_pool_cleanup_t  *cln;
 
     if (plcf->upstream.ssl->ctx) {
+        if (plcf->upstream.ssl_certificate
+            && plcf->upstream.ssl_certificate->value.len
+            && (plcf->upstream.ssl_certificate->lengths
+                || plcf->upstream.ssl_certificate_key->lengths))
+        {
+            plcf->upstream.ssl_passwords =
+                  ngx_ssl_preserve_passwords(cf, plcf->upstream.ssl_passwords);
+            if (plcf->upstream.ssl_passwords == NULL) {
+                return NGX_ERROR;
+            }
+        }
+
         return NGX_OK;
     }
 

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -2650,6 +2650,18 @@ ngx_http_uwsgi_set_ssl(ngx_conf_t *cf, ngx_http_uwsgi_loc_conf_t *uwcf)
     ngx_pool_cleanup_t  *cln;
 
     if (uwcf->upstream.ssl->ctx) {
+        if (uwcf->upstream.ssl_certificate
+            && uwcf->upstream.ssl_certificate->value.len
+            && (uwcf->upstream.ssl_certificate->lengths
+                || uwcf->upstream.ssl_certificate_key->lengths))
+        {
+            uwcf->upstream.ssl_passwords =
+                  ngx_ssl_preserve_passwords(cf, uwcf->upstream.ssl_passwords);
+            if (uwcf->upstream.ssl_passwords == NULL) {
+                return NGX_ERROR;
+            }
+        }
+
         return NGX_OK;
     }
 

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -2387,6 +2387,18 @@ ngx_stream_proxy_set_ssl(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *pscf)
     ngx_pool_cleanup_t  *cln;
 
     if (pscf->ssl->ctx) {
+        if (pscf->ssl_certificate
+            && pscf->ssl_certificate->value.len
+            && (pscf->ssl_certificate->lengths
+                || pscf->ssl_certificate_key->lengths))
+        {
+            pscf->ssl_passwords =
+                           ngx_ssl_preserve_passwords(cf, pscf->ssl_passwords);
+            if (pscf->ssl_passwords == NULL) {
+                return NGX_ERROR;
+            }
+        }
+
         return NGX_OK;
     }
 


### PR DESCRIPTION
The bug had appeared in nginx 1.23.1 with optimized use of SSL contexts.
