### PR TITLE
Configure: fixed --with-libatomic=DIR with recent libatomic_ops.

### DIFF
--- a/auto/lib/libatomic/conf
+++ b/auto/lib/libatomic/conf
@@ -7,8 +7,8 @@ if [ $NGX_LIBATOMIC != YES ]; then
 
     have=NGX_HAVE_LIBATOMIC . auto/have
     CORE_INCS="$CORE_INCS $NGX_LIBATOMIC/src"
-    LINK_DEPS="$LINK_DEPS $NGX_LIBATOMIC/src/libatomic_ops.a"
-    CORE_LIBS="$CORE_LIBS $NGX_LIBATOMIC/src/libatomic_ops.a"
+    LINK_DEPS="$LINK_DEPS $NGX_LIBATOMIC/build/lib/libatomic_ops.a"
+    CORE_LIBS="$CORE_LIBS $NGX_LIBATOMIC/build/lib/libatomic_ops.a"
 
 else
 

--- a/auto/lib/libatomic/make
+++ b/auto/lib/libatomic/make
@@ -3,14 +3,19 @@
 # Copyright (C) Nginx, Inc.
 
 
+    case $NGX_LIBATOMIC in
+        /*) ngx_prefix="$NGX_LIBATOMIC/build" ;;
+        *)  ngx_prefix="$PWD/$NGX_LIBATOMIC/build" ;;
+    esac
+
     cat << END                                            >> $NGX_MAKEFILE
 
-$NGX_LIBATOMIC/src/libatomic_ops.a:	$NGX_LIBATOMIC/Makefile
-	cd $NGX_LIBATOMIC && \$(MAKE)
+$NGX_LIBATOMIC/build/lib/libatomic_ops.a:	$NGX_LIBATOMIC/Makefile
+	cd $NGX_LIBATOMIC && \$(MAKE) && \$(MAKE) install
 
 $NGX_LIBATOMIC/Makefile:	$NGX_MAKEFILE
 	cd $NGX_LIBATOMIC \\
 	&& if [ -f Makefile ]; then \$(MAKE) distclean; fi \\
-	&& ./configure
+	&& ./configure --prefix=$ngx_prefix
 
 END


### PR DESCRIPTION
The build location of the resulting libatomic_ops.a was changed in v7.4.0 after converting libatomic_ops to use libtool.  The fix is to use headers and library from the install prefix, similar how we do this with OpenSSL. This approach allows building with both old and new library versions.

Initially reported here:
https://mailman.nginx.org/pipermail/nginx/2018-April/056054.html
