### PR TITLE
Stream: fix  break the preread handler chains bug

### DIFF
--- a/src/stream/ngx_stream_ssl_preread_module.c
+++ b/src/stream/ngx_stream_ssl_preread_module.c
@@ -190,7 +190,7 @@ ngx_stream_ssl_preread_handler(ngx_stream_session_t *s)
         }
 
         if (rc == NGX_OK) {
-            return ngx_stream_ssl_preread_servername(s, &ctx->host);
+            rc = ngx_stream_ssl_preread_servername(s, &ctx->host);
         }
 
         if (rc != NGX_AGAIN) {


### PR DESCRIPTION
### Proposed changes

In the processing flow of nginx stream preread, we need to make chain calls to invoke all callback functions on `NGX_STREAM_PREREAD_PHASE`

But in https://github.com/nginx/nginx/commit/d21675228a0ba8d4331e05c60660228a5d3326de, virtual server has been introduce in ssl preread module, if `ngx_stream_ssl_preread_servername(s, &ctx->host);` return `NGX_OK`, it will skip other `preread` module, and jump to next phase `content_phase` https://github.com/nginx/nginx/blob/5d5d9adccfeaff7d5926737ee5dfa43937fe5899/src/stream/ngx_stream_core_module.c#L294
