### PR TITLE
Upstream: fix NGX_COMPAT build without NGX_HTTP_SSL after 454ad0e.

### DIFF
--- a/src/core/ngx_core.h
+++ b/src/core/ngx_core.h
@@ -26,6 +26,7 @@ typedef struct ngx_event_aio_s       ngx_event_aio_t;
 typedef struct ngx_connection_s      ngx_connection_t;
 typedef struct ngx_thread_task_s     ngx_thread_task_t;
 typedef struct ngx_ssl_s             ngx_ssl_t;
+typedef struct ngx_ssl_cache_s       ngx_ssl_cache_t;
 typedef struct ngx_proxy_protocol_s  ngx_proxy_protocol_t;
 typedef struct ngx_quic_stream_s     ngx_quic_stream_t;
 typedef struct ngx_ssl_connection_s  ngx_ssl_connection_t;

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -83,7 +83,6 @@
 #endif
 
 
-typedef struct ngx_ssl_cache_s  ngx_ssl_cache_t;
 typedef struct ngx_ssl_ocsp_s   ngx_ssl_ocsp_t;
 
 


### PR DESCRIPTION
Fix "--with-compat" build, without "--with-http_ssl_module".