### PR TITLE
SSL: minimize the number of preserved password copies.

### DIFF
--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -248,8 +248,7 @@ void *ngx_ssl_cache_connection_fetch(ngx_ssl_cache_t *cache, ngx_pool_t *pool,
     ngx_uint_t index, char **err, ngx_str_t *path, void *data);
 
 ngx_array_t *ngx_ssl_read_password_file(ngx_conf_t *cf, ngx_str_t *file);
-ngx_array_t *ngx_ssl_preserve_passwords(ngx_conf_t *cf,
-    ngx_array_t *passwords);
+ngx_int_t ngx_ssl_preserve_passwords(ngx_conf_t *cf, ngx_array_t *passwords);
 ngx_int_t ngx_ssl_dhparam(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *file);
 ngx_int_t ngx_ssl_ecdh_curve(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *name);
 ngx_int_t ngx_ssl_early_data(ngx_conf_t *cf, ngx_ssl_t *ssl,

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -5080,9 +5080,9 @@ ngx_http_grpc_set_ssl(ngx_conf_t *cf, ngx_http_grpc_loc_conf_t *glcf)
         if (glcf->upstream.ssl_certificate->lengths
             || glcf->upstream.ssl_certificate_key->lengths)
         {
-            glcf->upstream.ssl_passwords =
-                  ngx_ssl_preserve_passwords(cf, glcf->upstream.ssl_passwords);
-            if (glcf->upstream.ssl_passwords == NULL) {
+            if (ngx_ssl_preserve_passwords(cf, glcf->upstream.ssl_passwords)
+                != NGX_OK)
+            {
                 return NGX_ERROR;
             }
 

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -5340,9 +5340,9 @@ ngx_http_proxy_set_ssl(ngx_conf_t *cf, ngx_http_proxy_loc_conf_t *plcf)
         if (plcf->upstream.ssl_certificate->lengths
             || plcf->upstream.ssl_certificate_key->lengths)
         {
-            plcf->upstream.ssl_passwords =
-                  ngx_ssl_preserve_passwords(cf, plcf->upstream.ssl_passwords);
-            if (plcf->upstream.ssl_passwords == NULL) {
+            if (ngx_ssl_preserve_passwords(cf, plcf->upstream.ssl_passwords)
+                != NGX_OK)
+            {
                 return NGX_ERROR;
             }
 

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -988,8 +988,7 @@ found:
         }
     }
 
-    conf->passwords = ngx_ssl_preserve_passwords(cf, conf->passwords);
-    if (conf->passwords == NULL) {
+    if (ngx_ssl_preserve_passwords(cf, conf->passwords) != NGX_OK) {
         return NGX_ERROR;
     }
 

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -2688,9 +2688,9 @@ ngx_http_uwsgi_set_ssl(ngx_conf_t *cf, ngx_http_uwsgi_loc_conf_t *uwcf)
         if (uwcf->upstream.ssl_certificate->lengths
             || uwcf->upstream.ssl_certificate_key->lengths)
         {
-            uwcf->upstream.ssl_passwords =
-                  ngx_ssl_preserve_passwords(cf, uwcf->upstream.ssl_passwords);
-            if (uwcf->upstream.ssl_passwords == NULL) {
+            if (ngx_ssl_preserve_passwords(cf, uwcf->upstream.ssl_passwords)
+                != NGX_OK)
+            {
                 return NGX_ERROR;
             }
 

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -2421,9 +2421,7 @@ ngx_stream_proxy_set_ssl(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *pscf)
         if (pscf->ssl_certificate->lengths
             || pscf->ssl_certificate_key->lengths)
         {
-            pscf->ssl_passwords =
-                           ngx_ssl_preserve_passwords(cf, pscf->ssl_passwords);
-            if (pscf->ssl_passwords == NULL) {
+            if (ngx_ssl_preserve_passwords(cf, pscf->ssl_passwords) != NGX_OK) {
                 return NGX_ERROR;
             }
 

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -1207,8 +1207,7 @@ found:
         }
     }
 
-    conf->passwords = ngx_ssl_preserve_passwords(cf, conf->passwords);
-    if (conf->passwords == NULL) {
+    if (ngx_ssl_preserve_passwords(cf, conf->passwords) != NGX_OK) {
         return NGX_ERROR;
     }
 


### PR DESCRIPTION
This also fixes dynamic loading of password protected certificates via proxy_ssl_certificate and friends. After d791b4a (1.23.1), when upstream SSL context was shared between several locations, only the first one had properly preserved passwords.

There are two commits, so that backward compatible part can be easily merged into stable, if desired.
