### PR TITLE
QUIC: added missing casts in iov_base assignments.

### DIFF
--- a/src/event/quic/ngx_event_quic_output.c
+++ b/src/event/quic/ngx_event_quic_output.c
@@ -411,7 +411,7 @@ ngx_quic_send_segments(ngx_connection_t *c, u_char *buf, size_t len,
     ngx_memzero(msg_control, sizeof(msg_control));
 
     iov.iov_len = len;
-    iov.iov_base = buf;
+    iov.iov_base = (void *) buf;
 
     msg.msg_iov = &iov;
     msg.msg_iovlen = 1;
@@ -699,7 +699,7 @@ ngx_quic_send(ngx_connection_t *c, u_char *buf, size_t len,
     ngx_memzero(&msg, sizeof(struct msghdr));
 
     iov.iov_len = len;
-    iov.iov_base = buf;
+    iov.iov_base = (void *) buf;
 
     msg.msg_iov = &iov;
     msg.msg_iovlen = 1;


### PR DESCRIPTION
This is consistent with the rest of the code and fixes build on systems with non-standard definition of struct iovec (Solaris, Illumos).

```
src/event/quic/ngx_event_quic_output.c: In function 'ngx_quic_send':
src/event/quic/ngx_event_quic_output.c:702:18: error: pointer targets in assignment from 'u_char *' {aka 'unsigned char *'} to 'caddr_t' {aka 'char *'} differ in signedness [-Werror=pointer-sign]
  702 |     iov.iov_base = buf;
      |                  ^
```