### PR TITLE
Use _GNU_SOURCE on glibc-based platforms

### DIFF
--- a/src/os/unix/ngx_posix_config.h
+++ b/src/os/unix/ngx_posix_config.h
@@ -21,10 +21,13 @@
 #endif
 
 
-#if (NGX_GNU_HURD)
+#if defined(NGX_GNU_HURD) || defined(__GLIBC__)
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE             /* accept4() */
 #endif
+#endif
+
+#if (NGX_GNU_HURD)
 #define _FILE_OFFSET_BITS       64
 #endif
 


### PR DESCRIPTION
### Proposed changes

Define _GNU_SOURCE not only on GNU/Hurd, but also other glibc-based platforms including GNU/kFreeBSD.

This patch is used in the Debian NGINX package and is used to make NGINX compilable on the GNU/kFreeBSD architecture.


