### PR TITLE
QUIC: fix quic request block after reload

### DIFF
--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -1111,7 +1111,15 @@ ngx_close_listening_sockets(ngx_cycle_t *cycle)
 
 #if (NGX_QUIC)
         if (ls[i].quic) {
-            continue;
+#if (NGX_HAVE_REUSEPORT)
+            if (ls[i].reuseport) {
+                // close quic reuseport fd unrelated to current worker
+                if (ngx_process == NGX_PROCESS_WORKER && ls[i].worker == ngx_worker) {
+                    continue;
+                }
+            } else
+#endif
+                continue;
         }
 #endif
 

--- a/src/event/quic/ngx_event_quic_connid.h
+++ b/src/event/quic/ngx_event_quic_connid.h
@@ -11,6 +11,20 @@
 #include <ngx_config.h>
 #include <ngx_core.h>
 
+typedef struct {
+    ngx_flag_t            enabled;
+    ngx_uint_t            map_size;
+    int                   worker_map_fd;
+    ngx_queue_t           groups;     /* of ngx_quic_sock_group_t */
+} ngx_quic_bpf_conf_t;
+
+extern ngx_module_t ngx_quic_bpf_module;
+#define ngx_quic_bpf_get_conf(cycle)                                          \
+    (ngx_quic_bpf_conf_t *) ngx_get_conf(cycle->conf_ctx, ngx_quic_bpf_module)
+
+// shuttingdown worker use magic_cid to redirect received new quic conn to new worker.
+// 0x6e67696e78 refers to "nginx".
+#define REDIRECT_WORKER_CID_MAGIC 0x6e67696e78000000ULL
 
 ngx_int_t ngx_quic_handle_retire_connection_id_frame(ngx_connection_t *c,
     ngx_quic_retire_cid_frame_t *f);

--- a/src/event/quic/ngx_event_quic_output.c
+++ b/src/event/quic/ngx_event_quic_output.c
@@ -967,7 +967,7 @@ ngx_quic_send_early_cc(ngx_connection_t *c, ngx_quic_header_t *inpkt,
 
 ngx_int_t
 ngx_quic_send_retry(ngx_connection_t *c, ngx_quic_conf_t *conf,
-    ngx_quic_header_t *inpkt)
+    ngx_quic_header_t *inpkt, ngx_uint_t redirect_worker)
 {
     time_t             expires;
     ssize_t            len;
@@ -1002,6 +1002,13 @@ ngx_quic_send_retry(ngx_connection_t *c, ngx_quic_conf_t *conf,
     if (RAND_bytes(dcid, NGX_QUIC_SERVER_CID_LEN) != 1) {
         return NGX_ERROR;
     }
+
+#if (NGX_QUIC_BPF)
+    if (redirect_worker) {
+        uint64_t tmp_key = REDIRECT_WORKER_CID_MAGIC + ngx_worker;
+        ngx_quic_dcid_encode_key(dcid, tmp_key);
+    }
+#endif
 
     pkt.scid.len = NGX_QUIC_SERVER_CID_LEN;
     pkt.scid.data = dcid;

--- a/src/event/quic/ngx_event_quic_output.h
+++ b/src/event/quic/ngx_event_quic_output.h
@@ -24,7 +24,7 @@ ngx_int_t ngx_quic_send_early_cc(ngx_connection_t *c,
     ngx_quic_header_t *inpkt, ngx_uint_t err, const char *reason);
 
 ngx_int_t ngx_quic_send_retry(ngx_connection_t *c,
-    ngx_quic_conf_t *conf, ngx_quic_header_t *pkt);
+    ngx_quic_conf_t *conf, ngx_quic_header_t *pkt, ngx_uint_t redirect_worker);
 ngx_int_t ngx_quic_send_new_token(ngx_connection_t *c, ngx_quic_path_t *path);
 
 ngx_int_t ngx_quic_send_ack(ngx_connection_t *c,


### PR DESCRIPTION
fixes #425

After nginx reloading, old workers become shuttingdown if there are still in-flight requests, and old quic reuseport socket still open before all shuttingdown workers exit. New quic conn packet received on old quic socket binding to old workers will not be processed, thus new quic request blocked after reload.

To fix this problem:

1. In ngx_close_listening_sockets, close old udp socket unrelated to current worker;
2. In ngx_quic_handle_packet, shutingdown worker send retry packet with routable magic_cid when receive new quic conn;
3. Users need to config _quic_bpf on_ in nginx.conf, to enable quic_bpf redirecting packet with magic_cid to new worker.
4. Users need to config _quic_host_key_ in nginx.conf, to ensure new worker can decrypt retry token.
![fix_reload_blocked](https://github.com/user-attachments/assets/3200f04f-3c63-4929-bbe0-c9aa2c7b2284)

