### PR TITLE
Improve parallel build.

### DIFF
--- a/auto/install
+++ b/auto/install
@@ -8,7 +8,7 @@ if [ $USE_PERL != NO ]; then
     cat << END                                                >> $NGX_MAKEFILE
 
 install_perl_modules:
-	cd $NGX_OBJS/src/http/modules/perl && \$(MAKE) install
+	+cd $NGX_OBJS/src/http/modules/perl && \$(MAKE) install
 END
 
     NGX_INSTALL_PERL_MODULES=install_perl_modules
@@ -199,13 +199,13 @@ done
 cat << END >> Makefile
 
 build:
-	\$(MAKE) -f $NGX_MAKEFILE
+	+\$(MAKE) -f $NGX_MAKEFILE
 
 install:
-	\$(MAKE) -f $NGX_MAKEFILE install
+	+\$(MAKE) -f $NGX_MAKEFILE install
 
 modules:
-	\$(MAKE) -f $NGX_MAKEFILE modules
+	+\$(MAKE) -f $NGX_MAKEFILE modules
 
 upgrade:
 	$NGX_SBIN_PATH -t

--- a/auto/lib/libatomic/make
+++ b/auto/lib/libatomic/make
@@ -11,10 +11,10 @@
     cat << END                                            >> $NGX_MAKEFILE
 
 $NGX_LIBATOMIC/build/lib/libatomic_ops.a:	$NGX_LIBATOMIC/Makefile
-	cd $NGX_LIBATOMIC && \$(MAKE) && \$(MAKE) install
+	+cd $NGX_LIBATOMIC && \$(MAKE) && \$(MAKE) install
 
 $NGX_LIBATOMIC/Makefile:	$NGX_MAKEFILE
-	cd $NGX_LIBATOMIC \\
+	+cd $NGX_LIBATOMIC \\
 	&& if [ -f Makefile ]; then \$(MAKE) distclean; fi \\
 	&& ./configure --prefix=$ngx_prefix
 

--- a/auto/lib/openssl/make
+++ b/auto/lib/openssl/make
@@ -22,7 +22,7 @@ case "$CC" in
         cat << END                                            >> $NGX_MAKEFILE
 
 $OPENSSL/openssl/include/openssl/ssl.h:	$NGX_MAKEFILE
-	\$(MAKE) -f auto/lib/openssl/makefile.msvc			\
+	+\$(MAKE) -f auto/lib/openssl/makefile.msvc			\
 		OPENSSL="$OPENSSL" OPENSSL_OPT="$OPENSSL_OPT"		\
 		OPENSSL_TARGET="$OPENSSL_TARGET"
 
@@ -47,7 +47,7 @@ END
 
 `echo "$OPENSSL\\openssl\\include\\openssl\\ssl.h:	$NGX_MAKEFILE"	\
 	| sed -e "s/\//$ngx_regex_dirsep/g"`
-	\$(MAKE) -f auto/lib/openssl/makefile.bcc $ngx_opt
+	+\$(MAKE) -f auto/lib/openssl/makefile.bcc $ngx_opt
 
 END
 
@@ -62,7 +62,7 @@ END
         cat << END                                            >> $NGX_MAKEFILE
 
 $OPENSSL/.openssl/include/openssl/ssl.h:	$NGX_MAKEFILE
-	cd $OPENSSL \\
+	+cd $OPENSSL \\
 	&& if [ -f Makefile ]; then \$(MAKE) clean; fi \\
 	&& ./config --prefix=$ngx_prefix no-shared no-threads $OPENSSL_OPT \\
 	&& \$(MAKE) \\

--- a/auto/lib/pcre/make
+++ b/auto/lib/pcre/make
@@ -88,13 +88,13 @@ END
 $PCRE/src/pcre2.h:	$PCRE/Makefile
 
 $PCRE/Makefile:	$NGX_MAKEFILE
-	cd $PCRE \\
+	+cd $PCRE \\
 	&& if [ -f Makefile ]; then \$(MAKE) distclean; fi \\
 	&& CC="\$(CC)" CFLAGS="$PCRE_OPT" \\
 	./configure --disable-shared $PCRE_CONF_OPT
 
 $PCRE/.libs/libpcre2-8.a:	$PCRE/Makefile
-	cd $PCRE \\
+	+cd $PCRE \\
 	&& \$(MAKE) libpcre2-8.la
 
 END
@@ -140,10 +140,10 @@ else
 
 `echo "$PCRE/pcre.lib:	$PCRE/pcre.h $NGX_MAKEFILE"			\
 	| sed -e "s/\//$ngx_regex_dirsep/g"`
-	\$(MAKE) -f auto/lib/pcre/$ngx_makefile $ngx_pcre $ngx_opt
+	+\$(MAKE) -f auto/lib/pcre/$ngx_makefile $ngx_pcre $ngx_opt
 
 `echo "$PCRE/pcre.h:" | sed -e "s/\//$ngx_regex_dirsep/g"`
-	\$(MAKE) -f auto/lib/pcre/$ngx_makefile $ngx_pcre pcre.h
+	+\$(MAKE) -f auto/lib/pcre/$ngx_makefile $ngx_pcre pcre.h
 
 END
 
@@ -154,13 +154,13 @@ END
 $PCRE/pcre.h:	$PCRE/Makefile
 
 $PCRE/Makefile:	$NGX_MAKEFILE
-	cd $PCRE \\
+	+cd $PCRE \\
 	&& if [ -f Makefile ]; then \$(MAKE) distclean; fi \\
 	&& CC="\$(CC)" CFLAGS="$PCRE_OPT" \\
 	./configure --disable-shared $PCRE_CONF_OPT
 
 $PCRE/.libs/libpcre.a:	$PCRE/Makefile
-	cd $PCRE \\
+	+cd $PCRE \\
 	&& \$(MAKE) libpcre.la
 
 END

--- a/auto/lib/perl/make
+++ b/auto/lib/perl/make
@@ -12,7 +12,7 @@ $NGX_OBJS/$ngx_perl_module: \\
 		\$(CORE_DEPS) \$(HTTP_DEPS) \\
 		src/http/modules/perl/ngx_http_perl_module.h \\
 		$NGX_OBJS/src/http/modules/perl/Makefile
-	cd $NGX_OBJS/src/http/modules/perl && \$(MAKE)
+	+cd $NGX_OBJS/src/http/modules/perl && \$(MAKE)
 
 	rm -rf $NGX_OBJS/install_perl
 

--- a/auto/lib/zlib/make
+++ b/auto/lib/zlib/make
@@ -42,7 +42,7 @@ case "$NGX_PLATFORM" in
             cat << END                                        >> $NGX_MAKEFILE
 
 `echo "$ZLIB/zlib.lib:	$NGX_MAKEFILE" | sed -e "s/\//$ngx_regex_dirsep/g"`
-	\$(MAKE) -f auto/lib/zlib/$ngx_makefile $ngx_opt $ngx_zlib
+	+\$(MAKE) -f auto/lib/zlib/$ngx_makefile $ngx_opt $ngx_zlib
 
 END
 
@@ -51,7 +51,7 @@ END
             cat << END                                        >> $NGX_MAKEFILE
 
 $ZLIB/libz.a:	$NGX_MAKEFILE
-	cd $ZLIB \\
+	+cd $ZLIB \\
 	&& \$(MAKE) distclean \\
 	&& \$(MAKE) -f win32/Makefile.gcc \\
 		CFLAGS="$ZLIB_OPT" CC="\$(CC)" \\
@@ -74,7 +74,7 @@ END
                 cat << END                                    >> $NGX_MAKEFILE
 
 $ZLIB/libz.a:	$NGX_MAKEFILE
-	cd $ZLIB \\
+	+cd $ZLIB \\
 	&& \$(MAKE) distclean \\
 	&& cp contrib/asm586/match.S . \\
 	&& CFLAGS="$ZLIB_OPT -DASMV" CC="\$(CC)" \\
@@ -91,7 +91,7 @@ END
                 cat << END                                    >> $NGX_MAKEFILE
 
 $ZLIB/libz.a:	$NGX_MAKEFILE
-	cd $ZLIB \\
+	+cd $ZLIB \\
 	&& \$(MAKE) distclean \\
 	&& cp contrib/asm686/match.S . \\
 	&& CFLAGS="$ZLIB_OPT -DASMV" CC="\$(CC)" \\
@@ -124,7 +124,7 @@ if [ $done = NO ]; then
     cat << END                                                >> $NGX_MAKEFILE
 
 $ZLIB/libz.a:	$NGX_MAKEFILE
-	cd $ZLIB \\
+	+cd $ZLIB \\
 	&& \$(MAKE) distclean \\
 	&& CFLAGS="$ZLIB_OPT" CC="\$(CC)" \\
 		./configure \\

--- a/misc/GNUmakefile
+++ b/misc/GNUmakefile
@@ -18,7 +18,7 @@ release: export
 	mv $(TEMP)/$(NGINX)/docs/html $(TEMP)/$(NGINX)
 	mv $(TEMP)/$(NGINX)/docs/man $(TEMP)/$(NGINX)
 
-	$(MAKE) -f docs/GNUmakefile changes
+	+$(MAKE) -f docs/GNUmakefile changes
 
 	rm -r $(TEMP)/$(NGINX)/docs
 	rm -r $(TEMP)/$(NGINX)/misc
@@ -35,7 +35,7 @@ RELEASE:
 	git commit -m nginx-$(VER)-RELEASE
 	git tag -m "release-$(VER) tag" release-$(VER)
 
-	$(MAKE) -f misc/GNUmakefile release
+	+$(MAKE) -f misc/GNUmakefile release
 
 
 win32:
@@ -103,7 +103,7 @@ zip: export
 
 	cp -p $(OBJS)/nginx.exe $(TEMP)/$(NGINX)
 
-	$(MAKE) -f docs/GNUmakefile changes
+	+$(MAKE) -f docs/GNUmakefile changes
 	mv $(TEMP)/$(NGINX)/CHANGES* $(TEMP)/$(NGINX)/docs/
 
 	cp -p $(OBJS)/lib/$(OPENSSL)/LICENSE.txt			\


### PR DESCRIPTION
Adding `+` prefix tells make that the executed command is also make, so it shares the jobserver and improves parallel build.
