### PR TITLE
auto: Fix validation for Windows executables.

### DIFF
--- a/auto/feature
+++ b/auto/feature
@@ -47,7 +47,7 @@ ngx_feature_inc_path=
 eval "/bin/sh -c \"$ngx_test\" >> $NGX_AUTOCONF_ERR 2>&1"
 
 
-if [ -x $NGX_AUTOTEST ]; then
+if [ $? -eq 0 ]; then
 
     case "$ngx_feature_run" in
 


### PR DESCRIPTION
When passing `-o $NGX_AUTOTEST`, gcc actually creates `$NGX_AUTOTEST.exe`, so testing by the original filename fails.

Just check for success on the compiler invocation instead.