### PR TITLE
Core: fix build without libcrypt

### DIFF
--- a/auto/unix
+++ b/auto/unix
@@ -150,7 +150,7 @@ fi
 
 
 ngx_feature="crypt()"
-ngx_feature_name=
+ngx_feature_name="NGX_HAVE_CRYPT"
 ngx_feature_run=no
 ngx_feature_incs=
 ngx_feature_path=
@@ -162,7 +162,7 @@ ngx_feature_test="crypt(\"test\", \"salt\");"
 if [ $ngx_found = no ]; then
 
     ngx_feature="crypt() in libcrypt"
-    ngx_feature_name=
+    ngx_feature_name="NGX_HAVE_CRYPT"
     ngx_feature_run=no
     ngx_feature_incs=
     ngx_feature_path=

--- a/src/os/unix/ngx_linux_config.h
+++ b/src/os/unix/ngx_linux_config.h
@@ -52,13 +52,17 @@
 #include <malloc.h>             /* memalign() */
 #include <limits.h>             /* IOV_MAX */
 #include <sys/ioctl.h>
-#include <crypt.h>
 #include <sys/utsname.h>        /* uname() */
 
 #include <dlfcn.h>
 
 
 #include <ngx_auto_config.h>
+
+
+#if (NGX_HAVE_CRYPT_H)
+#include <crypt.h>
+#endif
 
 
 #if (NGX_HAVE_POSIX_SEM)

--- a/src/os/unix/ngx_user.c
+++ b/src/os/unix/ngx_user.c
@@ -41,7 +41,7 @@ ngx_libc_crypt(ngx_pool_t *pool, u_char *key, u_char *salt, u_char **encrypted)
     return NGX_ERROR;
 }
 
-#else
+#elif (NGX_HAVE_CRYPT)
 
 ngx_int_t
 ngx_libc_crypt(ngx_pool_t *pool, u_char *key, u_char *salt, u_char **encrypted)
@@ -68,6 +68,14 @@ ngx_libc_crypt(ngx_pool_t *pool, u_char *key, u_char *salt, u_char **encrypted)
 
     ngx_log_error(NGX_LOG_CRIT, pool->log, err, "crypt() failed");
 
+    return NGX_ERROR;
+}
+
+#else
+
+ngx_int_t
+ngx_libc_crypt(ngx_pool_t *pool, u_char *key, u_char *salt, u_char **encrypted)
+{
     return NGX_ERROR;
 }
 


### PR DESCRIPTION
libcrypt is no longer part of glibc, so it might not be available.

Source: https://mailman.nginx.org/pipermail/nginx-devel/2024-February/U6NVHU7OSALXTJ65MTY2M5GNNWD7UA7U.html