### PR TITLE
Support accepting PCRE_CONF_OPT from env variable.

### DIFF
--- a/auto/options
+++ b/auto/options
@@ -148,7 +148,8 @@ NGX_COMPAT=NO
 USE_PCRE=NO
 PCRE=NONE
 PCRE_OPT=
-PCRE_CONF_OPT=
+# Intentionally commented out to allow external flags to be passed
+#PCRE_CONF_OPT=
 PCRE_JIT=NO
 PCRE2=YES
 


### PR DESCRIPTION
Needed for cross-compilation. Example:
```
PCRE_CONF_OPT="--host aarch64-none-linux-gnu-"
```
