### PR TITLE
Configure: MSVC compatibility with PCRE2 10.45.

### DIFF
--- a/auto/lib/pcre/make
+++ b/auto/lib/pcre/make
@@ -37,6 +37,7 @@ if [ $PCRE_LIBRARY = PCRE2 ]; then
                        pcre2_xclass.c"
 
         ngx_pcre_test="pcre2_chkdint.c \
+                       pcre2_compile_class.c \
                        pcre2_convert.c \
                        pcre2_extuni.c \
                        pcre2_find_bracket.c \


### PR DESCRIPTION
### Proposed changes

this allows to build with the latest PCRE 2 10.45 on windows.