### PR TITLE
SSL: workaround for saving big sessions from upstream servers

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -4034,12 +4034,12 @@ ngx_ssl_get_cached_session(ngx_ssl_conn_t *ssl_conn,
     const u_char             *p;
     ngx_shm_zone_t           *shm_zone;
     ngx_slab_pool_t          *shpool;
+    ngx_connection_t         *c;
     ngx_rbtree_node_t        *node, *sentinel;
     ngx_ssl_session_t        *sess;
     ngx_ssl_sess_id_t        *sess_id;
     ngx_ssl_session_cache_t  *cache;
     u_char                    buf[NGX_SSL_MAX_SESSION_SIZE];
-    ngx_connection_t         *c;
 
     hash = ngx_crc32_short((u_char *) (uintptr_t) id, (size_t) len);
     *copy = 0;

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -362,4 +362,7 @@ extern int  ngx_ssl_index;
 extern int  ngx_ssl_certificate_name_index;
 
 
+extern u_char  ngx_ssl_session_buffer[NGX_SSL_MAX_SESSION_SIZE];
+
+
 #endif /* _NGX_EVENT_OPENSSL_H_INCLUDED_ */

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -142,7 +142,7 @@ struct ngx_ssl_connection_s {
 #define NGX_SSL_DFLT_BUILTIN_SCACHE  -5
 
 
-#define NGX_SSL_MAX_SESSION_SIZE  4096
+#define NGX_SSL_MAX_SESSION_SIZE  8192
 
 typedef struct ngx_ssl_sess_id_s  ngx_ssl_sess_id_t;
 

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -878,7 +878,6 @@ ngx_http_upstream_set_round_robin_peer_session(ngx_peer_connection_t *pc,
     int                            len;
     const u_char                  *p;
     ngx_http_upstream_rr_peers_t  *peers;
-    u_char                         buf[NGX_SSL_MAX_SESSION_SIZE];
 #endif
 
     peer = rrp->current;
@@ -898,12 +897,12 @@ ngx_http_upstream_set_round_robin_peer_session(ngx_peer_connection_t *pc,
 
         len = peer->ssl_session_len;
 
-        ngx_memcpy(buf, peer->ssl_session, len);
+        ngx_memcpy(ngx_ssl_session_buffer, peer->ssl_session, len);
 
         ngx_http_upstream_rr_peer_unlock(peers, peer);
         ngx_http_upstream_rr_peers_unlock(peers);
 
-        p = buf;
+        p = ngx_ssl_session_buffer;
         ssl_session = d2i_SSL_SESSION(NULL, &p, len);
 
         rc = ngx_ssl_set_session(pc->connection, ssl_session);
@@ -940,7 +939,6 @@ ngx_http_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
     int                            len;
     u_char                        *p;
     ngx_http_upstream_rr_peers_t  *peers;
-    u_char                         buf[NGX_SSL_MAX_SESSION_SIZE];
 #endif
 
 #if (NGX_HTTP_UPSTREAM_ZONE)
@@ -965,7 +963,7 @@ ngx_http_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
             return;
         }
 
-        p = buf;
+        p = ngx_ssl_session_buffer;
         (void) i2d_SSL_SESSION(ssl_session, &p);
 
         peer = rrp->current;
@@ -995,7 +993,7 @@ ngx_http_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
             peer->ssl_session_len = len;
         }
 
-        ngx_memcpy(peer->ssl_session, buf, len);
+        ngx_memcpy(peer->ssl_session, ngx_ssl_session_buffer, len);
 
         ngx_http_upstream_rr_peer_unlock(peers, peer);
         ngx_http_upstream_rr_peers_unlock(peers);

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -1021,8 +1021,6 @@ ngx_http_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                        "old session: %p", old_ssl_session);
 
-        /* TODO: may block */
-
         ngx_ssl_free_session(old_ssl_session);
     }
 }

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -952,10 +952,10 @@ ngx_http_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
             return;
         }
 
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                       "save session: %p", ssl_session);
-
         len = i2d_SSL_SESSION(ssl_session, NULL);
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                       "save session: %p:%d", ssl_session, len);
 
         /* do not cache too big session */
 

--- a/src/stream/ngx_stream_upstream_round_robin.c
+++ b/src/stream/ngx_stream_upstream_round_robin.c
@@ -911,7 +911,6 @@ ngx_stream_upstream_set_round_robin_peer_session(ngx_peer_connection_t *pc,
     int                              len;
     const u_char                    *p;
     ngx_stream_upstream_rr_peers_t  *peers;
-    u_char                           buf[NGX_SSL_MAX_SESSION_SIZE];
 #endif
 
     peer = rrp->current;
@@ -931,12 +930,12 @@ ngx_stream_upstream_set_round_robin_peer_session(ngx_peer_connection_t *pc,
 
         len = peer->ssl_session_len;
 
-        ngx_memcpy(buf, peer->ssl_session, len);
+        ngx_memcpy(ngx_ssl_session_buffer, peer->ssl_session, len);
 
         ngx_stream_upstream_rr_peer_unlock(peers, peer);
         ngx_stream_upstream_rr_peers_unlock(peers);
 
-        p = buf;
+        p = ngx_ssl_session_buffer;
         ssl_session = d2i_SSL_SESSION(NULL, &p, len);
 
         rc = ngx_ssl_set_session(pc->connection, ssl_session);
@@ -973,7 +972,6 @@ ngx_stream_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
     int                              len;
     u_char                          *p;
     ngx_stream_upstream_rr_peers_t  *peers;
-    u_char                           buf[NGX_SSL_MAX_SESSION_SIZE];
 #endif
 
 #if (NGX_STREAM_UPSTREAM_ZONE)
@@ -998,7 +996,7 @@ ngx_stream_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
             return;
         }
 
-        p = buf;
+        p = ngx_ssl_session_buffer;
         (void) i2d_SSL_SESSION(ssl_session, &p);
 
         peer = rrp->current;
@@ -1028,7 +1026,7 @@ ngx_stream_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
             peer->ssl_session_len = len;
         }
 
-        ngx_memcpy(peer->ssl_session, buf, len);
+        ngx_memcpy(peer->ssl_session, ngx_ssl_session_buffer, len);
 
         ngx_stream_upstream_rr_peer_unlock(peers, peer);
         ngx_stream_upstream_rr_peers_unlock(peers);

--- a/src/stream/ngx_stream_upstream_round_robin.c
+++ b/src/stream/ngx_stream_upstream_round_robin.c
@@ -985,10 +985,10 @@ ngx_stream_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
             return;
         }
 
-        ngx_log_debug1(NGX_LOG_DEBUG_STREAM, pc->log, 0,
-                       "save session: %p", ssl_session);
-
         len = i2d_SSL_SESSION(ssl_session, NULL);
+
+        ngx_log_debug2(NGX_LOG_DEBUG_STREAM, pc->log, 0,
+                       "save session: %p:%d", ssl_session, len);
 
         /* do not cache too big session */
 

--- a/src/stream/ngx_stream_upstream_round_robin.c
+++ b/src/stream/ngx_stream_upstream_round_robin.c
@@ -1054,8 +1054,6 @@ ngx_stream_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
         ngx_log_debug1(NGX_LOG_DEBUG_STREAM, pc->log, 0,
                        "old session: %p", old_ssl_session);
 
-        /* TODO: may block */
-
         ngx_ssl_free_session(old_ssl_session);
     }
 }


### PR DESCRIPTION
This series implements a workaround for JDK servers, and related commits.

For JDK internals, see [SSLSessionImpl.java](https://github.com/openjdk/jdk/commit/94e1d7530ff#diff-4470a44ff1ce93434aa6703abb4e6315ae6199cfe04e7ab85f76bc76f197942e) in https://github.com/openjdk/jdk/commit/94e1d7530ff