### PR TITLE
mail auth: Add Client-Port

### DIFF
--- a/src/mail/ngx_mail_auth_http_module.c
+++ b/src/mail/ngx_mail_auth_http_module.c
@@ -1244,6 +1244,7 @@ ngx_mail_auth_http_create_request(ngx_mail_session_t *s, ngx_pool_t *pool,
           + sizeof("Client-IP: ") - 1 + s->connection->addr_text.len
                 + sizeof(CRLF) - 1
           + sizeof("Client-Host: ") - 1 + s->host.len + sizeof(CRLF) - 1
+          + sizeof("Client-Port: ") - 1 + sizeof("65535") - 1 + sizeof(CRLF) - 1
           + ahcf->header.len
           + sizeof(CRLF) - 1;
 
@@ -1341,6 +1342,9 @@ ngx_mail_auth_http_create_request(ngx_mail_session_t *s, ngx_pool_t *pool,
     b->last = ngx_copy(b->last, s->connection->addr_text.data,
                        s->connection->addr_text.len);
     *b->last++ = CR; *b->last++ = LF;
+
+    b->last = ngx_sprintf(b->last, "Client-Port: %ui" CRLF,
+                          ngx_inet_get_port(c->sockaddr));
 
     if (s->host.len) {
         b->last = ngx_cpymem(b->last, "Client-Host: ",


### PR DESCRIPTION
### Proposed changes

Describe the use case and detail of the change.

#205 

When mail proxy with auth asks the HTTP server for authentication, it can add Client-Port in the request headers.

It can be observed `tcpdump` during test which is executed by prove [./mail_smtp.t ](https://github.com/nginx/nginx-tests/blob/master/mail_smtp.t) as below.

```
sudo tcpdump -i lo -A dst port 8080

GET /mail/auth HTTP/1.0
Host: 127.0.0.1
Auth-Method: none
Auth-User:
Auth-Pass:
Auth-Protocol: smtp
Auth-Login-Attempt: 1
Client-IP: 127.0.0.1
Client-Port: 46500
Client-Host: [UNAVAILABLE]
Auth-SMTP-Helo: example.com
Auth-SMTP-From: MAIL FROM:<test@example.com> SIZE=100
Auth-SMTP-To: RCPT TO:<example.com>
```

If this pull request addresses an issue on GitHub, make sure to reference that
issue using one of the
[supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).

Before creating a pull request, make sure to comply with the
[Contributing Guidelines](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md).
