### PR TITLE
Fix runtime errors: "Run-time Check Failure" in x64 generated executa…

### DIFF
--- a/src/event/modules/ngx_iocp_module.c
+++ b/src/event/modules/ngx_iocp_module.c
@@ -235,7 +235,11 @@ static ngx_int_t
 ngx_iocp_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
 {
     int                rc;
+#ifdef _WIN64
+    u_int64            key;
+#else
     u_int              key;
+#endif
     u_long             bytes;
     ngx_err_t          err;
     ngx_msec_t         delta;


### PR DESCRIPTION
After nginx.exe is generated on Windows x64 and started using the ngx_iocp_module event module, the worker process pops up a runtime error dialog and terminates the process when a new TCP connection is established with the following message: **Run-time Check Failure #2 - Stack arount the variable 'key' was corrupted**.

The reason for this is that the third parameter of the GetQueuedCompletionStatus interface, **key**, is of type PULONG_PTR, which on Win32 platforms is **unsigned long** (32-bit), while on x64 platforms this should be **unsigned long long** (64-bit). So the type of the key variable should be differentiated for different compilation platforms.
