### PR TITLE
SSL: signature variables $ssl_sigalg and $ssl_client_sigalg

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5882,7 +5882,7 @@ ngx_ssl_get_sigalg(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 
 
 ngx_int_t
-ngx_ssl_get_peer_sigalg(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+ngx_ssl_get_client_sigalg(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 {
     int         nid;
     int         rc;

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5881,6 +5881,40 @@ ngx_ssl_get_sigalg(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 }
 
 
+ngx_int_t
+ngx_ssl_get_peer_sigalg(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+{
+    int         nid;
+    int         rc;
+    const char *sn;
+
+    rc = SSL_get_peer_signature_type_nid(c->ssl->connection, &nid);
+
+    if (rc && nid != NID_undef) {
+        sn = OBJ_nid2sn(nid);
+        if (sn == NULL) {
+            s->len = sizeof("0x0000") - 1;
+
+            s->data = ngx_pnalloc(pool, s->len);
+            if (s->data == NULL) {
+                return NGX_ERROR;
+            }
+
+            ngx_sprintf(s->data, "0x%04xd", nid & 0xffff);
+
+            return NGX_OK;
+        }
+
+        s->len = ngx_strlen(sn);
+        s->data = (u_char *) sn;
+        return NGX_OK;
+    }
+
+    s->len = 0;
+    return NGX_OK;
+}
+
+
 static time_t
 ngx_ssl_parse_time(
 #if OPENSSL_VERSION_NUMBER > 0x10100000L

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5847,6 +5847,40 @@ ngx_ssl_get_client_v_remain(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 }
 
 
+ngx_int_t
+ngx_ssl_get_sigalg(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+{
+    int         nid;
+    int         rc;
+    const char *sn;
+
+    rc = SSL_get_signature_type_nid(c->ssl->connection, &nid);
+
+    if (rc && nid != NID_undef) {
+        sn = OBJ_nid2sn(nid);
+        if (sn == NULL) {
+            s->len = sizeof("0x0000") - 1;
+
+            s->data = ngx_pnalloc(pool, s->len);
+            if (s->data == NULL) {
+                return NGX_ERROR;
+            }
+
+            ngx_sprintf(s->data, "0x%04xd", nid & 0xffff);
+
+            return NGX_OK;
+        }
+
+        s->len = ngx_strlen(sn);
+        s->data = (u_char *) sn;
+        return NGX_OK;
+    }
+
+    s->len = 0;
+    return NGX_OK;
+}
+
+
 static time_t
 ngx_ssl_parse_time(
 #if OPENSSL_VERSION_NUMBER > 0x10100000L

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -337,6 +337,8 @@ ngx_int_t ngx_ssl_get_client_v_remain(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_sigalg(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
+ngx_int_t ngx_ssl_get_peer_sigalg(ngx_connection_t *c, ngx_pool_t *pool,
+    ngx_str_t *s);
 
 
 ngx_int_t ngx_ssl_handshake(ngx_connection_t *c);

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -299,6 +299,8 @@ ngx_int_t ngx_ssl_get_curve(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_curves(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
+ngx_int_t ngx_ssl_get_sigalg(ngx_connection_t *c, ngx_pool_t *pool,
+    ngx_str_t *s);
 ngx_int_t ngx_ssl_get_session_id(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_session_reused(ngx_connection_t *c, ngx_pool_t *pool,
@@ -335,9 +337,7 @@ ngx_int_t ngx_ssl_get_client_v_end(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_client_v_remain(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
-ngx_int_t ngx_ssl_get_sigalg(ngx_connection_t *c, ngx_pool_t *pool,
-    ngx_str_t *s);
-ngx_int_t ngx_ssl_get_peer_sigalg(ngx_connection_t *c, ngx_pool_t *pool,
+ngx_int_t ngx_ssl_get_client_sigalg(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 
 

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -335,6 +335,8 @@ ngx_int_t ngx_ssl_get_client_v_end(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_client_v_remain(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
+ngx_int_t ngx_ssl_get_sigalg(ngx_connection_t *c, ngx_pool_t *pool,
+    ngx_str_t *s);
 
 
 ngx_int_t ngx_ssl_handshake(ngx_connection_t *c);

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -411,6 +411,9 @@ static ngx_http_variable_t  ngx_http_ssl_vars[] = {
     { ngx_string("ssl_sigalg"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_sigalg, NGX_HTTP_VAR_CHANGEABLE, 0 },
 
+    { ngx_string("ssl_peer_sigalg"), NULL, ngx_http_ssl_variable,
+      (uintptr_t) ngx_ssl_get_peer_sigalg, NGX_HTTP_VAR_CHANGEABLE, 0 },
+
       ngx_http_null_variable
 };
 

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -408,6 +408,9 @@ static ngx_http_variable_t  ngx_http_ssl_vars[] = {
     { ngx_string("ssl_client_v_remain"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_client_v_remain, NGX_HTTP_VAR_CHANGEABLE, 0 },
 
+    { ngx_string("ssl_sigalg"), NULL, ngx_http_ssl_variable,
+      (uintptr_t) ngx_ssl_get_sigalg, NGX_HTTP_VAR_CHANGEABLE, 0 },
+
       ngx_http_null_variable
 };
 

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -411,8 +411,8 @@ static ngx_http_variable_t  ngx_http_ssl_vars[] = {
     { ngx_string("ssl_sigalg"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_sigalg, NGX_HTTP_VAR_CHANGEABLE, 0 },
 
-    { ngx_string("ssl_peer_sigalg"), NULL, ngx_http_ssl_variable,
-      (uintptr_t) ngx_ssl_get_peer_sigalg, NGX_HTTP_VAR_CHANGEABLE, 0 },
+    { ngx_string("ssl_client_sigalg"), NULL, ngx_http_ssl_variable,
+      (uintptr_t) ngx_ssl_get_client_sigalg, NGX_HTTP_VAR_CHANGEABLE, 0 },
 
       ngx_http_null_variable
 };

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -397,6 +397,9 @@ static ngx_stream_variable_t  ngx_stream_ssl_vars[] = {
     { ngx_string("ssl_client_v_remain"), NULL, ngx_stream_ssl_variable,
       (uintptr_t) ngx_ssl_get_client_v_remain, NGX_STREAM_VAR_CHANGEABLE, 0 },
 
+    { ngx_string("ssl_sigalg"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_sigalg, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
       ngx_stream_null_variable
 };
 

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -400,8 +400,8 @@ static ngx_stream_variable_t  ngx_stream_ssl_vars[] = {
     { ngx_string("ssl_sigalg"), NULL, ngx_stream_ssl_variable,
       (uintptr_t) ngx_ssl_get_sigalg, NGX_STREAM_VAR_CHANGEABLE, 0 },
 
-    { ngx_string("ssl_peer_sigalg"), NULL, ngx_stream_ssl_variable,
-      (uintptr_t) ngx_ssl_get_peer_sigalg, NGX_STREAM_VAR_CHANGEABLE, 0 },
+    { ngx_string("ssl_client_sigalg"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_client_sigalg, NGX_STREAM_VAR_CHANGEABLE, 0 },
 
       ngx_stream_null_variable
 };

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -400,6 +400,9 @@ static ngx_stream_variable_t  ngx_stream_ssl_vars[] = {
     { ngx_string("ssl_sigalg"), NULL, ngx_stream_ssl_variable,
       (uintptr_t) ngx_ssl_get_sigalg, NGX_STREAM_VAR_CHANGEABLE, 0 },
 
+    { ngx_string("ssl_peer_sigalg"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_peer_sigalg, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
       ngx_stream_null_variable
 };
 


### PR DESCRIPTION
### Proposed changes

feature: #554 

* Add $ssl_sigalg variable to get signature algorithm used for signing messages during tls handshake

* Add $ssl_peer_sigalg variable to get signature algorithm the peer used for signing messages during tls handshake

* we can use both of them in log to know more details about the tls handshake