### PR TITLE
Slice filter: improved memory allocation error handling.

### DIFF
--- a/src/http/modules/ngx_http_slice_filter_module.c
+++ b/src/http/modules/ngx_http_slice_filter_module.c
@@ -419,12 +419,12 @@ ngx_http_slice_range_variable(ngx_http_request_t *r,
             return NGX_ERROR;
         }
 
-        ngx_http_set_ctx(r, ctx, ngx_http_slice_filter_module);
-
         p = ngx_pnalloc(r->pool, sizeof("bytes=-") - 1 + 2 * NGX_OFF_T_LEN);
         if (p == NULL) {
             return NGX_ERROR;
         }
+
+        ngx_http_set_ctx(r, ctx, ngx_http_slice_filter_module);
 
         ctx->start = slcf->size * (ngx_http_slice_get_start(r) / slcf->size);
 


### PR DESCRIPTION
As uncovered by recent addition in slice.t, a partially initialized context, coupled with HTTP 206 response from stub backend, might be accessed in the next slice subrequest.

Found by bad memory allocator simulation.
