### PR TITLE
Charset filter: improved validation of charset_map with utf-8.

### DIFF
--- a/src/http/modules/ngx_http_charset_filter_module.c
+++ b/src/http/modules/ngx_http_charset_filter_module.c
@@ -1332,6 +1332,12 @@ ngx_http_charset_map(ngx_conf_t *cf, ngx_command_t *dummy, void *conf)
     table = ctx->table;
 
     if (ctx->charset->utf8) {
+        if (value[1].len / 2 > NGX_UTF_LEN - 1) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "invalid value \"%V\"", &value[1]);
+            return NGX_CONF_ERROR;
+        }
+
         p = &table->src2dst[src * NGX_UTF_LEN];
 
         *p++ = (u_char) (value[1].len / 2);


### PR DESCRIPTION
It was possible to write outside of the buffer boundary used to keep UTF-8 decoded values when parsing conversion table configuration.

As it happens before UTF-8 decoding, the fix is to check in advance if character codes are of more than 3-byte sequence.  Note that this is already enforced later by checking ngx_utf8_decode() decoded values for 0xffff, which corresponds to the maximum value encoded as a valid 3-byte sequence, so the fix should not result in functional changes.

Found with AddressSanitizer.
Fixes GitHub issue #529.
