### PR TITLE
HTTP: support regex ssl_servername while request multiplex in mtls

### DIFF
--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -2288,6 +2288,16 @@ ngx_http_set_virtual_server(ngx_http_request_t *r, ngx_str_t *host)
             }
 #endif
             return NGX_OK;
+        } else {
+            
+#if (NGX_PCRE)
+            if (hc->ssl_servername_regex
+                && ngx_http_regex_exec(r, hc->ssl_servername_regex,
+                                          host) == NGX_OK)
+            {
+                return NGX_OK;
+            }
+#endif
         }
     }
 


### PR DESCRIPTION
### Proposed changes

support regex ssl_servername while request multiplext and verify client

server block like:

> 

    server {
        listen       443 ssl;

        server_name  ~.*test.com;
        ssl_certificate     server.crt;
        ssl_certificate_key  server.key;
        ssl_trusted_certificate server_intermediate.crt;
        ssl_verify_client on;
        ssl_client_certificate client_intermediate.crt;

        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
        ssl_ciphers ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP;
        http2        on;

        ssl_session_cache    shared:SSL:1m;
        ssl_session_timeout  5m;
        ssl_prefer_server_ciphers  on;

        location / {
                proxy_buffers 16 4k;
                proxy_buffer_size 2k;
                proxy_set_header Connection "";
                proxy_pass http://test/;
        }
    }


It will return *421 Misdirected Request* while `curl https://a.test.com -H 'Host: b.test.com'`.
This situation will be obvious when http2 multiplexing.

So I proposed this PR, intending to release requests that match the SSL servername regex during http2 multiplexing.
