### PR TITLE
Add 52 bytes to special responses supporting updated accessibility

### DIFF
--- a/src/http/ngx_http_special_response.c
+++ b/src/http/ngx_http_special_response.c
@@ -59,7 +59,10 @@ static u_char ngx_http_msie_refresh_tail[] =
 
 static char ngx_http_error_301_page[] =
 "<html>" CRLF
-"<head><title>301 Moved Permanently</title></head>" CRLF
+"<head>" CRLF
+"<title>301 Moved Permanently</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>301 Moved Permanently</h1></center>" CRLF
 ;
@@ -67,7 +70,10 @@ static char ngx_http_error_301_page[] =
 
 static char ngx_http_error_302_page[] =
 "<html>" CRLF
-"<head><title>302 Found</title></head>" CRLF
+"<head>" CRLF
+"<title>302 Found</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>302 Found</h1></center>" CRLF
 ;
@@ -75,7 +81,10 @@ static char ngx_http_error_302_page[] =
 
 static char ngx_http_error_303_page[] =
 "<html>" CRLF
-"<head><title>303 See Other</title></head>" CRLF
+"<head>" CRLF
+"<title>303 See Other</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>303 See Other</h1></center>" CRLF
 ;
@@ -83,7 +92,10 @@ static char ngx_http_error_303_page[] =
 
 static char ngx_http_error_307_page[] =
 "<html>" CRLF
-"<head><title>307 Temporary Redirect</title></head>" CRLF
+"<head>" CRLF
+"<title>307 Temporary Redirect</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>307 Temporary Redirect</h1></center>" CRLF
 ;
@@ -91,7 +103,10 @@ static char ngx_http_error_307_page[] =
 
 static char ngx_http_error_308_page[] =
 "<html>" CRLF
-"<head><title>308 Permanent Redirect</title></head>" CRLF
+"<head>" CRLF
+"<title>308 Permanent Redirect</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>308 Permanent Redirect</h1></center>" CRLF
 ;
@@ -99,7 +114,10 @@ static char ngx_http_error_308_page[] =
 
 static char ngx_http_error_400_page[] =
 "<html>" CRLF
-"<head><title>400 Bad Request</title></head>" CRLF
+"<head>" CRLF
+"<title>400 Bad Request</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>400 Bad Request</h1></center>" CRLF
 ;
@@ -107,7 +125,10 @@ static char ngx_http_error_400_page[] =
 
 static char ngx_http_error_401_page[] =
 "<html>" CRLF
-"<head><title>401 Authorization Required</title></head>" CRLF
+"<head>" CRLF
+"<title>401 Authorization Required</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>401 Authorization Required</h1></center>" CRLF
 ;
@@ -115,7 +136,10 @@ static char ngx_http_error_401_page[] =
 
 static char ngx_http_error_402_page[] =
 "<html>" CRLF
-"<head><title>402 Payment Required</title></head>" CRLF
+"<head>" CRLF
+"<title>402 Payment Required</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>402 Payment Required</h1></center>" CRLF
 ;
@@ -123,7 +147,10 @@ static char ngx_http_error_402_page[] =
 
 static char ngx_http_error_403_page[] =
 "<html>" CRLF
-"<head><title>403 Forbidden</title></head>" CRLF
+"<head>" CRLF
+"<title>403 Forbidden</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>403 Forbidden</h1></center>" CRLF
 ;
@@ -131,7 +158,10 @@ static char ngx_http_error_403_page[] =
 
 static char ngx_http_error_404_page[] =
 "<html>" CRLF
-"<head><title>404 Not Found</title></head>" CRLF
+"<head>" CRLF
+"<title>404 Not Found</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>404 Not Found</h1></center>" CRLF
 ;
@@ -139,7 +169,10 @@ static char ngx_http_error_404_page[] =
 
 static char ngx_http_error_405_page[] =
 "<html>" CRLF
-"<head><title>405 Not Allowed</title></head>" CRLF
+"<head>" CRLF
+"<title>405 Not Allowed</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>405 Not Allowed</h1></center>" CRLF
 ;
@@ -147,7 +180,10 @@ static char ngx_http_error_405_page[] =
 
 static char ngx_http_error_406_page[] =
 "<html>" CRLF
-"<head><title>406 Not Acceptable</title></head>" CRLF
+"<head>" CRLF
+"<title>406 Not Acceptable</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>406 Not Acceptable</h1></center>" CRLF
 ;
@@ -155,7 +191,10 @@ static char ngx_http_error_406_page[] =
 
 static char ngx_http_error_408_page[] =
 "<html>" CRLF
-"<head><title>408 Request Time-out</title></head>" CRLF
+"<head>" CRLF
+"<title>408 Request Time-out</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>408 Request Time-out</h1></center>" CRLF
 ;
@@ -163,7 +202,10 @@ static char ngx_http_error_408_page[] =
 
 static char ngx_http_error_409_page[] =
 "<html>" CRLF
-"<head><title>409 Conflict</title></head>" CRLF
+"<head>" CRLF
+"<title>409 Conflict</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>409 Conflict</h1></center>" CRLF
 ;
@@ -171,7 +213,10 @@ static char ngx_http_error_409_page[] =
 
 static char ngx_http_error_410_page[] =
 "<html>" CRLF
-"<head><title>410 Gone</title></head>" CRLF
+"<head>" CRLF
+"<title>410 Gone</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>410 Gone</h1></center>" CRLF
 ;
@@ -179,7 +224,10 @@ static char ngx_http_error_410_page[] =
 
 static char ngx_http_error_411_page[] =
 "<html>" CRLF
-"<head><title>411 Length Required</title></head>" CRLF
+"<head>" CRLF
+"<title>411 Length Required</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>411 Length Required</h1></center>" CRLF
 ;
@@ -187,7 +235,10 @@ static char ngx_http_error_411_page[] =
 
 static char ngx_http_error_412_page[] =
 "<html>" CRLF
-"<head><title>412 Precondition Failed</title></head>" CRLF
+"<head>" CRLF
+"<title>412 Precondition Failed</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>412 Precondition Failed</h1></center>" CRLF
 ;
@@ -195,7 +246,10 @@ static char ngx_http_error_412_page[] =
 
 static char ngx_http_error_413_page[] =
 "<html>" CRLF
-"<head><title>413 Request Entity Too Large</title></head>" CRLF
+"<head>" CRLF
+"<title>413 Request Entity Too Large</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>413 Request Entity Too Large</h1></center>" CRLF
 ;
@@ -203,7 +257,10 @@ static char ngx_http_error_413_page[] =
 
 static char ngx_http_error_414_page[] =
 "<html>" CRLF
-"<head><title>414 Request-URI Too Large</title></head>" CRLF
+"<head>" CRLF
+"<title>414 Request-URI Too Large</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>414 Request-URI Too Large</h1></center>" CRLF
 ;
@@ -211,7 +268,10 @@ static char ngx_http_error_414_page[] =
 
 static char ngx_http_error_415_page[] =
 "<html>" CRLF
-"<head><title>415 Unsupported Media Type</title></head>" CRLF
+"<head>" CRLF
+"<title>415 Unsupported Media Type</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>415 Unsupported Media Type</h1></center>" CRLF
 ;
@@ -219,7 +279,10 @@ static char ngx_http_error_415_page[] =
 
 static char ngx_http_error_416_page[] =
 "<html>" CRLF
-"<head><title>416 Requested Range Not Satisfiable</title></head>" CRLF
+"<head>" CRLF
+"<title>416 Requested Range Not Satisfiable</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>416 Requested Range Not Satisfiable</h1></center>" CRLF
 ;
@@ -227,7 +290,10 @@ static char ngx_http_error_416_page[] =
 
 static char ngx_http_error_421_page[] =
 "<html>" CRLF
-"<head><title>421 Misdirected Request</title></head>" CRLF
+"<head>" CRLF
+"<title>421 Misdirected Request</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>421 Misdirected Request</h1></center>" CRLF
 ;
@@ -235,7 +301,10 @@ static char ngx_http_error_421_page[] =
 
 static char ngx_http_error_429_page[] =
 "<html>" CRLF
-"<head><title>429 Too Many Requests</title></head>" CRLF
+"<head>" CRLF
+"<title>429 Too Many Requests</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>429 Too Many Requests</h1></center>" CRLF
 ;
@@ -243,8 +312,10 @@ static char ngx_http_error_429_page[] =
 
 static char ngx_http_error_494_page[] =
 "<html>" CRLF
-"<head><title>400 Request Header Or Cookie Too Large</title></head>"
-CRLF
+"<head>" CRLF
+"<title>400 Request Header Or Cookie Too Large</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>400 Bad Request</h1></center>" CRLF
 "<center>Request Header Or Cookie Too Large</center>" CRLF
@@ -253,8 +324,10 @@ CRLF
 
 static char ngx_http_error_495_page[] =
 "<html>" CRLF
-"<head><title>400 The SSL certificate error</title></head>"
-CRLF
+"<head>" CRLF
+"<title>400 The SSL certificate error</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>400 Bad Request</h1></center>" CRLF
 "<center>The SSL certificate error</center>" CRLF
@@ -263,8 +336,10 @@ CRLF
 
 static char ngx_http_error_496_page[] =
 "<html>" CRLF
-"<head><title>400 No required SSL certificate was sent</title></head>"
-CRLF
+"<head>" CRLF
+"<title>400 No required SSL certificate was sent</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>400 Bad Request</h1></center>" CRLF
 "<center>No required SSL certificate was sent</center>" CRLF
@@ -273,8 +348,10 @@ CRLF
 
 static char ngx_http_error_497_page[] =
 "<html>" CRLF
-"<head><title>400 The plain HTTP request was sent to HTTPS port</title></head>"
-CRLF
+"<head>" CRLF
+"<title>400 The plain HTTP request was sent to HTTPS port</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>400 Bad Request</h1></center>" CRLF
 "<center>The plain HTTP request was sent to HTTPS port</center>" CRLF
@@ -283,7 +360,10 @@ CRLF
 
 static char ngx_http_error_500_page[] =
 "<html>" CRLF
-"<head><title>500 Internal Server Error</title></head>" CRLF
+"<head>" CRLF
+"<title>500 Internal Server Error</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>500 Internal Server Error</h1></center>" CRLF
 ;
@@ -291,7 +371,10 @@ static char ngx_http_error_500_page[] =
 
 static char ngx_http_error_501_page[] =
 "<html>" CRLF
-"<head><title>501 Not Implemented</title></head>" CRLF
+"<head>" CRLF
+"<title>501 Not Implemented</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>501 Not Implemented</h1></center>" CRLF
 ;
@@ -299,7 +382,10 @@ static char ngx_http_error_501_page[] =
 
 static char ngx_http_error_502_page[] =
 "<html>" CRLF
-"<head><title>502 Bad Gateway</title></head>" CRLF
+"<head>" CRLF
+"<title>502 Bad Gateway</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>502 Bad Gateway</h1></center>" CRLF
 ;
@@ -307,7 +393,10 @@ static char ngx_http_error_502_page[] =
 
 static char ngx_http_error_503_page[] =
 "<html>" CRLF
-"<head><title>503 Service Temporarily Unavailable</title></head>" CRLF
+"<head>" CRLF
+"<title>503 Service Temporarily Unavailable</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>503 Service Temporarily Unavailable</h1></center>" CRLF
 ;
@@ -315,7 +404,10 @@ static char ngx_http_error_503_page[] =
 
 static char ngx_http_error_504_page[] =
 "<html>" CRLF
-"<head><title>504 Gateway Time-out</title></head>" CRLF
+"<head>" CRLF
+"<title>504 Gateway Time-out</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>504 Gateway Time-out</h1></center>" CRLF
 ;
@@ -323,7 +415,10 @@ static char ngx_http_error_504_page[] =
 
 static char ngx_http_error_505_page[] =
 "<html>" CRLF
-"<head><title>505 HTTP Version Not Supported</title></head>" CRLF
+"<head>" CRLF
+"<title>505 HTTP Version Not Supported</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>505 HTTP Version Not Supported</h1></center>" CRLF
 ;
@@ -331,7 +426,10 @@ static char ngx_http_error_505_page[] =
 
 static char ngx_http_error_507_page[] =
 "<html>" CRLF
-"<head><title>507 Insufficient Storage</title></head>" CRLF
+"<head>" CRLF
+"<title>507 Insufficient Storage</title>" CRLF
+"<meta name=\"color-scheme\" content=\"light dark\">" CRLF
+"</head>" CRLF
 "<body>" CRLF
 "<center><h1>507 Insufficient Storage</h1></center>" CRLF
 ;


### PR DESCRIPTION
This change allows error pages to follow the WhatWG specification for rendering according to the agent's style choices at a minimal cost.

Specification available from the WhatWG
https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme

These accessibility changes constitute a net increase of 52 bytes on the affected response payloads.

Response download timing increase impacts at low network speeds:
* 7 milliseconds at 56 kbps
* 0.4 microseconds at 1 Mbps

Full Credit & Authorship to [Stanislaw](https://github.com/anvme)