### PR TITLE
Core: -t flag now also shows included config files

### DIFF
--- a/src/core/ngx_conf_file.c
+++ b/src/core/ngx_conf_file.c
@@ -875,6 +875,11 @@ ngx_conf_include(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         if (rv != NGX_CONF_OK) {
             break;
         }
+
+        if(ngx_test_config){
+            ngx_log_stderr(0, "the configuration file %s syntax is ok",
+                file.data);
+        }
     }
 
     ngx_close_glob(&gl);


### PR DESCRIPTION
Simple implementation that shows included files

### Proposed changes

Describe the use case and detail of the change.

The creator in the attached issue asked for more information pertaining files included on the main conf file when running `nginx -t`.
This is a simple implementation of the requested feature. The discussion in the issue also talks about having another flag to display this more verbose version of `-t`, but no final word has been given on the matter as of now, so this PR is open to suggestions.

If this pull request addresses an issue on GitHub, make sure to reference that
issue using one of the
[supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).

This PR addresses the following issue: https://github.com/nginx/nginx/issues/347

Before creating a pull request, make sure to comply with the
[Contributing Guidelines](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md).
