### PR TITLE
Update mime.types: add .sarif and .sarf-external-properties

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -35,6 +35,8 @@ types {
     application/pdf                                  pdf;
     application/postscript                           ps eps ai;
     application/rtf                                  rtf;
+    application/sarif+json                           sarif;
+    application/sarif-external-properties+json       sarif-external-properties+json;
     application/vnd.apple.mpegurl                    m3u8;
     application/vnd.google-earth.kml+xml             kml;
     application/vnd.google-earth.kmz                 kmz;


### PR DESCRIPTION
Add IANA registered Media Types for
 *  https://www.iana.org/assignments/media-types/application/sarif+json
 *  https://www.iana.org/assignments/media-types/application/sarif-external-properties+json 

### Proposed changes

SARIF is the _Static Analysis Results Interchange Format_ and its file extensions are registered with IANA.
When `.sarf` and `.sarif-external-properties`  files are served, this change will allow then to be served with the correct media types by default.


https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
