### PR TITLE
HTTP: Consider tab as whitespace in field value

### DIFF
--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -972,6 +972,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_space_before_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 break;
             case CR:
                 r->header_start = p;
@@ -996,6 +997,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 r->header_end = p;
                 state = sw_space_after_value;
                 break;
@@ -1016,6 +1018,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_space_after_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 break;
             case CR:
                 state = sw_almost_done;


### PR DESCRIPTION
HTTP considers 0x09 (horizontal tab) to be valid horizontal whitespace in a field value, and there are badly-behaved clients in the wild that rely on this behavior and cannot be fixed.  This also ensures that NGINX is not itself such a badly-behaved client and that, for HTTP/1.x requests, the values of the `$http_*` variables agree with what upstream servers will see.

Fixes: #187