### PR TITLE
[RFC] Fix new GCC 15 warning [-Wunterminated-string-initialization]

### DIFF
--- a/auto/cc/conf
+++ b/auto/cc/conf
@@ -137,7 +137,7 @@ else
 
     esac
 
-    CC_TEST_FLAGS="$CC_TEST_FLAGS $NGX_CC_OPT"
+    CC_TEST_FLAGS="$CC_TEST_FLAGS $NGX_CC_OPT -Werror"
 
 fi
 
@@ -238,6 +238,17 @@ if [ "$NGX_PLATFORM" != win32 ]; then
     ngx_feature_test="if (__builtin_bswap64(0)) return 1"
     . auto/feature
 
+
+    ngx_feature="gcc __attribute__ nonstring"
+    ngx_feature_name=NGX_HAVE_GCC_ATTRIBUTE_NONSTRING
+    ngx_feature_run=no
+    ngx_feature_incs=
+    ngx_feature_path=
+    ngx_feature_libs=
+    ngx_feature_test="static const char str[3] __attribute__((nonstring)) =
+                          \"ABC\";
+                      return !!str[0]"
+    . auto/feature
 
 #    ngx_feature="inline"
 #    ngx_feature_name=

--- a/src/core/ngx_config.h
+++ b/src/core/ngx_config.h
@@ -142,4 +142,15 @@ typedef intptr_t        ngx_flag_t;
 #endif
 
 
+#if (NGX_HAVE_GCC_ATTRIBUTE_NONSTRING)
+
+#define NGX_NONSTRING  __attribute__((nonstring))
+
+#else
+
+#define NGX_NONSTRING
+
+#endif
+
+
 #endif /* _NGX_CONFIG_H_INCLUDED_ */

--- a/src/http/v2/ngx_http_v2_filter_module.c
+++ b/src/http/v2/ngx_http_v2_filter_module.c
@@ -115,9 +115,9 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
     ngx_http_core_srv_conf_t  *cscf;
     u_char                     addr[NGX_SOCKADDR_STRLEN];
 
-    static const u_char nginx[5] = "\x84\xaa\x63\x55\xe7";
+    static const u_char nginx[5] NGX_NONSTRING = "\x84\xaa\x63\x55\xe7";
 #if (NGX_HTTP_GZIP)
-    static const u_char accept_encoding[12] =
+    static const u_char accept_encoding[12] NGX_NONSTRING =
         "\x8b\x84\x84\x2d\x69\x5b\x05\x44\x3c\x86\xaa\x6f";
 #endif
 


### PR DESCRIPTION
This is an RFC pull-request to check if this approach is acceptable. It's what we do in [Unit](https://github.com/nginx/unit/commit/764ad73fc7e3cbbe48b259159340e063f7d7b082) and what I've proposed for [njs](https://github.com/nginx/njs/pull/871).

GCC 15 (Fedora 42 which shipped today^H^H^Hyesterday has a GCC 15 snapshot)  implements a new warning `-Wunterminated-string-initialization` that is also enabled by `-Wextra` that we enable.

This causes compilation failures (due to -Werror) due to the likes of

```c
static const u_char nginx[5] = "\x84\xaa\x63\x55\xe7";
```

E.g.

```
src/http/v2/ngx_http_v2_filter_module.c:118:36: error: initializer-string for array of ‘unsigned char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (6 chars into 5 available) [-Werror=unterminated-string-initialization]
        118 |     static const u_char nginx[5] = "\x84\xaa\x63\x55\xe7";
            |                                    ^~~~~~~~~~~~~~~~~~~~~~
```

These are very much meant not to be NUL terminated.

Now we could just disable this new warning. But I think it is worth leaving it enabled (the GCC developers also obviously feel it's useful enough to enable under -Wexta), anything that helps the compiler help us avoid silly mistakes is a good thing(tm), particularly in the current climate.

So rather than disable this warning, we can make use of the GCC "nonstring" variable attribute `__attribute__((nonstring))`. 

This attribute is used to mark character arrays that are intentionally not NUL terminated.

So the above example would become (we of course wrap it in a more friendly name `NGX_NONSTRING`)

```c
 static const u_char nginx[5] NGX_NONSTRING = "\x84\xaa\x63\x55\xe7";
```

This attribute doesn't exist in clang (where we just define it to nothing), but then clang doesn't have this warning.

The good news is no released version of GCC had this warning that couldn't be quelled by the "nonstring" attribute. (This attribute existed before this new warning was added, the fix to allow this attribute to quell the warning went in sometime after the warning was added).

The first commit checks for the "nonstring" attribute.

The second commit is just a taster of what it looks like in practice.

Before I go through finding all the places that need fixing, I just wanted to check a couple of things.

So @arut @pluknet a couple of questions.

1) Is this general approach acceptable?

I believe it to be superior to either simply disabling this new warning or removing the size from arrays making them NUL terminated, or setting the individual array elements.

I think it's a good idea to keep the warning enabled and aside from saving a byte it keeps it clear what their function is. Code _may_ also assume these arrays to be of certain sizes.

2) I couldn't find a great place to create the `NGX_NONSTRING` macro, so I just stuck it in `src/core/ngx_config.h`.

An alternative would be to create a new file something like `src/core/ngx_clang.h` for putting general C language stuff (we have this in Unit & njs).