### PR TITLE
QUIC: silence unknown/reserved transport param "info" messages.

### DIFF
--- a/src/event/quic/ngx_event_quic_transport.c
+++ b/src/event/quic/ngx_event_quic_transport.c
@@ -1773,7 +1773,7 @@ ngx_quic_parse_transport_params(u_char *p, u_char *end, ngx_quic_tp_t *tp,
         }
 
         if (rc == NGX_DECLINED) {
-            ngx_log_error(NGX_LOG_INFO, log, 0,
+            ngx_log_debug2(NGX_LOG_DEBUG_EVENT, log, 0,
                           "quic %s transport param id:0x%xL, skipped",
                           (id % 31 == 27) ? "reserved" : "unknown", id);
         }


### PR DESCRIPTION
When using ngctp2, the following messages are usually logged:

```
2025/04/16 19:23:48 [info] 558480#0: *1 quic unknown transport param id:0x2ab2, skipped while handling frames, client: 127.0.0.1, server: 0.0.0.0:8443
2025/04/16 19:23:48 [info] 558480#0: *1 quic unknown transport param id:0xff73db, skipped while handling frames, client: 127.0.0.1, server: 0.0.0.0:8443
```

These are grease bit (RFC 9287) and version negotiation (draft-ietf-quic-version-negotiation-13). The latter was changed to 0x11 in newer ngtcp2 code though.