### PR TITLE
HTTP/3: fixed NGX_HTTP_V3_VARLEN_INT_LEN value.

### DIFF
--- a/src/http/v3/ngx_http_v3.h
+++ b/src/http/v3/ngx_http_v3.h
@@ -23,7 +23,7 @@
 #define NGX_HTTP_V3_HQ_ALPN_PROTO                  "\x0Ahq-interop"
 #define NGX_HTTP_V3_HQ_PROTO                       "hq-interop"
 
-#define NGX_HTTP_V3_VARLEN_INT_LEN                 4
+#define NGX_HTTP_V3_VARLEN_INT_LEN                 8
 #define NGX_HTTP_V3_PREFIX_INT_LEN                 11
 
 #define NGX_HTTP_V3_STREAM_CONTROL                 0x00


### PR DESCRIPTION
After fixing ngx_http_v3_encode_varlen_int() in 400eb1b628, NGX_HTTP_V3_VARLEN_INT_LEN retained the old value of 4, which is insufficient for the values over 1073741823 (1G - 1).

The NGX_HTTP_V3_VARLEN_INT_LEN macro is used in ngx_http_v3_uni.c to format stream and frame types.  Old buffer size is enough for formatting this data.  Also, the macro is used in ngx_http_v3_filter_module.c to format output chunks and trailers.  Considering output_buffers and proxy_buffer_size are below 1G in all realistic scenarios, the old buffer size is enough here as well.
