### PR TITLE
auto/lib/zlib: fix zlib-ng build bug—skip distclean when no Makefile & add configure option

### DIFF
--- a/auto/lib/zlib/make
+++ b/auto/lib/zlib/make
@@ -52,7 +52,7 @@ END
 
 $ZLIB/libz.a:	$NGX_MAKEFILE
 	cd $ZLIB \\
-	&& \$(MAKE) distclean \\
+	&& if [ -f Makefile ]; then \$(MAKE) distclean; fi \\
 	&& \$(MAKE) -f win32/Makefile.gcc \\
 		CFLAGS="$ZLIB_OPT" CC="\$(CC)" \\
 		libz.a
@@ -75,10 +75,10 @@ END
 
 $ZLIB/libz.a:	$NGX_MAKEFILE
 	cd $ZLIB \\
-	&& \$(MAKE) distclean \\
+	&& if [ -f Makefile ]; then \$(MAKE) distclean; fi \\
 	&& cp contrib/asm586/match.S . \\
 	&& CFLAGS="$ZLIB_OPT -DASMV" CC="\$(CC)" \\
-		./configure \\
+		./configure $ZLIB_CONF_OPT \\
 	&& \$(MAKE) OBJA=match.o libz.a
 
 END
@@ -92,10 +92,10 @@ END
 
 $ZLIB/libz.a:	$NGX_MAKEFILE
 	cd $ZLIB \\
-	&& \$(MAKE) distclean \\
+	&& if [ -f Makefile ]; then \$(MAKE) distclean; fi \\
 	&& cp contrib/asm686/match.S . \\
 	&& CFLAGS="$ZLIB_OPT -DASMV" CC="\$(CC)" \\
-		./configure \\
+		./configure $ZLIB_CONF_OPT \\
 	&& \$(MAKE) OBJA=match.o libz.a
 
 END
@@ -125,9 +125,9 @@ if [ $done = NO ]; then
 
 $ZLIB/libz.a:	$NGX_MAKEFILE
 	cd $ZLIB \\
-	&& \$(MAKE) distclean \\
+	&& if [ -f Makefile ]; then \$(MAKE) distclean; fi \\
 	&& CFLAGS="$ZLIB_OPT" CC="\$(CC)" \\
-		./configure \\
+		./configure $ZLIB_CONF_OPT \\
 	&& \$(MAKE) libz.a
 
 END

--- a/auto/options
+++ b/auto/options
@@ -402,6 +402,7 @@ $0: warning: the \"--with-sha1-asm\" option is deprecated"
 
         --with-zlib=*)                   ZLIB="$value"              ;;
         --with-zlib-opt=*)               ZLIB_OPT="$value"          ;;
+        --with-zlib-conf-opt=*)          ZLIB_CONF_OPT="$value"     ;;
         --with-zlib-asm=*)               ZLIB_ASM="$value"          ;;
 
         --with-libatomic)                NGX_LIBATOMIC=YES          ;;


### PR DESCRIPTION
The build system had two issues when zlib-ng is used:
1. `distclean` was always invoked, causing failure on first run when no Makefile exists yet.
2. There was no way to pass options like --zlib-compat to zlib's ./configure; users tried to sneak them in via CFLAGS which triggers "compiler error reporting is too harsh" and aborts.

The new --with-zlib-conf-opt=<opts> option feeds its value directly to ./configure, and `distclean` is now executed only if a Makefile is present.