### PR TITLE
Core: master_process_auto_reload directive.

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -55,6 +55,13 @@ static ngx_command_t  ngx_core_commands[] = {
       offsetof(ngx_core_conf_t, master),
       NULL },
 
+    { ngx_string("master_process_auto_reload"),
+      NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      0,
+      offsetof(ngx_core_conf_t, auto_reload),
+      NULL },
+
     { ngx_string("timer_resolution"),
       NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_msec_slot,
@@ -1113,6 +1120,7 @@ ngx_core_module_create_conf(ngx_cycle_t *cycle)
 
     ccf->daemon = NGX_CONF_UNSET;
     ccf->master = NGX_CONF_UNSET;
+    ccf->auto_reload = NGX_CONF_UNSET;
     ccf->timer_resolution = NGX_CONF_UNSET_MSEC;
     ccf->shutdown_timeout = NGX_CONF_UNSET_MSEC;
 
@@ -1142,6 +1150,7 @@ ngx_core_module_init_conf(ngx_cycle_t *cycle, void *conf)
 
     ngx_conf_init_value(ccf->daemon, 1);
     ngx_conf_init_value(ccf->master, 1);
+    ngx_conf_init_value(ccf->auto_reload, 0);
     ngx_conf_init_msec_value(ccf->timer_resolution, 0);
     ngx_conf_init_msec_value(ccf->shutdown_timeout, 0);
 

--- a/src/core/ngx_cycle.c
+++ b/src/core/ngx_cycle.c
@@ -434,6 +434,7 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
         }
 
         shm_zone[i].shm.log = cycle->log;
+        shm_zone[i].skip_inherit = 0;
 
         opart = &old_cycle->shared_memory.part;
         oshm_zone = opart->elts;
@@ -461,6 +462,10 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
                 != 0)
             {
                 continue;
+            }
+
+            if (shm_zone[i].tag == oshm_zone[n].tag && oshm_zone[i].skip_inherit) {
+                break;
             }
 
             if (shm_zone[i].tag == oshm_zone[n].tag && shm_zone[i].noreuse) {
@@ -1363,6 +1368,7 @@ ngx_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name, size_t size, void *tag)
     shm_zone->init = NULL;
     shm_zone->tag = tag;
     shm_zone->noreuse = 0;
+    shm_zone->skip_inherit = 0;
 
     return shm_zone;
 }

--- a/src/core/ngx_cycle.h
+++ b/src/core/ngx_cycle.h
@@ -32,7 +32,8 @@ struct ngx_shm_zone_s {
     ngx_shm_zone_init_pt      init;
     void                     *tag;
     void                     *sync;
-    ngx_uint_t                noreuse;  /* unsigned  noreuse:1; */
+    ngx_uint_t                noreuse:1;
+    ngx_uint_t                skip_inherit:1;
 };
 
 
@@ -89,6 +90,7 @@ struct ngx_cycle_s {
 typedef struct {
     ngx_flag_t                daemon;
     ngx_flag_t                master;
+    ngx_flag_t                auto_reload;
 
     ngx_msec_t                timer_resolution;
     ngx_msec_t                shutdown_timeout;


### PR DESCRIPTION
Termination of a worker process (or similar) with an unexpected signal, such as SIGKILL or SIGSEGV (or similar) while it is in the process of updating a shared memory zone, or is in the intermediate stage of performing processes that will result in the update of a shared memory zone, may result in the shared memory zones contents becoming corrupted / may result in an undefined state, resulting in request handling / nginx functionality not performing correctly.

This directive instructs nginx to be terminate itself to avoid continuing to process / continuing to accept new requests while potentially in such an undefined state, by means of self imitating either graceful or fast shutdown logic.

The directive may be set to either "quit" or "stop", following the shutdown signal naming scheme of the cli, corresponding to the SIGQUIT and SIGINT/SIGTERM equivalent shutdown logic.
