### PR TITLE
Add client_body_temp_access config

### DIFF
--- a/contrib/vim/syntax/nginx.vim
+++ b/contrib/vim/syntax/nginx.vim
@@ -153,6 +153,7 @@ syn keyword ngxDirective contained chunked_transfer_encoding
 syn keyword ngxDirective contained client_body_buffer_size
 syn keyword ngxDirective contained client_body_in_file_only
 syn keyword ngxDirective contained client_body_in_single_buffer
+syn keyword ngxDirective contained client_body_temp_access
 syn keyword ngxDirective contained client_body_temp_path
 syn keyword ngxDirective contained client_body_timeout
 syn keyword ngxDirective contained client_header_buffer_size

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -380,6 +380,13 @@ static ngx_command_t  ngx_http_core_commands[] = {
       offsetof(ngx_http_core_loc_conf_t, client_body_temp_path),
       NULL },
 
+    { ngx_string("client_body_temp_access"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE123,
+      ngx_conf_set_access_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_core_loc_conf_t, client_body_temp_access),
+      NULL },
+
     { ngx_string("client_body_in_file_only"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_enum_slot,
@@ -3663,6 +3670,7 @@ ngx_http_core_create_loc_conf(ngx_conf_t *cf)
     clcf->client_max_body_size = NGX_CONF_UNSET;
     clcf->client_body_buffer_size = NGX_CONF_UNSET_SIZE;
     clcf->client_body_timeout = NGX_CONF_UNSET_MSEC;
+    clcf->client_body_temp_access = NGX_CONF_UNSET_UINT;
     clcf->satisfy = NGX_CONF_UNSET_UINT;
     clcf->auth_delay = NGX_CONF_UNSET_MSEC;
     clcf->if_modified_since = NGX_CONF_UNSET_UINT;
@@ -3895,6 +3903,8 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                               NGX_HTTP_REQUEST_BODY_FILE_OFF);
     ngx_conf_merge_value(conf->client_body_in_single_buffer,
                               prev->client_body_in_single_buffer, 0);
+    ngx_conf_merge_uint_value(conf->client_body_temp_access,
+                              prev->client_body_temp_access, 0);
     ngx_conf_merge_value(conf->internal, prev->internal, 0);
     ngx_conf_merge_value(conf->sendfile, prev->sendfile, 0);
     ngx_conf_merge_size_value(conf->sendfile_max_chunk,

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -439,6 +439,7 @@ struct ngx_http_core_loc_conf_s {
     ngx_array_t  *error_pages;             /* error_page */
 
     ngx_path_t   *client_body_temp_path;   /* client_body_temp_path */
+    ngx_uint_t   client_body_temp_access;  /* client_body_temp_access */
 
     ngx_open_file_cache_t  *open_file_cache;
     time_t        open_file_cache_valid;

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -569,6 +569,7 @@ ngx_http_write_request_body(ngx_http_request_t *r)
         tf->file.fd = NGX_INVALID_FILE;
         tf->file.log = r->connection->log;
         tf->path = clcf->client_body_temp_path;
+        tf->access = clcf->client_body_temp_access;
         tf->pool = r->pool;
         tf->warn = "a client request body is buffered to a temporary file";
         tf->log_level = r->request_body_file_log_level;


### PR DESCRIPTION
### Proposed changes

Fixes #656 ; Ability to set file permissions for uploads when using client_body_temp_path

Patch verified to work with config

```conf
    location / {
        proxy_pass http://localhost:8000/;

        client_body_temp_access group:rw;
        client_body_in_file_only clean;
        proxy_set_header X-File $request_body_file;
        proxy_set_body off;
    }
```