### PR TITLE
Not modified filter: added "not_modified_check" directive.

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -129,6 +129,15 @@ static ngx_conf_enum_t  ngx_http_core_server_tokens[] = {
 };
 
 
+static ngx_conf_enum_t  ngx_http_core_not_modified_check[] = {
+    { ngx_string("off"), NGX_HTTP_NMC_OFF },
+    { ngx_string("any"), NGX_HTTP_NMC_ANY },
+    { ngx_string("strict"), NGX_HTTP_NMC_STRICT },
+    { ngx_string("prefer_if_none_match"), NGX_HTTP_NMC_PREFER_INM },
+    { ngx_null_string, 0 }
+};
+
+
 static ngx_conf_enum_t  ngx_http_core_if_modified_since[] = {
     { ngx_string("off"), NGX_HTTP_IMS_OFF },
     { ngx_string("exact"), NGX_HTTP_IMS_EXACT },
@@ -641,6 +650,13 @@ static ngx_command_t  ngx_http_core_commands[] = {
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_core_loc_conf_t, server_tokens),
       &ngx_http_core_server_tokens },
+
+    { ngx_string("not_modified_check"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_enum_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_core_loc_conf_t, not_modified_check),
+      &ngx_http_core_not_modified_check },
 
     { ngx_string("if_modified_since"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
@@ -3630,6 +3646,7 @@ ngx_http_core_create_loc_conf(ngx_conf_t *cf)
     clcf->client_body_timeout = NGX_CONF_UNSET_MSEC;
     clcf->satisfy = NGX_CONF_UNSET_UINT;
     clcf->auth_delay = NGX_CONF_UNSET_MSEC;
+    clcf->not_modified_check = NGX_CONF_UNSET_UINT;
     clcf->if_modified_since = NGX_CONF_UNSET_UINT;
     clcf->max_ranges = NGX_CONF_UNSET_UINT;
     clcf->client_body_in_file_only = NGX_CONF_UNSET_UINT;
@@ -3851,6 +3868,8 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_uint_value(conf->satisfy, prev->satisfy,
                               NGX_HTTP_SATISFY_ALL);
     ngx_conf_merge_msec_value(conf->auth_delay, prev->auth_delay, 0);
+    ngx_conf_merge_uint_value(conf->not_modified_check,
+                              prev->not_modified_check, NGX_HTTP_NMC_STRICT);
     ngx_conf_merge_uint_value(conf->if_modified_since, prev->if_modified_since,
                               NGX_HTTP_IMS_EXACT);
     ngx_conf_merge_uint_value(conf->max_ranges, prev->max_ranges,

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -129,6 +129,15 @@ static ngx_conf_enum_t  ngx_http_core_server_tokens[] = {
 };
 
 
+static ngx_conf_enum_t  ngx_http_core_not_modified_check[] = {
+    { ngx_string("off"), NGX_HTTP_NMC_OFF },
+    { ngx_string("any"), NGX_HTTP_NMC_ANY },
+    { ngx_string("strict"), NGX_HTTP_NMC_STRICT },
+    { ngx_string("prefer_if_none_match"), NGX_HTTP_NMC_PREFER_INM },
+    { ngx_null_string, 0 }
+};
+
+
 static ngx_conf_enum_t  ngx_http_core_if_modified_since[] = {
     { ngx_string("off"), NGX_HTTP_IMS_OFF },
     { ngx_string("exact"), NGX_HTTP_IMS_EXACT },
@@ -648,6 +657,13 @@ static ngx_command_t  ngx_http_core_commands[] = {
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_core_loc_conf_t, server_tokens),
       &ngx_http_core_server_tokens },
+
+    { ngx_string("not_modified_check"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_enum_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_core_loc_conf_t, not_modified_check),
+      &ngx_http_core_not_modified_check },
 
     { ngx_string("if_modified_since"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
@@ -3642,6 +3658,7 @@ ngx_http_core_create_loc_conf(ngx_conf_t *cf)
     clcf->client_body_timeout = NGX_CONF_UNSET_MSEC;
     clcf->satisfy = NGX_CONF_UNSET_UINT;
     clcf->auth_delay = NGX_CONF_UNSET_MSEC;
+    clcf->not_modified_check = NGX_CONF_UNSET_UINT;
     clcf->if_modified_since = NGX_CONF_UNSET_UINT;
     clcf->max_ranges = NGX_CONF_UNSET_UINT;
     clcf->client_body_in_file_only = NGX_CONF_UNSET_UINT;
@@ -3863,6 +3880,8 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_uint_value(conf->satisfy, prev->satisfy,
                               NGX_HTTP_SATISFY_ALL);
     ngx_conf_merge_msec_value(conf->auth_delay, prev->auth_delay, 0);
+    ngx_conf_merge_uint_value(conf->not_modified_check,
+                              prev->not_modified_check, NGX_HTTP_NMC_STRICT);
     ngx_conf_merge_uint_value(conf->if_modified_since, prev->if_modified_since,
                               NGX_HTTP_IMS_EXACT);
     ngx_conf_merge_uint_value(conf->max_ranges, prev->max_ranges,

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -60,6 +60,12 @@ typedef struct ngx_thread_pool_s  ngx_thread_pool_t;
 #define NGX_HTTP_SERVER_TOKENS_BUILD    2
 
 
+#define NGX_HTTP_NMC_OFF                0
+#define NGX_HTTP_NMC_ANY                1
+#define NGX_HTTP_NMC_STRICT             2
+#define NGX_HTTP_NMC_PREFER_INM         3
+
+
 typedef struct ngx_http_location_tree_node_s  ngx_http_location_tree_node_t;
 typedef struct ngx_http_core_loc_conf_s  ngx_http_core_loc_conf_t;
 
@@ -385,6 +391,7 @@ struct ngx_http_core_loc_conf_s {
     ngx_uint_t    keepalive_disable;       /* keepalive_disable */
     ngx_uint_t    satisfy;                 /* satisfy */
     ngx_uint_t    lingering_close;         /* lingering_close */
+    ngx_uint_t    not_modified_check;      /* not_modified_check */
     ngx_uint_t    if_modified_since;       /* if_modified_since */
     ngx_uint_t    max_ranges;              /* max_ranges */
     ngx_uint_t    client_body_in_file_only; /* client_body_in_file_only */

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -60,6 +60,12 @@ typedef struct ngx_thread_pool_s  ngx_thread_pool_t;
 #define NGX_HTTP_SERVER_TOKENS_BUILD    2
 
 
+#define NGX_HTTP_NMC_OFF                0
+#define NGX_HTTP_NMC_ANY                1
+#define NGX_HTTP_NMC_STRICT             2
+#define NGX_HTTP_NMC_PREFER_INM         3
+
+
 typedef struct ngx_http_location_tree_node_s  ngx_http_location_tree_node_t;
 typedef struct ngx_http_core_loc_conf_s  ngx_http_core_loc_conf_t;
 
@@ -388,6 +394,7 @@ struct ngx_http_core_loc_conf_s {
     ngx_uint_t    keepalive_disable;       /* keepalive_disable */
     ngx_uint_t    satisfy;                 /* satisfy */
     ngx_uint_t    lingering_close;         /* lingering_close */
+    ngx_uint_t    not_modified_check;      /* not_modified_check */
     ngx_uint_t    if_modified_since;       /* if_modified_since */
     ngx_uint_t    max_ranges;              /* max_ranges */
     ngx_uint_t    client_body_in_file_only; /* client_body_in_file_only */


### PR DESCRIPTION
This directive establishes four distinct modes for managing 304 responses, which determine how the `If-None-Match` and `If-Modified-Since` headers are evaluated.

When the directive parameter is set to `off`, the response is always treated as modified, regardless of the headers.

When set to `any`, a 304 response is returned if either the `If-Modified-Since` or `If-None-Match` condition is satisfied.

When set to `strict`, a 304 response is returned only if both the `If-Modified-Since` and `If-None-Match` conditions are met. This is the default setting and reflects the traditional behavior of NGINX.

When set to `prefer_if_none_match`, it will follow RFC 9110, Section 13.1.3. In this mode, if the `If-None-Match` header is present, the `If-Modified-Since` header is ignored.

### Proposed changes

Fixes https://github.com/nginx/nginx/issues/652
