### PR TITLE
proposed resolution of issue #611

### DIFF
--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -1115,6 +1115,11 @@ ngx_http_script_regex_start_code(ngx_http_script_engine_t *e)
         e->sp++;
 
         e->ip += sizeof(ngx_http_script_regex_code_t);
+
+        /* Resolve issue #611 (https://github.com/nginx/nginx/issues/611). */
+        if (NULL == strchr((const char *) e->line.data, '%')) {
+            e->quote = 0;
+        }
         return;
     }
 


### PR DESCRIPTION
### Proposed changes

To fix #611, a small addition has been made to the `ngx_http_script_regex_start_code` function in `src/http/ngx_http_script.c`. This addition prevents the `ngx_http_script_copy_capture_code` function in the same file from performing an unnecessary URI escape that was the origin of the bug in the “test1” case, while continuing to perform an appropriate URI escape in the “test2” case. This addition does not affect the “test3” case, which did not demonstrate the bug because it involved no capture group.

In running the nginx test suite on my system, many tests were skipped, and a failure was reported for `proxy_implicit.t` due to dying from “too many addresses in localhost”. Since my system’s `/etc/hosts` file originally came with (and still has) three different lines for `localhost` (specifying “127.0.0.1”, “::1”, and “fe80::1%lo0” respectively), I believe that the failure of `proxy_implicit.t` is due to the contents of its `/etc/hosts` file rather than due to this proposed addition.

If this proposed addition causes regressions on other systems that are capable of running all of the nginx test suite’s tests, I’d appreciate receiving feedback about it.
