### PR TITLE
HTTP: Reword message in SSL certificate error page

### DIFF
--- a/src/http/ngx_http_special_response.c
+++ b/src/http/ngx_http_special_response.c
@@ -253,11 +253,10 @@ CRLF
 
 static char ngx_http_error_495_page[] =
 "<html>" CRLF
-"<head><title>400 The SSL certificate error</title></head>"
-CRLF
+"<head><title>400 SSL certificate error</title></head>" CRLF
 "<body>" CRLF
 "<center><h1>400 Bad Request</h1></center>" CRLF
-"<center>The SSL certificate error</center>" CRLF
+"<center>SSL certificate error</center>" CRLF
 ;
 
 


### PR DESCRIPTION
The message in `ngx_http_error_495_page` read a bit akward to me, I think removing "The" from "The SSL certificate error" brings it more in line with the other default error pages.