### PR TITLE
use https in the default nginx welcome page, both domains support it

### DIFF
--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -14,9 +14,9 @@ font-family: Tahoma, Verdana, Arial, sans-serif; }
 working. Further configuration is required.</p>
 
 <p>For online documentation and support please refer to
-<a href="http://nginx.org/">nginx.org</a>.<br/>
+<a href="https://nginx.org/">nginx.org</a>.<br/>
 Commercial support is available at
-<a href="http://nginx.com/">nginx.com</a>.</p>
+<a href="https://nginx.com/">nginx.com</a>.</p>
 
 <p><em>Thank you for using nginx.</em></p>
 </body>


### PR DESCRIPTION
### Proposed changes

This commit updates the protocol on the default nginx welcome page to use `https` instead of `http`. Both nginx.com and nginx.org support https, so there's no reason not to use this protocol.