### PR TITLE
HTTP: use variable for better maintainability

### DIFF
--- a/src/http/ngx_http_special_response.c
+++ b/src/http/ngx_http_special_response.c
@@ -33,7 +33,7 @@ static u_char ngx_http_error_build_tail[] =
 
 
 static u_char ngx_http_error_tail[] =
-"<hr><center>nginx</center>" CRLF
+"<hr><center>"NGINX_VAR"</center>" CRLF
 "</body>" CRLF
 "</html>" CRLF
 ;


### PR DESCRIPTION
### Changed
In `ngx_http-special_response.c`, replace the hard-coded `"nginx"` string literal with the `NGINX_VAR` variable to enhance maintainability.

This change should follow the same structure used on lines 21 and 28, ensuring clarity and consistency.
