### PR TITLE
Auth basic: check if file of auth_basic_user_file can be open.

### DIFF
--- a/src/http/modules/ngx_http_auth_basic_module.c
+++ b/src/http/modules/ngx_http_auth_basic_module.c
@@ -404,6 +404,7 @@ ngx_http_auth_basic_user_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     ngx_str_t                         *value;
     ngx_http_compile_complex_value_t   ccv;
+    ngx_file_info_t                    fi;
 
     if (alcf->user_file != NGX_CONF_UNSET_PTR) {
         return "is duplicate";
@@ -426,6 +427,14 @@ ngx_http_auth_basic_user_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
         return NGX_CONF_ERROR;
+    }
+
+    if (alcf->user_file->lengths == NULL && 
+        ngx_file_info(alcf->user_file->value.data, &fi) 
+        == NGX_FILE_ERROR) {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, ngx_errno,
+                           ngx_file_info_n " \"%s\" failed", 
+                           alcf->user_file->value.data);
     }
 
     return NGX_CONF_OK;


### PR DESCRIPTION
Fixed #557 by check if the file can be open.

As described in Issue #557   the user want to log an error and let the the config test failed if the file of auth_basic_user_file specified can not be open.

since we can not check the filepath that contain variable at compile time, so this fix ignored the path that contain $ character.

this is my test:
config:
```
  location / {
            root   html;
            index  index.html index.htm;
            auth_basic "Restricted Access";  
            auth_basic_user_file /home/hayden/code/git/nginx/tmp/.passwd;
        }
```

**case 1.if the file not exist, then there will be a warning log in error_log file:**
2025/05/22 18:44:01 [warn] 747167#0: stat() "/home/hayden/code/git/nginx/tmp/.passwda" failed (2: No such file or directory) in /home/hayden/code/git/nginx/tmp/conf/nginx.conf:49


and config test will print warn infor:
nginx: [warn] stat() "/home/hayden/code/git/nginx/tmp/.passwda" failed (2: No such file or directory) in /home/hayden/code/git/nginx/tmp/conf/nginx.conf:49

**case 2.if the file exist then the config test will success:**
nginx: configuration file /home/hayden/code/git/nginx/tmp/conf/nginx.conf test is successful


**case 3. if the file name contain $ character, then we bypass the  check logic. **
nginx: configuration file /home/hayden/code/git/nginx/tmp/conf/nginx.conf test is successful
