### PR TITLE
Use NULL instead of 0 as null pointer constant

### DIFF
--- a/src/core/ngx_thread_pool.c
+++ b/src/core/ngx_thread_pool.c
@@ -207,7 +207,7 @@ ngx_thread_pool_exit_handler(void *data, ngx_log_t *log)
 
     *lock = 0;
 
-    pthread_exit(0);
+    pthread_exit(NULL);
 }
 
 

--- a/src/event/ngx_event_openssl_cache.c
+++ b/src/event/ngx_event_openssl_cache.c
@@ -694,7 +694,7 @@ ngx_ssl_cache_pkey_create(ngx_ssl_cache_key_t *id, char **err, void *data)
             return NULL;
         }
 
-        pkey = ENGINE_load_private_key(engine, (char *) last, 0, 0);
+        pkey = ENGINE_load_private_key(engine, (char *) last, NULL, NULL);
 
         if (pkey == NULL) {
             *err = "ENGINE_load_private_key() failed";

--- a/src/event/quic/ngx_event_quic.c
+++ b/src/event/quic/ngx_event_quic.c
@@ -964,7 +964,7 @@ ngx_quic_handle_payload(ngx_connection_t *c, ngx_quic_header_t *pkt)
     qc = ngx_quic_get_connection(c);
 
     qc->error = 0;
-    qc->error_reason = 0;
+    qc->error_reason = NULL;
 
     c->log->action = "decrypting packet";
 

--- a/src/http/modules/ngx_http_addition_filter_module.c
+++ b/src/http/modules/ngx_http_addition_filter_module.c
@@ -245,7 +245,7 @@ ngx_http_addition_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,
                              &prev->types_keys, &prev->types,
                              ngx_http_html_default_types)
-        != NGX_OK)
+        != NGX_CONF_OK)
     {
         return NGX_CONF_ERROR;
     }

--- a/src/http/modules/ngx_http_charset_filter_module.c
+++ b/src/http/modules/ngx_http_charset_filter_module.c
@@ -1564,7 +1564,7 @@ ngx_http_charset_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,
                              &prev->types_keys, &prev->types,
                              ngx_http_charset_default_types)
-        != NGX_OK)
+        != NGX_CONF_OK)
     {
         return NGX_CONF_ERROR;
     }

--- a/src/http/modules/ngx_http_fastcgi_module.c
+++ b/src/http/modules/ngx_http_fastcgi_module.c
@@ -3130,7 +3130,7 @@ ngx_http_fastcgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     if (ngx_conf_merge_path_value(cf, &conf->upstream.temp_path,
                               prev->upstream.temp_path,
                               &ngx_http_fastcgi_temp_path)
-        != NGX_OK)
+        != NGX_CONF_OK)
     {
         return NGX_CONF_ERROR;
     }

--- a/src/http/modules/ngx_http_gunzip_filter_module.c
+++ b/src/http/modules/ngx_http_gunzip_filter_module.c
@@ -304,7 +304,7 @@ ngx_http_gunzip_filter_inflate_start(ngx_http_request_t *r,
 {
     int  rc;
 
-    ctx->zstream.next_in = Z_NULL;
+    ctx->zstream.next_in = NULL;
     ctx->zstream.avail_in = 0;
 
     ctx->zstream.zalloc = ngx_http_gunzip_filter_alloc;

--- a/src/http/modules/ngx_http_gzip_filter_module.c
+++ b/src/http/modules/ngx_http_gzip_filter_module.c
@@ -1115,7 +1115,7 @@ ngx_http_gzip_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,
                              &prev->types_keys, &prev->types,
                              ngx_http_html_default_types)
-        != NGX_OK)
+        != NGX_CONF_OK)
     {
         return NGX_CONF_ERROR;
     }

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -3844,7 +3844,7 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     if (ngx_conf_merge_path_value(cf, &conf->upstream.temp_path,
                               prev->upstream.temp_path,
                               &ngx_http_proxy_temp_path)
-        != NGX_OK)
+        != NGX_CONF_OK)
     {
         return NGX_CONF_ERROR;
     }

--- a/src/http/modules/ngx_http_scgi_module.c
+++ b/src/http/modules/ngx_http_scgi_module.c
@@ -1543,7 +1543,7 @@ ngx_http_scgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     if (ngx_conf_merge_path_value(cf, &conf->upstream.temp_path,
                                   prev->upstream.temp_path,
                                   &ngx_http_scgi_temp_path)
-        != NGX_OK)
+        != NGX_CONF_OK)
     {
         return NGX_CONF_ERROR;
     }

--- a/src/http/modules/ngx_http_ssi_filter_module.c
+++ b/src/http/modules/ngx_http_ssi_filter_module.c
@@ -2942,7 +2942,7 @@ ngx_http_ssi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,
                              &prev->types_keys, &prev->types,
                              ngx_http_html_default_types)
-        != NGX_OK)
+        != NGX_CONF_OK)
     {
         return NGX_CONF_ERROR;
     }

--- a/src/http/modules/ngx_http_ssi_filter_module.c
+++ b/src/http/modules/ngx_http_ssi_filter_module.c
@@ -820,7 +820,7 @@ ngx_http_ssi_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 }
 
                 for (prm = cmd->params; prm->name.len; prm++) {
-                    if (prm->mandatory && params[prm->index] == 0) {
+                    if (prm->mandatory && params[prm->index] == NULL) {
                         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                                       "mandatory \"%V\" parameter is absent "
                                       "in \"%V\" SSI command",

--- a/src/http/modules/ngx_http_sub_filter_module.c
+++ b/src/http/modules/ngx_http_sub_filter_module.c
@@ -901,7 +901,7 @@ ngx_http_sub_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,
                              &prev->types_keys, &prev->types,
                              ngx_http_html_default_types)
-        != NGX_OK)
+        != NGX_CONF_OK)
     {
         return NGX_CONF_ERROR;
     }

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -1803,7 +1803,7 @@ ngx_http_uwsgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     if (ngx_conf_merge_path_value(cf, &conf->upstream.temp_path,
                                   prev->upstream.temp_path,
                                   &ngx_http_uwsgi_temp_path)
-        != NGX_OK)
+        != NGX_CONF_OK)
     {
         return NGX_CONF_ERROR;
     }

--- a/src/http/modules/ngx_http_xslt_filter_module.c
+++ b/src/http/modules/ngx_http_xslt_filter_module.c
@@ -1112,7 +1112,7 @@ ngx_http_xslt_filter_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,
                              &prev->types_keys, &prev->types,
                              ngx_http_xslt_default_types)
-        != NGX_OK)
+        != NGX_CONF_OK)
     {
         return NGX_CONF_ERROR;
     }

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -3892,7 +3892,7 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     if (ngx_conf_merge_path_value(cf, &conf->client_body_temp_path,
                               prev->client_body_temp_path,
                               &ngx_http_client_temp_path)
-        != NGX_OK)
+        != NGX_CONF_OK)
     {
         return NGX_CONF_ERROR;
     }

--- a/src/os/unix/ngx_time.c
+++ b/src/os/unix/ngx_time.c
@@ -43,7 +43,7 @@ ngx_timezone_update(void)
     struct tm  *t;
     char        buf[4];
 
-    s = time(0);
+    s = time(NULL);
 
     t = localtime(&s);
 


### PR DESCRIPTION
This pull-request is about using the `NULL` macro (or alias of) in places that require a null pointer constant rather than using `0`, which while the compiler can figure out the context of whether it should be treated as the number `0` or a `null pointer constant`, reading through the code, it's not always obvious.

We have this nice handy macro `NULL` for this purpose, lets use it. We of course do already use it in the _majority_ of cases, there was just a few outliers.

There is also as it happens, [interest](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117059) in deprecating `0` as a null pointer constant in `C`.

For example these were found using the `-Wzero-as-null-pointer-constant` warning which was enabled for C in GCC 15 and while it currently isn't enabled with either of `Wall` or `Wextra` it may be in the future.

Some of the uses of `0` as a null pointer constant where obvious, others not so much, illustrating the above point.

```
$ git request-pull master origin 0-to-NULL
The following changes since commit f3542500b6d74e3e88fc84b88144afe67882d1fa:

  QUIC: do not block ACKs by congestion control. (2025-04-29 19:53:41 +0400)

are available in the Git repository at:

  git@github.com:ac000/nginx.git 0-to-NULL

for you to fetch changes up to 34b24c55261e919fbc00e2ec34043f7bad131fc4:

  Use NULL instead of 0 for null pointer constant (2025-05-21 22:30:20 +0100)

----------------------------------------------------------------
Andrew Clayton (2):
      Use NGX_CONF_OK in some function return checks
      Use NULL instead of 0 for null pointer constant

 src/core/ngx_thread_pool.c                         | 2 +-
 src/event/quic/ngx_event_quic.c                    | 2 +-
 src/http/modules/ngx_http_addition_filter_module.c | 2 +-
 src/http/modules/ngx_http_charset_filter_module.c  | 2 +-
 src/http/modules/ngx_http_fastcgi_module.c         | 2 +-
 src/http/modules/ngx_http_gzip_filter_module.c     | 2 +-
 src/http/modules/ngx_http_proxy_module.c           | 2 +-
 src/http/modules/ngx_http_scgi_module.c            | 2 +-
 src/http/modules/ngx_http_ssi_filter_module.c      | 4 ++--
 src/http/modules/ngx_http_sub_filter_module.c      | 2 +-
 src/http/modules/ngx_http_uwsgi_module.c           | 2 +-
 src/http/modules/ngx_http_xslt_filter_module.c     | 2 +-
 src/http/ngx_http_core_module.c                    | 2 +-
 src/os/unix/ngx_time.c                             | 2 +-
 14 files changed, 15 insertions(+), 15 deletions(-)
```