### PR TITLE
Core: added support for TCP keepalive parameters on macOS.

### DIFF
--- a/auto/os/darwin
+++ b/auto/os/darwin
@@ -118,3 +118,19 @@ ngx_feature_libs=
 ngx_feature_test="int32_t  lock = 0;
                   if (!OSAtomicCompareAndSwap32Barrier(0, 1, &lock)) return 1"
 . auto/feature
+
+
+ngx_feature="TCP_KEEPALIVE"
+ngx_feature_name="NGX_HAVE_KEEPALIVE_TUNABLE"
+ngx_feature_run=no
+ngx_feature_incs="#include <sys/socket.h>
+                  #include <netinet/in.h>
+                  #include <netinet/tcp.h>"
+ngx_feature_path=
+ngx_feature_libs=
+ngx_feature_test="setsockopt(0, IPPROTO_TCP, TCP_KEEPALIVE, NULL, 0);
+                  setsockopt(0, IPPROTO_TCP, TCP_KEEPINTVL, NULL, 0);
+                  setsockopt(0, IPPROTO_TCP, TCP_KEEPCNT, NULL, 0)"
+. auto/feature
+
+NGX_KEEPALIVE_CHECKED=YES

--- a/auto/unix
+++ b/auto/unix
@@ -508,18 +508,20 @@ ngx_feature_test="setsockopt(0, IPPROTO_TCP, TCP_DEFER_ACCEPT, NULL, 0)"
 . auto/feature
 
 
-ngx_feature="TCP_KEEPIDLE"
-ngx_feature_name="NGX_HAVE_KEEPALIVE_TUNABLE"
-ngx_feature_run=no
-ngx_feature_incs="#include <sys/socket.h>
-                  #include <netinet/in.h>
-                  #include <netinet/tcp.h>"
-ngx_feature_path=
-ngx_feature_libs=
-ngx_feature_test="setsockopt(0, IPPROTO_TCP, TCP_KEEPIDLE, NULL, 0);
-                  setsockopt(0, IPPROTO_TCP, TCP_KEEPINTVL, NULL, 0);
-                  setsockopt(0, IPPROTO_TCP, TCP_KEEPCNT, NULL, 0)"
-. auto/feature
+if test -z "$NGX_KEEPALIVE_CHECKED"; then
+    ngx_feature="TCP_KEEPIDLE"
+    ngx_feature_name="NGX_HAVE_KEEPALIVE_TUNABLE"
+    ngx_feature_run=no
+    ngx_feature_incs="#include <sys/socket.h>
+                      #include <netinet/in.h>
+                      #include <netinet/tcp.h>"
+    ngx_feature_path=
+    ngx_feature_libs=
+    ngx_feature_test="setsockopt(0, IPPROTO_TCP, TCP_KEEPIDLE, NULL, 0);
+                      setsockopt(0, IPPROTO_TCP, TCP_KEEPINTVL, NULL, 0);
+                      setsockopt(0, IPPROTO_TCP, TCP_KEEPCNT, NULL, 0)"
+    . auto/feature
+fi
 
 
 ngx_feature="TCP_FASTOPEN"

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -765,6 +765,8 @@ ngx_configure_listening_sockets(ngx_cycle_t *cycle)
 
 #if (NGX_HAVE_KEEPALIVE_TUNABLE)
 
+#if !(NGX_DARWIN)
+
         if (ls[i].keepidle) {
             value = ls[i].keepidle;
 
@@ -781,6 +783,8 @@ ngx_configure_listening_sockets(ngx_cycle_t *cycle)
                               value, &ls[i].addr_text);
             }
         }
+
+#endif
 
         if (ls[i].keepintvl) {
             value = ls[i].keepintvl;

--- a/src/event/ngx_event_accept.c
+++ b/src/event/ngx_event_accept.c
@@ -203,6 +203,23 @@ ngx_event_accept(ngx_event_t *ev)
             }
         }
 
+#if (NGX_HAVE_KEEPALIVE_TUNABLE && NGX_DARWIN)
+
+        /* Darwin doesn't inherit TCP_KEEPALIVE from a listening socket */
+
+        if (ls->keepidle) {
+            if (setsockopt(s, IPPROTO_TCP, TCP_KEEPALIVE,
+                           (const void *) &ls->keepidle, sizeof(int))
+                == -1)
+            {
+                ngx_log_error(NGX_LOG_ALERT, ev->log, ngx_socket_errno,
+                              "setsockopt(TCP_KEEPALIVE, %d) failed, ignored",
+                              ls->keepidle);
+            }
+        }
+
+#endif
+
         *log = ls->log;
 
         c->recv = ngx_recv;


### PR DESCRIPTION
The support first appeared in OS X Mavericks 10.9 and is documented since OS X Yosemite 10.10, with two subtle implementation differences:

- the TCP_KEEPIDLE socket option is available as TCP_KEEPALIVE;

- socket options are not inhereted from the listen socket, they are explicitly set on the newly created socket upon accept.

Thanks to Andy Pan for initial work.

Closes #336.