### PR TITLE
QUIC: disabled OpenSSL 3.5 support by default.

### DIFF
--- a/src/event/quic/ngx_event_quic.h
+++ b/src/event/quic/ngx_event_quic.h
@@ -13,7 +13,10 @@
 
 
 #ifdef OSSL_RECORD_PROTECTION_LEVEL_NONE
-#define NGX_QUIC_OPENSSL_API                 1
+#ifndef NGX_QUIC_OPENSSL_API
+#define NGX_QUIC_BORINGSSL_API               1
+#define NGX_QUIC_OPENSSL_COMPAT              1
+#endif
 
 #elif (defined SSL_R_MISSING_QUIC_TRANSPORT_PARAMETERS_EXTENSION)
 #define NGX_QUIC_QUICTLS_API                 1


### PR DESCRIPTION
OpenSSL fails to copy table of custom extensions, when switching SSL contexts, which includes the quic_transport_parameters extension. This results in a broken QUIC handshake.

It can be switched on using --with-cc-opt='-DNGX_QUIC_OPENSSL_API=1'.
