### PR TITLE
Proxy: Fix handling of malformed status lines

### DIFF
--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -1860,11 +1860,11 @@ ngx_http_proxy_process_status_line(ngx_http_request_t *r)
         }
 #endif
 
-        r->http_version = NGX_HTTP_VERSION_9;
-        u->state->status = NGX_HTTP_OK;
+        u->state->status = NGX_HTTP_UPSTREAM_INVALID_HEADER;
+
         u->headers_in.connection_close = 1;
 
-        return NGX_OK;
+        return NGX_HTTP_UPSTREAM_INVALID_HEADER;
     }
 
     if (u->state && u->state->status == 0) {


### PR DESCRIPTION
```
Proxy: Fix handling of malformed status lines.

If an upstream returned a malformed status line, e.g.

  HTTP/1.1 404: Not Found

(Note the extraneous ':')

nginx would for HTTP/1.1 connections cause the client to hang until the
proxy timeout was reached while nginx was waiting for more response from
the upstream that were never going to come due to the client connection
being downgraded to HTTP/0.9.

The client would then see an empty reply from the server.

With HTTP/2 connections nginx would return a status of 000 to the
client. E.g.

  ...
  < HTTP/2 000
  ...

Both cases would log a 499 status code to the access log. E.g.

  ::1 - - [06/Jun/2025:16:31:08 +0100] "GET / HTTP/2.0" 499 0 "-" "curl/8.11.1"

This was due to returning NGX_OK from
ngx_http_proxy_process_status_line() in ngx_http_proxy_module.c rather
than NGX_HTTP_UPSTREAM_INVALID_HEADER.

We also don't want to set r->http_version to NGX_HTTP_VERSION_9 as for
HTTP/1.1 connections this would now result in

  > GET / HTTP/1.1
  ...
  curl: (1) Received HTTP/0.9 when not allowed

With this fix both the above cases return a 502 Bad Gateway, e.g.

  > GET / HTTP/2
  ...
  < HTTP/2 502
  ...

A 502 is now logged to the access log, e.g.

  ::1 - - [06/Jun/2025:16:33:15 +0100] "GET / HTTP/1.1" 502 157 "-" "curl/8.11.1"

Closes: https://github.com/nginx/nginx/issues/378
```
