### PR TITLE
SSL: Encrypted Client Hello support PoC

### DIFF
--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -232,6 +232,12 @@ ngx_int_t ngx_ssl_connection_certificate(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *cert, ngx_str_t *key, ngx_ssl_cache_t *cache,
     ngx_array_t *passwords);
 
+
+#if (defined OSSL_ECH_CURRENT_VERSION || defined SSL_R_ECH_REJECTED)
+ngx_int_t ngx_ssl_echconfigs(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *confs,
+    ngx_array_t *keys, ngx_array_t *passwords, ngx_uint_t for_retry);
+#endif
+
 ngx_int_t ngx_ssl_ciphers(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *ciphers,
     ngx_uint_t prefer_server_ciphers);
 ngx_int_t ngx_ssl_client_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl,

--- a/src/http/modules/ngx_http_ssl_module.h
+++ b/src/http/modules/ngx_http_ssl_module.h
@@ -40,6 +40,12 @@ typedef struct {
 
     ngx_ssl_cache_t                *certificate_cache;
 
+#if (defined OSSL_ECH_CURRENT_VERSION || defined SSL_R_ECH_REJECTED)
+    ngx_array_t                    *echconfigs;
+    ngx_array_t                    *echconfig_keys;
+    ngx_flag_t                      echconfig_retry;
+#endif
+
     ngx_str_t                       dhparam;
     ngx_str_t                       ecdh_curve;
     ngx_str_t                       client_certificate;


### PR DESCRIPTION
OpenSSL
=======

- Build OpenSSL from https://github.com/sftcd/openssl/tree/feature/ech
- PR to merge into OpenSSL feature/ech branch: https://github.com/openssl/openssl/pull/27561

Create ECH config
-----------------

- Output is in PEM format
- Needs to be split into 2 files: config and key

```
$ openssl ech -out certs/foo.test.pem -public_name foo.test

$awk '/-----BEGIN ECHCONFIG-----/ {f=1} /-----END ECHCONFIG-----/
     {print; f=0} f'  certs/foo.test.pem > certs/foo.test.ech

$ awk '/-----BEGIN PRIVATE KEY-----/ {f=1} /-----END PRIVATE KEY-----/
     {print; f=0} f' certs/foo.test.pem > certs/foo.test.key
```

Configuration
-------------
```
server {
    listen 8443 ssl;

    # PEM files
    ssl_echconfig       certs/foo.test.ech;
    ssl_echconfig_key   certs/foo.test.key;

    ssl_certificate     certs/example.com.crt;
    ssl_certificate_key certs/example.com.key;

    location / {
        return 200 foo;
    }
}
```

BoringSSL
=========

Create ECH config
-----------------

- All output is binary

```
$ bssl generate-ech -public-name bar.test
                    -out-ech-config-list certs/bar.test.echlist
                    -out-ech-config certs/bar.test.ech
                    -out-private-key certs/bar.test.key
                    -config-id 0
```

Configuration
-------------
```
server {
    listen 8443 ssl;

    # Binary files
    ssl_echconfig       certs/bar.test.ech;
    ssl_echconfig_key   certs/bar.test.key;

    ssl_certificate     certs/example.com.crt;
    ssl_certificate_key certs/example.com.key;

    location / {
        return 200 foo;
    }
}
```

Testing
=======

- Using OpenSSL client

OpenSSL to OpenSSL
------------------
```
$ openssl s_client -connect example.com:8443
                   -ech_config_list <base64 from certs/foo.test.ech>
                   -CAfile certs/root.crt -trace
```

OpenSSL to BoringSSL
--------------------

- Mandatory TlS 1.3

```
$ openssl s_client -connect example.com:8443
                   -ech_config_list <base64 of certs/bar.test.echlist>
                   -CAfile certs/root.crt -trace
                   -tls1_3
```

Client ECH trace
----------------

- "example.com" is encrypted, "foo.test" is open
```
...
extension_type=server_name(0), length=13
  0000 - 00 0b 00 00 08 66 6f 6f-2e 74 65 73 74         .....foo.test
extension_type=encrypted_client_hello(65037), length=218
  0000 - 00 00 01 00 01 0d 00 20-77 ac f1 94 2e 80 23   ....... w.....#
  000f - 34 18 17 61 8e 46 e7 5c-09 c5 2b 68 d7 e6 cd   4..a.F.\..+h...
  001e - 0c 35 c2 f6 41 09 2e ad-39 24 00 b0 bf 67 66   .5..A...9$...gf
  002d - fb b4 83 a8 8d 64 49 0f-fb 1c aa e9 d6 44 cc   .....dI......D.
  003c - 59 7e 59 55 7f bf d2 0f-72 e9 bf 8f 12 98 73   Y~YU....r.....s
  004b - 39 e9 8d f4 bf 87 72 ae-f5 9c e2 d9 d3 94 29   9.....r.......)
  005a - 13 f5 18 c6 92 48 b4 b7-00 5b 5b 82 b0 da f9   .....H...[[....
  0069 - 5e 26 73 75 fb 38 e9 82-3f 6b a4 ea 40 7c 77   ^&su.8..?k..@|w
  0078 - 46 99 22 a1 36 7d 8b 99-99 18 9b 4b aa 56 e6   F.".6}.....K.V.
  0087 - bd 78 f0 c6 02 f4 7b 38-e8 f5 b2 04 32 66 c6   .x....{8....2f.
  0096 - a0 e4 22 fc c3 5b ff d8-38 2a fd 0d 38 00 12   .."..[..8*..8..
  00a5 - 74 0c 91 d8 79 21 6b ad-1e 73 87 7a 39 b6 7c   t...y!k..s.z9.|
  00b4 - 38 80 a4 03 51 48 bf 47-6e 8e cc d1 17 a5 0a   8...QH.Gn......
  00c3 - 3e 28 c9 a8 4b 61 ad bb-7b 4d 97 fe a4 58 2d   >(..Ka..{M...X-
  00d2 - f7 34 b1 b8 45 74 cf 5e-                       .4..Et.^
...
```
- nginx debug log:
```
...
2025/06/06 13:45:28 [debug] 2867633#0: *1 SSL server name: "example.com"
...
```

TODO
====

- formats: PEM vs binary
- variables (dynamic loading)
- proxy
- Stream + split mode
