### PR TITLE
Add Web Application Manifest MIME type

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -31,6 +31,7 @@ types {
     application/java-archive                         jar war ear;
     application/json                                 json;
     application/mac-binhex40                         hqx;
+    application/manifest+json                        webmanifest;
     application/msword                               doc;
     application/pdf                                  pdf;
     application/postscript                           ps eps ai;


### PR DESCRIPTION
### Proposed changes

This is basically https://github.com/nginx/nginx/pull/137 re-opened. This MR was closed because of the lack of popularity on this MIME type and the lack of references.

However, I believe based on current 'state of the internet', this change is probably warranted, per the following comment I left (https://github.com/nginx/nginx/pull/137#issuecomment-2481127791): 
> Just wanted to chime in on this with noting that [MDN actively recommends](https://developer.mozilla.org/en-US/docs/Web/Manifest#deploying_a_manifest) responding with this mimetype on `.webmanifest` files, referring to https://w3c.github.io/manifest/#media-type-registration, which in my eyes is a relevant enough source to considering implementing this.

Possible other sources/references include:
- https://web.dev/articles/add-manifest#create
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types
- https://www.w3.org/TR/appmanifest/#using-a-link-element-to-link-to-a-manifest