### PR TITLE
Core: keep memory to a minimum in old workers.

### DIFF
--- a/auto/unix
+++ b/auto/unix
@@ -853,6 +853,16 @@ ngx_feature_test="void *p; p = memalign(4096, 4096);
 . auto/feature
 
 
+ngx_feature="malloc_trim()"
+ngx_feature_name="NGX_HAVE_MALLOC_TRIM"
+ngx_feature_run=no
+ngx_feature_incs="#include <malloc.h>"
+ngx_feature_path=
+ngx_feature_libs=
+ngx_feature_test="malloc_trim(0)"
+. auto/feature
+
+
 ngx_feature="mmap(MAP_ANON|MAP_SHARED)"
 ngx_feature_name="NGX_HAVE_MAP_ANON"
 ngx_feature_run=yes

--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -740,6 +740,12 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
             }
         }
 
+#if (NGX_HAVE_MALLOC_TRIM)
+        if (ngx_exiting) {
+            malloc_trim(0);
+        }
+#endif
+
         if (ngx_reopen) {
             ngx_reopen = 0;
             ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "reopening logs");


### PR DESCRIPTION
After nginx configuration reload, old workers may retain peak memory consumption which may increase overall system memory in use, considering multiple set of workers.

The change adds `malloc_trim(0)` call on each event loop iteration after reload to minimize memory consumption in old workers.  This call is currently available on Linux.