### PR TITLE
MIME: Add apk,appimage,metroska,otf,archive,torrent,visio,pcap definitions, update deb

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -25,6 +25,7 @@ types {
     image/x-jng                                      jng;
     image/x-ms-bmp                                   bmp;
 
+    font/otf                                         otf;
     font/woff                                        woff;
     font/woff2                                       woff2;
 
@@ -35,7 +36,10 @@ types {
     application/pdf                                  pdf;
     application/postscript                           ps eps ai;
     application/rtf                                  rtf;
+    application/vnd.android.package-archive          apk;
     application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.bzip3                            bz3;
+    application/vnd.debian.binary-package            deb udeb;
     application/vnd.google-earth.kml+xml             kml;
     application/vnd.google-earth.kmz                 kmz;
     application/vnd.ms-excel                         xls;
@@ -51,9 +55,15 @@ types {
                                                      xlsx;
     application/vnd.openxmlformats-officedocument.wordprocessingml.document
                                                      docx;
+    application/vnd.tcpdump.pcap                     pcap cap dmp;
+    application/vnd.visio                            vsd vst vsw vss;
     application/vnd.wap.wmlc                         wmlc;
     application/wasm                                 wasm;
     application/x-7z-compressed                      7z;
+    application/x-appimage                           appimage;
+    application/x-bittorrent                         torrent;
+    application/x-bzip                               bz;
+    application/x-bzip2                              bz2;
     application/x-cocoa                              cco;
     application/x-java-archive-diff                  jardiff;
     application/x-java-jnlp-file                     jnlp;
@@ -65,24 +75,34 @@ types {
     application/x-sea                                sea;
     application/x-shockwave-flash                    swf;
     application/x-stuffit                            sit;
+    application/x-tar                                tar;
     application/x-tcl                                tcl tk;
     application/x-x509-ca-cert                       der pem crt;
     application/x-xpinstall                          xpi;
     application/xhtml+xml                            xhtml;
     application/xspf+xml                             xspf;
     application/zip                                  zip;
+    application/zlib                                 zlib;
+    application/zstd                                 zst;
 
     application/octet-stream                         bin exe dll;
-    application/octet-stream                         deb;
     application/octet-stream                         dmg;
+    application/octet-stream                         gz;
     application/octet-stream                         iso img;
+    application/octet-stream                         lz;
+    application/octet-stream                         lzma;
     application/octet-stream                         msi msp msm;
+    application/octet-stream                         ova;
+    application/octet-stream                         txz;
+    application/octet-stream                         xz;
+    application/octet-stream                         zim;
 
     audio/midi                                       mid midi kar;
     audio/mpeg                                       mp3;
     audio/ogg                                        ogg;
     audio/x-m4a                                      m4a;
     audio/x-realaudio                                ra;
+    audio/x-matroska                                 mka;
 
     video/3gpp                                       3gpp 3gp;
     video/mp2t                                       ts;
@@ -92,6 +112,7 @@ types {
     video/webm                                       webm;
     video/x-flv                                      flv;
     video/x-m4v                                      m4v;
+    video/x-matroska                                 mkv;
     video/x-mng                                      mng;
     video/x-ms-asf                                   asx asf;
     video/x-ms-wmv                                   wmv;


### PR DESCRIPTION
Add the following mime types

- application/octet-stream gz
- application/octet-stream lz
- application/octet-stream ova
- application/octet-stream txz
- application/octet-stream xz
- application/octet-stream zim
- application/vnd.android.package-archive
- application/vnd.bzip3<br />https://www.iana.org/assignments/media-types/application/vnd.bzip3
- application/vnd.tcpdump.pcap<br />https://www.iana.org/assignments/media-types/application/vnd.tcpdump.pcap
- application/vnd.visio<br />https://www.iana.org/assignments/media-types/application/vnd.visio
- application/x-appimage
- application/x-bittorrent
- application/x-bzip
- application/x-bzip2
- application/x-tar
- application/zlib<br />https://www.iana.org/assignments/media-types/application/zlib
- application/zstd
- audio/x-matroska
- font/otf
- video/x-metroska

Update the following mime types

- application/vnd.debian.binary-package (instead of application/octet-stream for `.deb`)<br />Add the `.udeb` extension as well from the standards document.<br />https://www.iana.org/assignments/media-types/application/vnd.debian.binary-package

Further Reaading:

- Metroska
  - https://github.com/collab-project/videojs-record/issues/464
  - https://matroska.org/technical/specs/notes.html#MIME
  - https://chromium.googlesource.com/experimental/chromium/src/+/refs/wip/bajones/webvr/chrome/browser/resources/plugin_metadata/plugins_win.json#279
- Torrent
  - https://en.wikipedia.org/wiki/Torrent_file
  - https://www.bittorrent.org/beps/bep_0003.html
  - https://bittorrent.org/beps/bep_0052.html

Closes #730 #732 #733 #734 #735 #736