### PR TITLE
Core: fixed memory leak by freeing init_cycle.pool

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -292,6 +292,7 @@ main(int argc, char *const *argv)
 
     cycle = ngx_init_cycle(&init_cycle);
     if (cycle == NULL) {
+        ngx_destroy_pool(init_cycle.pool);	    
         if (ngx_test_config) {
             ngx_log_stderr(0, "configuration file %s test failed",
                            init_cycle.conf_file.data);
@@ -383,7 +384,7 @@ main(int argc, char *const *argv)
     } else {
         ngx_master_process_cycle(cycle);
     }
-
+    ngx_destroy_pool(init_cycle.pool);
     return 0;
 }
 


### PR DESCRIPTION
### Proposed changes

In the `main()` function of `src/core/nginx.c`, the `init_cycle.pool` memory allocation was not being freed in either the normal shutdown or error exit paths. As a result, dynamically allocated memory remained unreleased at process termination.

The patch adds an explicit call to `ngx_destroy_pool(init_cycle.pool)` in both return paths to ensure proper cleanup.

Closes #742