### PR TITLE
Xslt: fixed handle vsnprintf return value

### DIFF
--- a/src/http/modules/ngx_http_xslt_filter_module.c
+++ b/src/http/modules/ngx_http_xslt_filter_module.c
@@ -465,7 +465,7 @@ ngx_http_xslt_sax_error(void *data, const char *msg, ...)
 {
     xmlParserCtxtPtr ctxt = data;
 
-    size_t                       n;
+    int                          n;
     va_list                      args;
     ngx_http_xslt_filter_ctx_t  *ctx;
     u_char                       buf[NGX_MAX_ERROR_STR];
@@ -475,13 +475,23 @@ ngx_http_xslt_sax_error(void *data, const char *msg, ...)
     buf[0] = '\0';
 
     va_start(args, msg);
-    n = (size_t) vsnprintf((char *) buf, NGX_MAX_ERROR_STR, msg, args);
+    n = vsnprintf((char *) buf, NGX_MAX_ERROR_STR, msg, args);
     va_end(args);
+
+    if (n <= 0) {
+        ngx_log_error(NGX_LOG_ERR, ctx->request->connection->log, ngx_errno,
+                      "libxml2 error");
+        return;
+    }
+
+    if (n > NGX_MAX_ERROR_STR) {
+        n = NGX_MAX_ERROR_STR;
+    }
 
     while (--n && (buf[n] == CR || buf[n] == LF)) { /* void */ }
 
     ngx_log_error(NGX_LOG_ERR, ctx->request->connection->log, 0,
-                  "libxml2 error: \"%*s\"", n + 1, buf);
+                  "libxml2 error: \"%*s\"", (size_t) (n + 1), buf);
 }
 
 


### PR DESCRIPTION
1. The result of vsnprintf was cast to size_t, which could lead to a signed-to-unsigned overflow error.
2. There was no handling for cases where vsnprintf returns a negative value, zero, or a value greater than NGX_MAX_ERROR_STR.