### PR TITLE
QUIC: adjusted OpenSSL 3.5 QUIC API feature test.

### DIFF
--- a/src/event/quic/ngx_event_quic.h
+++ b/src/event/quic/ngx_event_quic.h
@@ -12,11 +12,8 @@
 #include <ngx_core.h>
 
 
-#ifdef OSSL_RECORD_PROTECTION_LEVEL_NONE
-#ifndef NGX_QUIC_OPENSSL_API
-#define NGX_QUIC_BORINGSSL_API               1
-#define NGX_QUIC_OPENSSL_COMPAT              1
-#endif
+#if (OPENSSL_VERSION_NUMBER >= 0x30500010L)
+#define NGX_QUIC_OPENSSL_API                 1
 
 #elif (defined SSL_R_MISSING_QUIC_TRANSPORT_PARAMETERS_EXTENSION)
 #define NGX_QUIC_QUICTLS_API                 1


### PR DESCRIPTION
In OpenSSL 3.5.0, the "quic_transport_parameters" extension set internally by the QUIC API is cleared on the SSL context switch, which disables sending QUIC transport parameters if switching to a different server block on SNI.  See the initial report in [1].

The test was narrowed down to the version number, in anticipation for the upcoming OpenSSL 3.5.1 release with the required bugfix [2]. Using OpenSSL 3.5.0 now falls back to the OpenSSL compat layer.

[1] https://github.com/nginx/nginx/issues/711
[2] https://github.com/openssl/openssl/commit/45bd3c3798
