### PR TITLE
QUIC: disabled OpenSSL 3.5 QUIC API support by default.

### DIFF
--- a/src/event/quic/ngx_event_quic.h
+++ b/src/event/quic/ngx_event_quic.h
@@ -13,7 +13,10 @@
 
 
 #ifdef OSSL_RECORD_PROTECTION_LEVEL_NONE
-#define NGX_QUIC_OPENSSL_API                 1
+#ifndef NGX_QUIC_OPENSSL_API
+#define NGX_QUIC_BORINGSSL_API               1
+#define NGX_QUIC_OPENSSL_COMPAT              1
+#endif
 
 #elif (defined SSL_R_MISSING_QUIC_TRANSPORT_PARAMETERS_EXTENSION)
 #define NGX_QUIC_QUICTLS_API                 1


### PR DESCRIPTION
QUIC: disabled OpenSSL 3.5 QUIC API support by default.

In OpenSSL 3.5.0, the "quic_transport_parameters" extension set
internally by the QUIC API is cleared on the SSL context switch,
which disables sending QUIC transport parameters if switching to
a different server block on SNI.  See the initial report in [1].

This is fixed post OpenSSL 3.5.0 [2].  The fix is anticipated in
OpenSSL 3.5.1, which has not been released yet.  When building
with OpenSSL 3.5, OpenSSL compat layer is now used by default.
The OpenSSL 3.5 QUIC API support can be switched back using
--with-cc-opt='-DNGX_QUIC_OPENSSL_API=1'.

[1] https://github.com/nginx/nginx/issues/711
[2] https://github.com/openssl/openssl/commit/45bd3c3798
