### PR TITLE
HTTP/2 to upstream

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -781,6 +781,17 @@ if [ $HTTP = YES ]; then
         . auto/module
     fi
 
+    if [ $HTTP_PROXY = YES -a $HTTP_V2 = YES ]; then
+        ngx_module_name=ngx_http_proxy_v2_module
+        ngx_module_incs=
+        ngx_module_deps=
+        ngx_module_srcs=src/http/modules/ngx_http_proxy_v2_module.c
+        ngx_module_libs=
+        ngx_module_link=$HTTP_V2
+
+        . auto/module
+    fi
+
     if [ $HTTP_PERL != NO ]; then
         ngx_module_name=ngx_http_perl_module
         ngx_module_incs=src/http/modules/perl

--- a/auto/modules
+++ b/auto/modules
@@ -729,7 +729,7 @@ if [ $HTTP = YES ]; then
 
         ngx_module_name=ngx_http_proxy_module
         ngx_module_incs=
-        ngx_module_deps=
+        ngx_module_deps=src/http/modules/ngx_http_proxy_module.h
         ngx_module_srcs=src/http/modules/ngx_http_proxy_module.c
         ngx_module_libs=
         ngx_module_link=$HTTP_PROXY

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -198,6 +198,9 @@ static ngx_conf_post_t  ngx_http_proxy_ssl_conf_command_post =
 static ngx_conf_enum_t  ngx_http_proxy_http_version[] = {
     { ngx_string("1.0"), NGX_HTTP_VERSION_10 },
     { ngx_string("1.1"), NGX_HTTP_VERSION_11 },
+#if (NGX_HTTP_V2)
+    { ngx_string("2"), NGX_HTTP_VERSION_20 },
+#endif
     { ngx_null_string, 0 }
 };
 
@@ -875,6 +878,14 @@ ngx_http_proxy_handler(ngx_http_request_t *r)
     ngx_http_proxy_main_conf_t  *pmcf;
 #endif
 
+    plcf = ngx_http_get_module_loc_conf(r, ngx_http_proxy_module);
+
+#if (NGX_HTTP_V2)
+    if (plcf->http_version == NGX_HTTP_VERSION_20) {
+        return ngx_http_proxy_v2_handler(r);
+    }
+#endif
+
     if (ngx_http_upstream_create(r) != NGX_OK) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
@@ -887,8 +898,6 @@ ngx_http_proxy_handler(ngx_http_request_t *r)
     ctx->legacy = 1;
 
     ngx_http_set_ctx(r, ctx, ngx_http_proxy_module);
-
-    plcf = ngx_http_get_module_loc_conf(r, ngx_http_proxy_module);
 
     u = r->upstream;
 

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -8,6 +8,7 @@
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
+#include <ngx_http_proxy_module.h>
 
 
 #define  NGX_HTTP_PROXY_COOKIE_SECURE           0x0001
@@ -21,11 +22,6 @@
 #define  NGX_HTTP_PROXY_COOKIE_SAMESITE_LAX     0x0100
 #define  NGX_HTTP_PROXY_COOKIE_SAMESITE_NONE    0x0200
 #define  NGX_HTTP_PROXY_COOKIE_SAMESITE_OFF     0x0400
-
-
-typedef struct {
-    ngx_array_t                    caches;  /* ngx_http_file_cache_t * */
-} ngx_http_proxy_main_conf_t;
 
 
 typedef struct ngx_http_proxy_rewrite_s  ngx_http_proxy_rewrite_t;
@@ -61,96 +57,6 @@ typedef struct {
 } ngx_http_proxy_cookie_flags_t;
 
 
-typedef struct {
-    ngx_str_t                      key_start;
-    ngx_str_t                      schema;
-    ngx_str_t                      host_header;
-    ngx_str_t                      port;
-    ngx_str_t                      uri;
-} ngx_http_proxy_vars_t;
-
-
-typedef struct {
-    ngx_array_t                   *flushes;
-    ngx_array_t                   *lengths;
-    ngx_array_t                   *values;
-    ngx_hash_t                     hash;
-} ngx_http_proxy_headers_t;
-
-
-typedef struct {
-    ngx_http_upstream_conf_t       upstream;
-
-    ngx_array_t                   *body_flushes;
-    ngx_array_t                   *body_lengths;
-    ngx_array_t                   *body_values;
-    ngx_str_t                      body_source;
-
-    ngx_http_proxy_headers_t       headers;
-#if (NGX_HTTP_CACHE)
-    ngx_http_proxy_headers_t       headers_cache;
-#endif
-    ngx_array_t                   *headers_source;
-
-    ngx_array_t                   *proxy_lengths;
-    ngx_array_t                   *proxy_values;
-
-    ngx_array_t                   *redirects;
-    ngx_array_t                   *cookie_domains;
-    ngx_array_t                   *cookie_paths;
-    ngx_array_t                   *cookie_flags;
-
-    ngx_http_complex_value_t      *method;
-    ngx_str_t                      location;
-    ngx_str_t                      url;
-
-#if (NGX_HTTP_CACHE)
-    ngx_http_complex_value_t       cache_key;
-#endif
-
-    ngx_http_proxy_vars_t          vars;
-
-    ngx_flag_t                     redirect;
-
-    ngx_uint_t                     http_version;
-
-    ngx_uint_t                     headers_hash_max_size;
-    ngx_uint_t                     headers_hash_bucket_size;
-
-#if (NGX_HTTP_SSL)
-    ngx_uint_t                     ssl;
-    ngx_uint_t                     ssl_protocols;
-    ngx_str_t                      ssl_ciphers;
-    ngx_uint_t                     ssl_verify_depth;
-    ngx_str_t                      ssl_trusted_certificate;
-    ngx_str_t                      ssl_crl;
-    ngx_array_t                   *ssl_conf_commands;
-#endif
-} ngx_http_proxy_loc_conf_t;
-
-
-typedef struct {
-    ngx_http_status_t              status;
-    ngx_http_chunked_t             chunked;
-    ngx_http_proxy_vars_t          vars;
-    off_t                          internal_body_length;
-
-    ngx_chain_t                   *free;
-    ngx_chain_t                   *busy;
-
-    ngx_buf_t                     *trailers;
-
-    unsigned                       head:1;
-    unsigned                       internal_chunked:1;
-    unsigned                       header_sent:1;
-} ngx_http_proxy_ctx_t;
-
-
-static ngx_int_t ngx_http_proxy_eval(ngx_http_request_t *r,
-    ngx_http_proxy_ctx_t *ctx, ngx_http_proxy_loc_conf_t *plcf);
-#if (NGX_HTTP_CACHE)
-static ngx_int_t ngx_http_proxy_create_key(ngx_http_request_t *r);
-#endif
 static ngx_int_t ngx_http_proxy_create_request(ngx_http_request_t *r);
 static ngx_int_t ngx_http_proxy_reinit_request(ngx_http_request_t *r);
 static ngx_int_t ngx_http_proxy_body_output_filter(void *data, ngx_chain_t *in);
@@ -179,14 +85,13 @@ static ngx_int_t
     ngx_http_proxy_add_x_forwarded_for_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t
+    ngx_http_proxy_internal_connection_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t
     ngx_http_proxy_internal_body_length_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_proxy_internal_chunked_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
-static ngx_int_t ngx_http_proxy_rewrite_redirect(ngx_http_request_t *r,
-    ngx_table_elt_t *h, size_t prefix);
-static ngx_int_t ngx_http_proxy_rewrite_cookie(ngx_http_request_t *r,
-    ngx_table_elt_t *h);
 static ngx_int_t ngx_http_proxy_parse_cookie(ngx_str_t *value,
     ngx_array_t *attrs);
 static ngx_int_t ngx_http_proxy_rewrite_cookie_value(ngx_http_request_t *r,
@@ -840,8 +745,8 @@ static char  ngx_http_proxy_version_11[] = " HTTP/1.1" CRLF;
 
 
 static ngx_keyval_t  ngx_http_proxy_headers[] = {
-    { ngx_string("Host"), ngx_string("$proxy_host") },
-    { ngx_string("Connection"), ngx_string("close") },
+    { ngx_string("Host"), ngx_string("$proxy_internal_host") },
+    { ngx_string("Connection"), ngx_string("$proxy_internal_connection") },
     { ngx_string("Content-Length"), ngx_string("$proxy_internal_body_length") },
     { ngx_string("Transfer-Encoding"), ngx_string("$proxy_internal_chunked") },
     { ngx_string("TE"), ngx_string("") },
@@ -868,8 +773,8 @@ static ngx_str_t  ngx_http_proxy_hide_headers[] = {
 #if (NGX_HTTP_CACHE)
 
 static ngx_keyval_t  ngx_http_proxy_cache_headers[] = {
-    { ngx_string("Host"), ngx_string("$proxy_host") },
-    { ngx_string("Connection"), ngx_string("close") },
+    { ngx_string("Host"), ngx_string("$proxy_internal_host") },
+    { ngx_string("Connection"), ngx_string("$proxy_internal_connection") },
     { ngx_string("Content-Length"), ngx_string("$proxy_internal_body_length") },
     { ngx_string("Transfer-Encoding"), ngx_string("$proxy_internal_chunked") },
     { ngx_string("TE"), ngx_string("") },
@@ -903,6 +808,14 @@ static ngx_http_variable_t  ngx_http_proxy_vars[] = {
 #if 0
     { ngx_string("proxy_add_via"), NULL, NULL, 0, NGX_HTTP_VAR_NOHASH, 0 },
 #endif
+
+    { ngx_string("proxy_internal_host"), NULL,
+      ngx_http_proxy_host_variable, 1,
+      NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_NOCACHEABLE|NGX_HTTP_VAR_NOHASH, 0 },
+
+    { ngx_string("proxy_internal_connection"), NULL,
+      ngx_http_proxy_internal_connection_variable, 0,
+      NGX_HTTP_VAR_NOCACHEABLE|NGX_HTTP_VAR_NOHASH, 0 },
 
     { ngx_string("proxy_internal_body_length"), NULL,
       ngx_http_proxy_internal_body_length_variable, 0,
@@ -970,6 +883,8 @@ ngx_http_proxy_handler(ngx_http_request_t *r)
     if (ctx == NULL) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
+
+    ctx->legacy = 1;
 
     ngx_http_set_ctx(r, ctx, ngx_http_proxy_module);
 
@@ -1050,7 +965,7 @@ ngx_http_proxy_handler(ngx_http_request_t *r)
 }
 
 
-static ngx_int_t
+ngx_int_t
 ngx_http_proxy_eval(ngx_http_request_t *r, ngx_http_proxy_ctx_t *ctx,
     ngx_http_proxy_loc_conf_t *plcf)
 {
@@ -1154,7 +1069,7 @@ ngx_http_proxy_eval(ngx_http_request_t *r, ngx_http_proxy_ctx_t *ctx,
 
 #if (NGX_HTTP_CACHE)
 
-static ngx_int_t
+ngx_int_t
 ngx_http_proxy_create_key(ngx_http_request_t *r)
 {
     size_t                      len, loc_len;
@@ -2768,6 +2683,11 @@ ngx_http_proxy_host_variable(ngx_http_request_t *r,
         return NGX_OK;
     }
 
+    if (data == 1 && !ctx->legacy) {
+        v->not_found = 1;
+        return NGX_OK;
+    }
+
     v->len = ctx->vars.host_header.len;
     v->valid = 1;
     v->no_cacheable = 0;
@@ -2849,6 +2769,29 @@ ngx_http_proxy_add_x_forwarded_for_variable(ngx_http_request_t *r,
 
 
 static ngx_int_t
+ngx_http_proxy_internal_connection_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    ngx_http_proxy_ctx_t  *ctx;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_proxy_module);
+
+    if (ctx == NULL || !ctx->legacy) {
+        v->not_found = 1;
+        return NGX_OK;
+    }
+
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+
+    ngx_str_set(v, "close");
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
 ngx_http_proxy_internal_body_length_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data)
 {
@@ -2901,7 +2844,7 @@ ngx_http_proxy_internal_chunked_variable(ngx_http_request_t *r,
 }
 
 
-static ngx_int_t
+ngx_int_t
 ngx_http_proxy_rewrite_redirect(ngx_http_request_t *r, ngx_table_elt_t *h,
     size_t prefix)
 {
@@ -2933,7 +2876,7 @@ ngx_http_proxy_rewrite_redirect(ngx_http_request_t *r, ngx_table_elt_t *h,
 }
 
 
-static ngx_int_t
+ngx_int_t
 ngx_http_proxy_rewrite_cookie(ngx_http_request_t *r, ngx_table_elt_t *h)
 {
     u_char                     *p;
@@ -3578,6 +3521,7 @@ ngx_http_proxy_create_loc_conf(ngx_conf_t *cf)
      *     conf->headers.values = NULL;
      *     conf->headers.hash = { NULL, 0 };
      *     conf->headers_cache.lengths = NULL;
+     *     conf->host_set = 0;
      *     conf->headers_cache.values = NULL;
      *     conf->headers_cache.hash = { NULL, 0 };
      *     conf->body_lengths = NULL;
@@ -4153,6 +4097,7 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 #if (NGX_HTTP_CACHE)
         conf->headers_cache = prev->headers_cache;
 #endif
+        conf->host_set = prev->host_set;
     }
 
     rc = ngx_http_proxy_init_headers(cf, conf, &conf->headers,
@@ -4185,6 +4130,7 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 #if (NGX_HTTP_CACHE)
         prev->headers_cache = conf->headers_cache;
 #endif
+        prev->host_set = conf->host_set;
     }
 
     return NGX_CONF_OK;
@@ -4236,6 +4182,12 @@ ngx_http_proxy_init_headers(ngx_conf_t *cf, ngx_http_proxy_loc_conf_t *conf,
 
         src = conf->headers_source->elts;
         for (i = 0; i < conf->headers_source->nelts; i++) {
+
+            if (src[i].key.len == 4
+                && ngx_strncasecmp(src[i].key.data, (u_char *) "Host", 4) == 0)
+            {
+                conf->host_set = 1;
+            }
 
             s = ngx_array_push(&headers_merged);
             if (s == NULL) {

--- a/src/http/modules/ngx_http_proxy_module.h
+++ b/src/http/modules/ngx_http_proxy_module.h
@@ -116,6 +116,10 @@ ngx_int_t ngx_http_proxy_rewrite_redirect(ngx_http_request_t *r,
 ngx_int_t ngx_http_proxy_rewrite_cookie(ngx_http_request_t *r,
     ngx_table_elt_t *h);
 
+#if (NGX_HTTP_V2)
+ngx_int_t ngx_http_proxy_v2_handler(ngx_http_request_t *r);
+#endif
+
 
 extern ngx_module_t  ngx_http_proxy_module;
 

--- a/src/http/modules/ngx_http_proxy_module.h
+++ b/src/http/modules/ngx_http_proxy_module.h
@@ -1,0 +1,123 @@
+
+/*
+ * Copyright (C) Igor Sysoev
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#ifndef _NGX_HTTP_PROXY_H_INCLUDED_
+#define _NGX_HTTP_PROXY_H_INCLUDED_
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+
+typedef struct {
+    ngx_array_t                    caches;  /* ngx_http_file_cache_t * */
+} ngx_http_proxy_main_conf_t;
+
+
+typedef struct {
+    ngx_str_t                      key_start;
+    ngx_str_t                      schema;
+    ngx_str_t                      host_header;
+    ngx_str_t                      port;
+    ngx_str_t                      uri;
+} ngx_http_proxy_vars_t;
+
+
+typedef struct {
+    ngx_array_t                   *flushes;
+    ngx_array_t                   *lengths;
+    ngx_array_t                   *values;
+    ngx_hash_t                     hash;
+} ngx_http_proxy_headers_t;
+
+
+typedef struct {
+    ngx_http_upstream_conf_t       upstream;
+
+    ngx_array_t                   *body_flushes;
+    ngx_array_t                   *body_lengths;
+    ngx_array_t                   *body_values;
+    ngx_str_t                      body_source;
+
+    ngx_http_proxy_headers_t       headers;
+#if (NGX_HTTP_CACHE)
+    ngx_http_proxy_headers_t       headers_cache;
+#endif
+    ngx_array_t                   *headers_source;
+    ngx_uint_t                     host_set;
+
+    ngx_array_t                   *proxy_lengths;
+    ngx_array_t                   *proxy_values;
+
+    ngx_array_t                   *redirects;
+    ngx_array_t                   *cookie_domains;
+    ngx_array_t                   *cookie_paths;
+    ngx_array_t                   *cookie_flags;
+
+    ngx_http_complex_value_t      *method;
+    ngx_str_t                      location;
+    ngx_str_t                      url;
+
+#if (NGX_HTTP_CACHE)
+    ngx_http_complex_value_t       cache_key;
+#endif
+
+    ngx_http_proxy_vars_t          vars;
+
+    ngx_flag_t                     redirect;
+
+    ngx_uint_t                     http_version;
+
+    ngx_uint_t                     headers_hash_max_size;
+    ngx_uint_t                     headers_hash_bucket_size;
+
+#if (NGX_HTTP_SSL || NGX_COMPAT)
+    ngx_uint_t                     ssl;
+    ngx_uint_t                     ssl_protocols;
+    ngx_str_t                      ssl_ciphers;
+    ngx_uint_t                     ssl_verify_depth;
+    ngx_str_t                      ssl_trusted_certificate;
+    ngx_str_t                      ssl_crl;
+    ngx_array_t                   *ssl_conf_commands;
+#endif
+} ngx_http_proxy_loc_conf_t;
+
+
+typedef struct {
+    ngx_http_status_t              status;
+    ngx_http_chunked_t             chunked;
+    ngx_http_proxy_vars_t          vars;
+    off_t                          internal_body_length;
+
+    ngx_chain_t                   *free;
+    ngx_chain_t                   *busy;
+
+    ngx_buf_t                     *trailers;
+
+    unsigned                       head:1;
+    unsigned                       internal_chunked:1;
+    unsigned                       header_sent:1;
+    unsigned                       legacy:1;
+} ngx_http_proxy_ctx_t;
+
+
+ngx_int_t ngx_http_proxy_eval(ngx_http_request_t *r, ngx_http_proxy_ctx_t *ctx,
+    ngx_http_proxy_loc_conf_t *plcf);
+#if (NGX_HTTP_CACHE)
+ngx_int_t ngx_http_proxy_create_key(ngx_http_request_t *r);
+#endif
+ngx_int_t ngx_http_proxy_rewrite_redirect(ngx_http_request_t *r,
+    ngx_table_elt_t *h, size_t prefix);
+ngx_int_t ngx_http_proxy_rewrite_cookie(ngx_http_request_t *r,
+    ngx_table_elt_t *h);
+
+
+extern ngx_module_t  ngx_http_proxy_module;
+
+
+#endif /* _NGX_HTTP_PROXY_H_INCLUDED_ */

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -1,0 +1,4012 @@
+
+/*
+ * Copyright (C) Maxim Dounin
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <ngx_http_proxy_module.h>
+
+
+typedef enum {
+    ngx_http_proxy_v2_st_start = 0,
+    ngx_http_proxy_v2_st_length_2,
+    ngx_http_proxy_v2_st_length_3,
+    ngx_http_proxy_v2_st_type,
+    ngx_http_proxy_v2_st_flags,
+    ngx_http_proxy_v2_st_stream_id,
+    ngx_http_proxy_v2_st_stream_id_2,
+    ngx_http_proxy_v2_st_stream_id_3,
+    ngx_http_proxy_v2_st_stream_id_4,
+    ngx_http_proxy_v2_st_payload,
+    ngx_http_proxy_v2_st_padding
+} ngx_http_proxy_v2_state_e;
+
+
+typedef struct {
+    size_t                         init_window;
+    size_t                         send_window;
+    size_t                         recv_window;
+    ngx_uint_t                     last_stream_id;
+} ngx_http_proxy_v2_conn_t;
+
+
+typedef struct {
+    ngx_http_proxy_ctx_t           ctx;
+
+    ngx_http_proxy_v2_state_e      state;
+    ngx_uint_t                     frame_state;
+    ngx_uint_t                     fragment_state;
+
+    ngx_chain_t                   *in;
+    ngx_chain_t                   *out;
+    ngx_chain_t                   *free;
+    ngx_chain_t                   *busy;
+
+    ngx_http_proxy_v2_conn_t      *connection;
+
+    ngx_uint_t                     id;
+
+    ngx_uint_t                     pings;
+    ngx_uint_t                     settings;
+
+    off_t                          length;
+
+    ssize_t                        send_window;
+    size_t                         recv_window;
+
+    size_t                         rest;
+    ngx_uint_t                     stream_id;
+    u_char                         type;
+    u_char                         flags;
+    u_char                         padding;
+
+    ngx_uint_t                     error;
+    ngx_uint_t                     window_update;
+
+    ngx_uint_t                     setting_id;
+    ngx_uint_t                     setting_value;
+
+    u_char                         ping_data[8];
+
+    ngx_uint_t                     index;
+    ngx_str_t                      name;
+    ngx_str_t                      value;
+
+    u_char                        *field_end;
+    size_t                         field_length;
+    size_t                         field_rest;
+    u_char                         field_state;
+
+    unsigned                       literal:1;
+    unsigned                       field_huffman:1;
+
+    unsigned                       header_sent:1;
+    unsigned                       output_closed:1;
+    unsigned                       output_blocked:1;
+    unsigned                       parsing_headers:1;
+    unsigned                       end_stream:1;
+    unsigned                       done:1;
+    unsigned                       status:1;
+    unsigned                       rst:1;
+    unsigned                       goaway:1;
+} ngx_http_proxy_v2_ctx_t;
+
+
+typedef struct {
+    u_char                        length_0;
+    u_char                        length_1;
+    u_char                        length_2;
+    u_char                        type;
+    u_char                        flags;
+    u_char                        stream_id_0;
+    u_char                        stream_id_1;
+    u_char                        stream_id_2;
+    u_char                        stream_id_3;
+} ngx_http_proxy_v2_frame_t;
+
+
+static ngx_int_t ngx_http_proxy_v2_create_request(ngx_http_request_t *r);
+static ngx_int_t ngx_http_proxy_v2_reinit_request(ngx_http_request_t *r);
+static ngx_int_t ngx_http_proxy_v2_body_output_filter(void *data,
+    ngx_chain_t *in);
+static ngx_int_t ngx_http_proxy_v2_process_header(ngx_http_request_t *r);
+static ngx_int_t ngx_http_proxy_v2_filter_init(void *data);
+static ngx_int_t ngx_http_proxy_v2_non_buffered_filter(void *data,
+    ssize_t bytes);
+
+static ngx_int_t ngx_http_proxy_v2_parse_frame(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b);
+static ngx_int_t ngx_http_proxy_v2_parse_header(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b);
+static ngx_int_t ngx_http_proxy_v2_parse_fragment(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b);
+static ngx_int_t ngx_http_proxy_v2_validate_header_name(ngx_http_request_t *r,
+    ngx_str_t *s);
+static ngx_int_t ngx_http_proxy_v2_validate_header_value(ngx_http_request_t *r,
+    ngx_str_t *s);
+static ngx_int_t ngx_http_proxy_v2_parse_rst_stream(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b);
+static ngx_int_t ngx_http_proxy_v2_parse_goaway(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b);
+static ngx_int_t ngx_http_proxy_v2_parse_window_update(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b);
+static ngx_int_t ngx_http_proxy_v2_parse_settings(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b);
+static ngx_int_t ngx_http_proxy_v2_parse_ping(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b);
+
+static ngx_int_t ngx_http_proxy_v2_send_settings_ack(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx);
+static ngx_int_t ngx_http_proxy_v2_send_ping_ack(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx);
+static ngx_int_t ngx_http_proxy_v2_send_window_update(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx);
+
+static ngx_chain_t *ngx_http_proxy_v2_get_buf(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx);
+static ngx_http_proxy_v2_ctx_t *
+    ngx_http_proxy_v2_get_ctx(ngx_http_request_t *r);
+static ngx_int_t ngx_http_proxy_v2_get_connection_data(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_peer_connection_t *pc);
+static void ngx_http_proxy_v2_cleanup(void *data);
+
+static void ngx_http_proxy_v2_abort_request(ngx_http_request_t *r);
+static void ngx_http_proxy_v2_finalize_request(ngx_http_request_t *r,
+    ngx_int_t rc);
+
+
+static ngx_http_module_t  ngx_http_proxy_v2_module_ctx = {
+    NULL,                                  /* preconfiguration */
+    NULL,                                  /* postconfiguration */
+
+    NULL,                                  /* create main configuration */
+    NULL,                                  /* init main configuration */
+
+    NULL,                                  /* create server configuration */
+    NULL,                                  /* merge server configuration */
+
+    NULL,                                  /* create location configuration */
+    NULL                                   /* merge location configuration */
+};
+
+
+ngx_module_t  ngx_http_proxy_v2_module = {
+    NGX_MODULE_V1,
+    &ngx_http_proxy_v2_module_ctx,         /* module context */
+    NULL,                                  /* module directives */
+    NGX_HTTP_MODULE,                       /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    NULL,                                  /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    NULL,                                  /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+static u_char  ngx_http_proxy_v2_connection_start[] =
+    "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"         /* connection preface */
+
+    "\x00\x00\x12\x04\x00\x00\x00\x00\x00"     /* settings frame */
+    "\x00\x01\x00\x00\x00\x00"                 /* header table size */
+    "\x00\x02\x00\x00\x00\x00"                 /* disable push */
+    "\x00\x04\x7f\xff\xff\xff"                 /* initial window */
+
+    "\x00\x00\x04\x08\x00\x00\x00\x00\x00"     /* window update frame */
+    "\x7f\xff\x00\x00";
+
+
+ngx_int_t
+ngx_http_proxy_v2_handler(ngx_http_request_t *r)
+{
+    ngx_int_t                   rc;
+    ngx_http_upstream_t        *u;
+    ngx_http_proxy_v2_ctx_t    *ctx;
+    ngx_http_proxy_loc_conf_t  *plcf;
+
+    if (ngx_http_upstream_create(r) != NGX_OK) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    ctx = ngx_pcalloc(r->pool, sizeof(ngx_http_proxy_v2_ctx_t));
+    if (ctx == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    ngx_http_set_ctx(r, ctx, ngx_http_proxy_v2_module);
+
+    ngx_http_set_ctx(r, &ctx->ctx, ngx_http_proxy_module);
+
+    plcf = ngx_http_get_module_loc_conf(r, ngx_http_proxy_module);
+
+    plcf->upstream.preserve_output = 1;
+
+    u = r->upstream;
+
+    if (plcf->proxy_lengths == NULL) {
+        ctx->ctx.vars = plcf->vars;
+        u->schema = plcf->vars.schema;
+#if (NGX_HTTP_SSL)
+        u->ssl = plcf->ssl;
+#endif
+
+    } else {
+        if (ngx_http_proxy_eval(r, &ctx->ctx, plcf) != NGX_OK) {
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+    }
+
+#if (NGX_HTTP_SSL)
+    ngx_str_set(&u->ssl_alpn_protocol, NGX_HTTP_V2_ALPN_PROTO);
+#endif
+
+    u->output.tag = (ngx_buf_tag_t) &ngx_http_proxy_v2_module;
+
+    u->conf = &plcf->upstream;
+
+    u->create_request = ngx_http_proxy_v2_create_request;
+    u->reinit_request = ngx_http_proxy_v2_reinit_request;
+    u->process_header = ngx_http_proxy_v2_process_header;
+    u->abort_request = ngx_http_proxy_v2_abort_request;
+    u->finalize_request = ngx_http_proxy_v2_finalize_request;
+
+    if (plcf->redirects) {
+        u->rewrite_redirect = ngx_http_proxy_rewrite_redirect;
+    }
+
+    if (plcf->cookie_domains || plcf->cookie_paths || plcf->cookie_flags) {
+        u->rewrite_cookie = ngx_http_proxy_rewrite_cookie;
+    }
+
+    u->input_filter_init = ngx_http_proxy_v2_filter_init;
+    u->input_filter = ngx_http_proxy_v2_non_buffered_filter;
+    u->input_filter_ctx = r;
+
+    u->accel = 1;
+
+    if (!plcf->upstream.request_buffering
+        && plcf->body_values == NULL && plcf->upstream.pass_request_body)
+    {
+        r->request_body_no_buffering = 1;
+    }
+
+    rc = ngx_http_read_client_request_body(r, ngx_http_upstream_init);
+
+    if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+        return rc;
+    }
+
+    return NGX_DONE;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_create_request(ngx_http_request_t *r)
+{
+    u_char                       *p, *tmp, *key_tmp, *val_tmp, *headers_frame;
+    size_t                        len, tmp_len, key_len, val_len, uri_len,
+                                  loc_len, body_len;
+    uintptr_t                     escape;
+    ngx_buf_t                    *b;
+    ngx_str_t                     method, *host;
+    ngx_uint_t                    i, next, unparsed_uri;
+    ngx_chain_t                  *cl, *body;
+    ngx_list_part_t              *part;
+    ngx_table_elt_t              *header;
+    ngx_http_upstream_t          *u;
+    ngx_http_proxy_v2_ctx_t      *ctx;
+    ngx_http_script_code_pt       code;
+    ngx_http_script_engine_t      e, le;
+    ngx_http_proxy_headers_t     *headers;
+    ngx_http_proxy_v2_frame_t    *f;
+    ngx_http_proxy_loc_conf_t    *plcf;
+    ngx_http_script_len_code_pt   lcode;
+
+    u = r->upstream;
+
+    plcf = ngx_http_get_module_loc_conf(r, ngx_http_proxy_module);
+
+    headers = &plcf->headers;
+
+    if (u->method.len) {
+        /* HEAD was changed to GET to cache response */
+        method = u->method;
+
+    } else if (plcf->method) {
+        if (ngx_http_complex_value(r, plcf->method, &method) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+    } else {
+        method = r->method_name;
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_proxy_v2_module);
+
+    if (method.len == 4
+        && ngx_strncasecmp(method.data, (u_char *) "HEAD", 4) == 0)
+    {
+        ctx->ctx.head = 1;
+    }
+
+    len = sizeof(ngx_http_proxy_v2_connection_start) - 1
+          + sizeof(ngx_http_proxy_v2_frame_t);             /* headers frame */
+
+    /* :method header */
+
+    if ((method.len == 3 && ngx_strncmp(method.data, "GET", 3) == 0)
+        || (method.len == 4 && ngx_strncmp(method.data, "POST", 4) == 0))
+    {
+        len += 1;
+        tmp_len = 0;
+
+    } else {
+        len += 1 + NGX_HTTP_V2_INT_OCTETS + method.len;
+        tmp_len = method.len;
+    }
+
+    /* :scheme header */
+
+    len += 1;
+
+    /* :path header */
+
+    escape = 0;
+    loc_len = 0;
+    unparsed_uri = 0;
+
+    if (plcf->proxy_lengths && ctx->ctx.vars.uri.len) {
+        uri_len = ctx->ctx.vars.uri.len;
+
+    } else if (ctx->ctx.vars.uri.len == 0 && r->valid_unparsed_uri) {
+        unparsed_uri = 1;
+        uri_len = r->unparsed_uri.len;
+
+    } else {
+        loc_len = (r->valid_location && ctx->ctx.vars.uri.len)
+                  ? ngx_min(plcf->location.len, r->uri.len) : 0;
+
+        if (r->quoted_uri || r->internal) {
+            escape = 2 * ngx_escape_uri(NULL, r->uri.data + loc_len,
+                                        r->uri.len - loc_len, NGX_ESCAPE_URI);
+        }
+
+        uri_len = ctx->ctx.vars.uri.len + r->uri.len - loc_len + escape
+                  + sizeof("?") - 1 + r->args.len;
+    }
+
+    if (uri_len == 0) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "zero length URI to proxy");
+        return NGX_ERROR;
+    }
+
+    len += 1 + NGX_HTTP_V2_INT_OCTETS + uri_len;
+
+    if (tmp_len < uri_len) {
+        tmp_len = uri_len;
+    }
+
+    /* :authority header */
+
+    host = &ctx->ctx.vars.host_header;
+
+    if (!plcf->host_set) {
+        len += 1 + NGX_HTTP_V2_INT_OCTETS + host->len;
+
+        if (tmp_len < host->len) {
+            tmp_len = host->len;
+        }
+    }
+
+    /* other headers */
+
+    ngx_memzero(&le, sizeof(ngx_http_script_engine_t));
+
+    ngx_http_script_flush_no_cacheable_variables(r, plcf->body_flushes);
+    ngx_http_script_flush_no_cacheable_variables(r, headers->flushes);
+
+    body_len = 0;
+
+    if (plcf->body_lengths) {
+        le.ip = plcf->body_lengths->elts;
+        le.request = r;
+        le.flushed = 1;
+
+        while (*(uintptr_t *) le.ip) {
+            lcode = *(ngx_http_script_len_code_pt *) le.ip;
+            body_len += lcode(&le);
+        }
+
+        ctx->ctx.internal_body_length = body_len;
+
+        len += sizeof(ngx_http_proxy_v2_frame_t);
+        len += body_len;
+
+    } else if (r->headers_in.chunked && r->reading_body) {
+        ctx->ctx.internal_body_length = -1;
+
+    } else {
+        ctx->ctx.internal_body_length = r->headers_in.content_length_n;
+    }
+
+    le.ip = headers->lengths->elts;
+    le.request = r;
+    le.flushed = 1;
+
+    while (*(uintptr_t *) le.ip) {
+
+        lcode = *(ngx_http_script_len_code_pt *) le.ip;
+        key_len = lcode(&le);
+
+        for (val_len = 0; *(uintptr_t *) le.ip; val_len += lcode(&le)) {
+            lcode = *(ngx_http_script_len_code_pt *) le.ip;
+        }
+        le.ip += sizeof(uintptr_t);
+
+        if (val_len == 0) {
+            continue;
+        }
+
+        len += 1 + NGX_HTTP_V2_INT_OCTETS + key_len
+                 + NGX_HTTP_V2_INT_OCTETS + val_len;
+
+        if (tmp_len < key_len) {
+            tmp_len = key_len;
+        }
+
+        if (tmp_len < val_len) {
+            tmp_len = val_len;
+        }
+    }
+
+    if (plcf->upstream.pass_request_headers) {
+        part = &r->headers_in.headers.part;
+        header = part->elts;
+
+        for (i = 0; /* void */; i++) {
+
+            if (i >= part->nelts) {
+                if (part->next == NULL) {
+                    break;
+                }
+
+                part = part->next;
+                header = part->elts;
+                i = 0;
+            }
+
+            if (ngx_hash_find(&headers->hash, header[i].hash,
+                              header[i].lowcase_key, header[i].key.len))
+            {
+                continue;
+            }
+
+            len += 1 + NGX_HTTP_V2_INT_OCTETS + header[i].key.len
+                     + NGX_HTTP_V2_INT_OCTETS + header[i].value.len;
+
+            if (tmp_len < header[i].key.len) {
+                tmp_len = header[i].key.len;
+            }
+
+            if (tmp_len < header[i].value.len) {
+                tmp_len = header[i].value.len;
+            }
+        }
+    }
+
+    /* continuation frames */
+
+    len += sizeof(ngx_http_proxy_v2_frame_t)
+           * (len / NGX_HTTP_V2_DEFAULT_FRAME_SIZE);
+
+
+    b = ngx_create_temp_buf(r->pool, len);
+    if (b == NULL) {
+        return NGX_ERROR;
+    }
+
+    cl = ngx_alloc_chain_link(r->pool);
+    if (cl == NULL) {
+        return NGX_ERROR;
+    }
+
+    cl->buf = b;
+    cl->next = NULL;
+
+    tmp = ngx_palloc(r->pool, tmp_len * 3);
+    if (tmp == NULL) {
+        return NGX_ERROR;
+    }
+
+    key_tmp = tmp + tmp_len;
+    val_tmp = tmp + 2 * tmp_len;
+
+    /* connection preface */
+
+    b->last = ngx_copy(b->last, ngx_http_proxy_v2_connection_start,
+                       sizeof(ngx_http_proxy_v2_connection_start) - 1);
+
+    /* headers frame */
+
+    headers_frame = b->last;
+
+    f = (ngx_http_proxy_v2_frame_t *) b->last;
+    b->last += sizeof(ngx_http_proxy_v2_frame_t);
+
+    f->length_0 = 0;
+    f->length_1 = 0;
+    f->length_2 = 0;
+    f->type = NGX_HTTP_V2_HEADERS_FRAME;
+    f->flags = 0;
+    f->stream_id_0 = 0;
+    f->stream_id_1 = 0;
+    f->stream_id_2 = 0;
+    f->stream_id_3 = 1;
+
+    if (method.len == 3 && ngx_strncmp(method.data, "GET", 3) == 0) {
+        *b->last++ = ngx_http_v2_indexed(NGX_HTTP_V2_METHOD_GET_INDEX);
+
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy header: \":method: GET\"");
+
+    } else if (method.len == 4 && ngx_strncmp(method.data, "POST", 4) == 0) {
+        *b->last++ = ngx_http_v2_indexed(NGX_HTTP_V2_METHOD_POST_INDEX);
+
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy header: \":method: POST\"");
+
+    } else {
+        *b->last++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_METHOD_INDEX);
+        b->last = ngx_http_v2_write_value(b->last, method.data,
+                                          method.len, tmp);
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy header: \":method: %V\"", &method);
+    }
+
+#if (NGX_HTTP_SSL)
+    if (u->ssl) {
+        *b->last++ = ngx_http_v2_indexed(NGX_HTTP_V2_SCHEME_HTTPS_INDEX);
+
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy header: \":scheme: https\"");
+    } else
+#endif
+    {
+        *b->last++ = ngx_http_v2_indexed(NGX_HTTP_V2_SCHEME_HTTP_INDEX);
+
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy header: \":scheme: http\"");
+    }
+
+    if (plcf->proxy_lengths && ctx->ctx.vars.uri.len) {
+
+        *b->last++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_PATH_INDEX);
+        b->last = ngx_http_v2_write_value(b->last, ctx->ctx.vars.uri.data,
+                                          ctx->ctx.vars.uri.len, tmp);
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy header: \":path: %V\"", &ctx->ctx.vars.uri);
+
+    } else if (unparsed_uri) {
+
+        if (r->unparsed_uri.len == 1 && r->unparsed_uri.data[0] == '/') {
+            *b->last++ = ngx_http_v2_indexed(NGX_HTTP_V2_PATH_ROOT_INDEX);
+
+        } else {
+            *b->last++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_PATH_INDEX);
+            b->last = ngx_http_v2_write_value(b->last, r->unparsed_uri.data,
+                                              r->unparsed_uri.len, tmp);
+        }
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy header: \":path: %V\"", &r->unparsed_uri);
+
+    } else {
+        p = val_tmp;
+
+        if (r->valid_location) {
+            p = ngx_copy(p, ctx->ctx.vars.uri.data, ctx->ctx.vars.uri.len);
+        }
+
+        if (escape) {
+            ngx_escape_uri(p, r->uri.data + loc_len,
+                           r->uri.len - loc_len, NGX_ESCAPE_URI);
+            p += r->uri.len - loc_len + escape;
+
+        } else {
+            p = ngx_copy(p, r->uri.data + loc_len, r->uri.len - loc_len);
+        }
+
+        if (r->args.len > 0) {
+            *p++ = '?';
+            p = ngx_copy(p, r->args.data, r->args.len);
+        }
+
+        *b->last++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_PATH_INDEX);
+        b->last = ngx_http_v2_write_value(b->last, val_tmp, p - val_tmp, tmp);
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy header: \":path: %*s\"", p - val_tmp,
+                       val_tmp);
+    }
+
+    if (!plcf->host_set) {
+        *b->last++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_AUTHORITY_INDEX);
+        b->last = ngx_http_v2_write_value(b->last, host->data, host->len, tmp);
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy header: \":authority: %V\"", host);
+    }
+
+    ngx_memzero(&e, sizeof(ngx_http_script_engine_t));
+
+    e.ip = headers->values->elts;
+    e.request = r;
+    e.flushed = 1;
+
+    le.ip = headers->lengths->elts;
+
+    while (*(uintptr_t *) le.ip) {
+
+        lcode = *(ngx_http_script_len_code_pt *) le.ip;
+        key_len = lcode(&le);
+
+        for (val_len = 0; *(uintptr_t *) le.ip; val_len += lcode(&le)) {
+            lcode = *(ngx_http_script_len_code_pt *) le.ip;
+        }
+        le.ip += sizeof(uintptr_t);
+
+        if (val_len == 0) {
+            e.skip = 1;
+
+            while (*(uintptr_t *) e.ip) {
+                code = *(ngx_http_script_code_pt *) e.ip;
+                code((ngx_http_script_engine_t *) &e);
+            }
+            e.ip += sizeof(uintptr_t);
+
+            e.skip = 0;
+
+            continue;
+        }
+
+        *b->last++ = 0;
+
+        e.pos = key_tmp;
+
+        code = *(ngx_http_script_code_pt *) e.ip;
+        code((ngx_http_script_engine_t *) &e);
+
+        b->last = ngx_http_v2_write_name(b->last, key_tmp, key_len, tmp);
+
+        e.pos = val_tmp;
+
+        while (*(uintptr_t *) e.ip) {
+            code = *(ngx_http_script_code_pt *) e.ip;
+            code((ngx_http_script_engine_t *) &e);
+        }
+        e.ip += sizeof(uintptr_t);
+
+        b->last = ngx_http_v2_write_value(b->last, val_tmp, val_len, tmp);
+
+#if (NGX_DEBUG)
+        if (r->connection->log->log_level & NGX_LOG_DEBUG_HTTP) {
+            ngx_strlow(key_tmp, key_tmp, key_len);
+
+            ngx_log_debug4(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http proxy header: \"%*s: %*s\"",
+                           key_len, key_tmp, val_len, val_tmp);
+        }
+#endif
+    }
+
+    if (plcf->upstream.pass_request_headers) {
+        part = &r->headers_in.headers.part;
+        header = part->elts;
+
+        for (i = 0; /* void */; i++) {
+
+            if (i >= part->nelts) {
+                if (part->next == NULL) {
+                    break;
+                }
+
+                part = part->next;
+                header = part->elts;
+                i = 0;
+            }
+
+            if (ngx_hash_find(&headers->hash, header[i].hash,
+                              header[i].lowcase_key, header[i].key.len))
+            {
+                continue;
+            }
+
+            *b->last++ = 0;
+
+            b->last = ngx_http_v2_write_name(b->last, header[i].key.data,
+                                             header[i].key.len, tmp);
+
+            b->last = ngx_http_v2_write_value(b->last, header[i].value.data,
+                                              header[i].value.len, tmp);
+
+#if (NGX_DEBUG)
+            if (r->connection->log->log_level & NGX_LOG_DEBUG_HTTP) {
+                ngx_strlow(tmp, header[i].key.data, header[i].key.len);
+
+                ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                               "http proxy header: \"%*s: %V\"",
+                               header[i].key.len, tmp, &header[i].value);
+            }
+#endif
+        }
+    }
+
+    /* update headers frame length */
+
+    len = b->last - headers_frame - sizeof(ngx_http_proxy_v2_frame_t);
+
+    if (len > NGX_HTTP_V2_DEFAULT_FRAME_SIZE) {
+        len = NGX_HTTP_V2_DEFAULT_FRAME_SIZE;
+        next = 1;
+
+    } else {
+        next = 0;
+    }
+
+    f = (ngx_http_proxy_v2_frame_t *) headers_frame;
+
+    f->length_0 = (u_char) ((len >> 16) & 0xff);
+    f->length_1 = (u_char) ((len >> 8) & 0xff);
+    f->length_2 = (u_char) (len & 0xff);
+
+    /* create additional continuation frames */
+
+    p = headers_frame;
+
+    while (next) {
+        p += sizeof(ngx_http_proxy_v2_frame_t) + NGX_HTTP_V2_DEFAULT_FRAME_SIZE;
+        len = b->last - p;
+
+        ngx_memmove(p + sizeof(ngx_http_proxy_v2_frame_t), p, len);
+        b->last += sizeof(ngx_http_proxy_v2_frame_t);
+
+        if (len > NGX_HTTP_V2_DEFAULT_FRAME_SIZE) {
+            len = NGX_HTTP_V2_DEFAULT_FRAME_SIZE;
+            next = 1;
+
+        } else {
+            next = 0;
+        }
+
+        f = (ngx_http_proxy_v2_frame_t *) p;
+
+        f->length_0 = (u_char) ((len >> 16) & 0xff);
+        f->length_1 = (u_char) ((len >> 8) & 0xff);
+        f->length_2 = (u_char) (len & 0xff);
+        f->type = NGX_HTTP_V2_CONTINUATION_FRAME;
+        f->flags = 0;
+        f->stream_id_0 = 0;
+        f->stream_id_1 = 0;
+        f->stream_id_2 = 0;
+        f->stream_id_3 = 1;
+    }
+
+    f->flags |= NGX_HTTP_V2_END_HEADERS_FLAG;
+
+    if (plcf->body_values) {
+        f = (ngx_http_proxy_v2_frame_t *) b->last;
+        b->last += sizeof(ngx_http_proxy_v2_frame_t);
+
+        f->length_0 = (u_char) ((body_len >> 16) & 0xff);
+        f->length_1 = (u_char) ((body_len >> 8) & 0xff);
+        f->length_2 = (u_char) (body_len & 0xff);
+        f->type = NGX_HTTP_V2_DATA_FRAME;
+        f->flags = NGX_HTTP_V2_END_STREAM_FLAG;
+        f->stream_id_0 = 0;
+        f->stream_id_1 = 0;
+        f->stream_id_2 = 0;
+        f->stream_id_3 = 1;
+
+        e.ip = plcf->body_values->elts;
+        e.pos = b->last;
+        e.request = r;
+        e.flushed = 1;
+        e.skip = 0;
+
+        while (*(uintptr_t *) e.ip) {
+            code = *(ngx_http_script_code_pt *) e.ip;
+            code((ngx_http_script_engine_t *) &e);
+        }
+
+        b->last = e.pos;
+    }
+
+    ngx_log_debug4(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http proxy header: %*xs%s, len: %uz",
+                   (size_t) ngx_min(b->last - b->pos, 256), b->pos,
+                   b->last - b->pos > 256 ? "..." : "",
+                   b->last - b->pos);
+
+    if (r->request_body_no_buffering) {
+
+        u->request_bufs = cl;
+
+    } else if (plcf->body_values == NULL && plcf->upstream.pass_request_body) {
+
+        body = u->request_bufs;
+        u->request_bufs = cl;
+
+        if (body == NULL) {
+            f = (ngx_http_proxy_v2_frame_t *) headers_frame;
+            f->flags |= NGX_HTTP_V2_END_STREAM_FLAG;
+        }
+
+        while (body) {
+            b = ngx_alloc_buf(r->pool);
+            if (b == NULL) {
+                return NGX_ERROR;
+            }
+
+            ngx_memcpy(b, body->buf, sizeof(ngx_buf_t));
+
+            cl->next = ngx_alloc_chain_link(r->pool);
+            if (cl->next == NULL) {
+                return NGX_ERROR;
+            }
+
+            cl = cl->next;
+            cl->buf = b;
+
+            body = body->next;
+        }
+
+        b->last_buf = 1;
+
+    } else {
+        u->request_bufs = cl;
+
+        if (plcf->body_values == NULL) {
+            f = (ngx_http_proxy_v2_frame_t *) headers_frame;
+            f->flags |= NGX_HTTP_V2_END_STREAM_FLAG;
+        }
+    }
+
+    u->output.output_filter = ngx_http_proxy_v2_body_output_filter;
+    u->output.filter_ctx = r;
+
+    b->flush = 1;
+    cl->next = NULL;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_reinit_request(ngx_http_request_t *r)
+{
+    ngx_http_proxy_v2_ctx_t  *ctx;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_proxy_v2_module);
+
+    if (ctx == NULL) {
+        return NGX_OK;
+    }
+
+    ctx->state = 0;
+    ctx->header_sent = 0;
+    ctx->output_closed = 0;
+    ctx->output_blocked = 0;
+    ctx->parsing_headers = 0;
+    ctx->end_stream = 0;
+    ctx->done = 0;
+    ctx->status = 0;
+    ctx->rst = 0;
+    ctx->goaway = 0;
+    ctx->connection = NULL;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_body_output_filter(void *data, ngx_chain_t *in)
+{
+    ngx_http_request_t  *r = data;
+
+    off_t                       file_pos;
+    u_char                     *p, *pos, *start;
+    size_t                      len, limit;
+    ngx_buf_t                  *b;
+    ngx_int_t                  rc;
+    ngx_uint_t                 next, last;
+    ngx_chain_t                *cl, *out, *ln, **ll;
+    ngx_http_upstream_t        *u;
+    ngx_http_proxy_v2_ctx_t    *ctx;
+    ngx_http_proxy_v2_frame_t  *f;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http proxy output filter");
+
+    ctx = ngx_http_proxy_v2_get_ctx(r);
+
+    if (ctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    if (in) {
+        if (ngx_chain_add_copy(r->pool, &ctx->in, in) != NGX_OK) {
+            return NGX_ERROR;
+        }
+    }
+
+    out = NULL;
+    ll = &out;
+
+    if (!ctx->header_sent) {
+        /* first buffer contains headers */
+
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy output header");
+
+        ctx->header_sent = 1;
+
+        if (ctx->id != 1) {
+            /*
+             * keepalive connection: skip connection preface,
+             * update stream identifiers
+             */
+
+            b = ctx->in->buf;
+            b->pos += sizeof(ngx_http_proxy_v2_connection_start) - 1;
+
+            p = b->pos;
+
+            while (p < b->last) {
+                f = (ngx_http_proxy_v2_frame_t *) p;
+                p += sizeof(ngx_http_proxy_v2_frame_t);
+
+                f->stream_id_0 = (u_char) ((ctx->id >> 24) & 0xff);
+                f->stream_id_1 = (u_char) ((ctx->id >> 16) & 0xff);
+                f->stream_id_2 = (u_char) ((ctx->id >> 8) & 0xff);
+                f->stream_id_3 = (u_char) (ctx->id & 0xff);
+
+                p += (f->length_0 << 16) + (f->length_1 << 8) + f->length_2;
+            }
+        }
+
+        if (ctx->in->buf->last_buf) {
+            ctx->output_closed = 1;
+        }
+
+        *ll = ctx->in;
+        ll = &ctx->in->next;
+
+        ctx->in = ctx->in->next;
+    }
+
+    if (ctx->out) {
+        /* queued control frames */
+
+        *ll = ctx->out;
+
+        for (cl = ctx->out, ll = &cl->next; cl; cl = cl->next) {
+            ll = &cl->next;
+        }
+
+        ctx->out = NULL;
+    }
+
+    f = NULL;
+    last = 0;
+
+    limit = ngx_max(0, ctx->send_window);
+
+    if (limit > ctx->connection->send_window) {
+        limit = ctx->connection->send_window;
+    }
+
+    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http proxy output limit: %uz w:%z:%uz",
+                   limit, ctx->send_window, ctx->connection->send_window);
+
+#if (NGX_SUPPRESS_WARN)
+    file_pos = 0;
+    pos = NULL;
+    cl = NULL;
+#endif
+
+    in = ctx->in;
+
+    while (in && limit > 0) {
+
+        ngx_log_debug7(NGX_LOG_DEBUG_EVENT, r->connection->log, 0,
+                       "http proxy output in  l:%d f:%d %p, pos %p, size: %z "
+                       "file: %O, size: %O",
+                       in->buf->last_buf,
+                       in->buf->in_file,
+                       in->buf->start, in->buf->pos,
+                       in->buf->last - in->buf->pos,
+                       in->buf->file_pos,
+                       in->buf->file_last - in->buf->file_pos);
+
+        if (ngx_buf_special(in->buf)) {
+            goto next;
+        }
+
+        if (in->buf->in_file) {
+            file_pos = in->buf->file_pos;
+
+        } else {
+            pos = in->buf->pos;
+        }
+
+        next = 0;
+
+        do {
+
+            cl = ngx_http_proxy_v2_get_buf(r, ctx);
+            if (cl == NULL) {
+                return NGX_ERROR;
+            }
+
+            b = cl->buf;
+
+            f = (ngx_http_proxy_v2_frame_t *) b->last;
+            b->last += sizeof(ngx_http_proxy_v2_frame_t);
+
+            *ll = cl;
+            ll = &cl->next;
+
+            cl = ngx_chain_get_free_buf(r->pool, &ctx->free);
+            if (cl == NULL) {
+                return NGX_ERROR;
+            }
+
+            b = cl->buf;
+            start = b->start;
+
+            ngx_memcpy(b, in->buf, sizeof(ngx_buf_t));
+
+            /*
+             * restore b->start to preserve memory allocated in the buffer,
+             * to reuse it later for headers and control frames
+             */
+
+            b->start = start;
+
+            if (in->buf->in_file) {
+                b->file_pos = file_pos;
+                file_pos += ngx_min(NGX_HTTP_V2_DEFAULT_FRAME_SIZE, limit);
+
+                if (file_pos >= in->buf->file_last) {
+                    file_pos = in->buf->file_last;
+                    next = 1;
+                }
+
+                b->file_last = file_pos;
+                len = (ngx_uint_t) (file_pos - b->file_pos);
+
+            } else {
+                b->pos = pos;
+                pos += ngx_min(NGX_HTTP_V2_DEFAULT_FRAME_SIZE, limit);
+
+                if (pos >= in->buf->last) {
+                    pos = in->buf->last;
+                    next = 1;
+                }
+
+                b->last = pos;
+                len = (ngx_uint_t) (pos - b->pos);
+            }
+
+            b->tag = (ngx_buf_tag_t) &ngx_http_proxy_v2_body_output_filter;
+            b->shadow = in->buf;
+            b->last_shadow = next;
+
+            b->last_buf = 0;
+            b->last_in_chain = 0;
+
+            *ll = cl;
+            ll = &cl->next;
+
+            f->length_0 = (u_char) ((len >> 16) & 0xff);
+            f->length_1 = (u_char) ((len >> 8) & 0xff);
+            f->length_2 = (u_char) (len & 0xff);
+            f->type = NGX_HTTP_V2_DATA_FRAME;
+            f->flags = 0;
+            f->stream_id_0 = (u_char) ((ctx->id >> 24) & 0xff);
+            f->stream_id_1 = (u_char) ((ctx->id >> 16) & 0xff);
+            f->stream_id_2 = (u_char) ((ctx->id >> 8) & 0xff);
+            f->stream_id_3 = (u_char) (ctx->id & 0xff);
+
+            limit -= len;
+            ctx->send_window -= len;
+            ctx->connection->send_window -= len;
+
+        } while (!next && limit > 0);
+
+        if (!next) {
+            /*
+             * if the buffer wasn't fully sent due to flow control limits,
+             * preserve position for future use
+             */
+
+            if (in->buf->in_file) {
+                in->buf->file_pos = file_pos;
+
+            } else {
+                in->buf->pos = pos;
+            }
+
+            break;
+        }
+
+    next:
+
+        if (in->buf->last_buf) {
+            last = 1;
+        }
+
+        ln = in;
+        in = in->next;
+
+        ngx_free_chain(r->pool, ln);
+    }
+
+    ctx->in = in;
+
+    if (last) {
+
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy output last");
+
+        ctx->output_closed = 1;
+
+        if (f) {
+            f->flags |= NGX_HTTP_V2_END_STREAM_FLAG;
+
+        } else {
+            cl = ngx_http_proxy_v2_get_buf(r, ctx);
+            if (cl == NULL) {
+                return NGX_ERROR;
+            }
+
+            b = cl->buf;
+
+            f = (ngx_http_proxy_v2_frame_t *) b->last;
+            b->last += sizeof(ngx_http_proxy_v2_frame_t);
+
+            f->length_0 = 0;
+            f->length_1 = 0;
+            f->length_2 = 0;
+            f->type = NGX_HTTP_V2_DATA_FRAME;
+            f->flags = NGX_HTTP_V2_END_STREAM_FLAG;
+            f->stream_id_0 = (u_char) ((ctx->id >> 24) & 0xff);
+            f->stream_id_1 = (u_char) ((ctx->id >> 16) & 0xff);
+            f->stream_id_2 = (u_char) ((ctx->id >> 8) & 0xff);
+            f->stream_id_3 = (u_char) (ctx->id & 0xff);
+
+            *ll = cl;
+            ll = &cl->next;
+        }
+
+        cl->buf->last_buf = 1;
+    }
+
+    *ll = NULL;
+
+#if (NGX_DEBUG)
+
+    for (cl = out; cl; cl = cl->next) {
+        ngx_log_debug7(NGX_LOG_DEBUG_EVENT, r->connection->log, 0,
+                       "http proxy output out l:%d f:%d %p, pos %p, size: %z "
+                       "file: %O, size: %O",
+                       cl->buf->last_buf,
+                       cl->buf->in_file,
+                       cl->buf->start, cl->buf->pos,
+                       cl->buf->last - cl->buf->pos,
+                       cl->buf->file_pos,
+                       cl->buf->file_last - cl->buf->file_pos);
+    }
+
+    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http proxy output limit: %uz w:%z:%uz",
+                   limit, ctx->send_window, ctx->connection->send_window);
+
+#endif
+
+    rc = ngx_chain_writer(&r->upstream->writer, out);
+
+    ngx_chain_update_chains(r->pool, &ctx->free, &ctx->busy, &out,
+                         (ngx_buf_tag_t) &ngx_http_proxy_v2_body_output_filter);
+
+    for (cl = ctx->free; cl; cl = cl->next) {
+
+        /* mark original buffers as sent */
+
+        if (cl->buf->shadow) {
+            if (cl->buf->last_shadow) {
+                b = cl->buf->shadow;
+                b->pos = b->last;
+            }
+
+            cl->buf->shadow = NULL;
+        }
+    }
+
+    if (rc == NGX_OK && ctx->in) {
+        rc = NGX_AGAIN;
+    }
+
+    if (rc == NGX_AGAIN) {
+        ctx->output_blocked = 1;
+
+    } else {
+        ctx->output_blocked = 0;
+    }
+
+    if (ctx->done) {
+
+        /*
+         * We have already got the response and were sending some additional
+         * control frames.  Even if there is still something unsent, stop
+         * here anyway.
+         */
+
+        u = r->upstream;
+        u->length = 0;
+
+        if (ctx->in == NULL
+            && ctx->out == NULL
+            && ctx->output_closed
+            && !ctx->output_blocked
+            && !ctx->goaway
+            && ctx->state == ngx_http_proxy_v2_st_start)
+        {
+            u->keepalive = 1;
+        }
+
+        ngx_post_event(u->peer.connection->read, &ngx_posted_events);
+    }
+
+    return rc;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_process_header(ngx_http_request_t *r)
+{
+    u_char                         *pos;
+    ngx_str_t                      *status_line;
+    ngx_int_t                       rc, status;
+    ngx_buf_t                      *b;
+    ngx_table_elt_t                *h;
+    ngx_http_upstream_t            *u;
+    ngx_http_proxy_v2_ctx_t        *ctx;
+    ngx_http_upstream_header_t     *hh;
+    ngx_http_upstream_main_conf_t  *umcf;
+
+    u = r->upstream;
+    b = &u->buffer;
+    pos = b->pos;
+
+    ngx_log_debug4(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http proxy response: %*xs%s, len: %uz",
+                   (size_t) ngx_min(b->last - b->pos, 256),
+                   b->pos, b->last - b->pos > 256 ? "..." : "",
+                   b->last - b->pos);
+
+    ctx = ngx_http_proxy_v2_get_ctx(r);
+
+    if (ctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    umcf = ngx_http_get_module_main_conf(r, ngx_http_upstream_module);
+
+    for ( ;; ) {
+
+        if (ctx->state < ngx_http_proxy_v2_st_payload) {
+
+            rc = ngx_http_proxy_v2_parse_frame(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+
+                /*
+                 * there can be a lot of window update frames,
+                 * so we reset buffer if it is empty and we haven't
+                 * started parsing headers yet
+                 */
+
+                if (!ctx->parsing_headers) {
+                    b->pos = pos;
+                    b->last = b->pos;
+                }
+
+                return NGX_AGAIN;
+            }
+
+            if (rc == NGX_ERROR) {
+                return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+            }
+
+            /*
+             * RFC 7540 says that implementations MUST discard frames
+             * that have unknown or unsupported types.  However, extension
+             * frames that appear in the middle of a header block are
+             * not permitted.  Also, for obvious reasons CONTINUATION frames
+             * cannot appear before headers, and DATA frames are not expected
+             * to appear before all headers are parsed.
+             */
+
+            if (ctx->type == NGX_HTTP_V2_DATA_FRAME
+                || (ctx->type == NGX_HTTP_V2_CONTINUATION_FRAME
+                    && !ctx->parsing_headers)
+                || (ctx->type != NGX_HTTP_V2_CONTINUATION_FRAME
+                    && ctx->parsing_headers))
+            {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent unexpected http2 frame: %d",
+                              ctx->type);
+                return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+            }
+
+            if (ctx->stream_id && ctx->stream_id != ctx->id) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent frame for unknown stream %ui",
+                              ctx->stream_id);
+                return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+            }
+        }
+
+        /* frame payload */
+
+        if (ctx->type == NGX_HTTP_V2_RST_STREAM_FRAME) {
+
+            rc = ngx_http_proxy_v2_parse_rst_stream(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+                return NGX_AGAIN;
+            }
+
+            if (rc == NGX_ERROR) {
+                return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+            }
+
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream rejected request with error %ui",
+                          ctx->error);
+
+            return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+        }
+
+        if (ctx->type == NGX_HTTP_V2_GOAWAY_FRAME) {
+
+            rc = ngx_http_proxy_v2_parse_goaway(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+                return NGX_AGAIN;
+            }
+
+            if (rc == NGX_ERROR) {
+                return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+            }
+
+            /*
+             * If stream_id is lower than one we use, our
+             * request won't be processed and needs to be retried.
+             * If stream_id is greater or equal to the one we use,
+             * we can continue normally (except we can't use this
+             * connection for additional requests).  If there is
+             * a real error, the connection will be closed.
+             */
+
+            if (ctx->stream_id < ctx->id) {
+
+                /* TODO: we can retry non-idempotent requests */
+
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent goaway with error %ui",
+                              ctx->error);
+
+                return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+            }
+
+            ctx->goaway = 1;
+
+            continue;
+        }
+
+        if (ctx->type == NGX_HTTP_V2_WINDOW_UPDATE_FRAME) {
+
+            rc = ngx_http_proxy_v2_parse_window_update(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+                return NGX_AGAIN;
+            }
+
+            if (rc == NGX_ERROR) {
+                return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+            }
+
+            if (ctx->in) {
+                ngx_post_event(u->peer.connection->write, &ngx_posted_events);
+            }
+
+            continue;
+        }
+
+        if (ctx->type == NGX_HTTP_V2_SETTINGS_FRAME) {
+
+            rc = ngx_http_proxy_v2_parse_settings(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+                return NGX_AGAIN;
+            }
+
+            if (rc == NGX_ERROR) {
+                return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+            }
+
+            if (ctx->in) {
+                ngx_post_event(u->peer.connection->write, &ngx_posted_events);
+            }
+
+            continue;
+        }
+
+        if (ctx->type == NGX_HTTP_V2_PING_FRAME) {
+
+            rc = ngx_http_proxy_v2_parse_ping(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+                return NGX_AGAIN;
+            }
+
+            if (rc == NGX_ERROR) {
+                return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+            }
+
+            ngx_post_event(u->peer.connection->write, &ngx_posted_events);
+            continue;
+        }
+
+        if (ctx->type == NGX_HTTP_V2_PUSH_PROMISE_FRAME) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent unexpected push promise frame");
+            return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+        }
+
+        if (ctx->type != NGX_HTTP_V2_HEADERS_FRAME
+            && ctx->type != NGX_HTTP_V2_CONTINUATION_FRAME)
+        {
+            /* priority, unknown frames */
+
+            if (b->last - b->pos < (ssize_t) ctx->rest) {
+                ctx->rest -= b->last - b->pos;
+                b->pos = b->last;
+                return NGX_AGAIN;
+            }
+
+            b->pos += ctx->rest;
+            ctx->rest = 0;
+            ctx->state = ngx_http_proxy_v2_st_start;
+
+            continue;
+        }
+
+        /* headers */
+
+        for ( ;; ) {
+
+            rc = ngx_http_proxy_v2_parse_header(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+                break;
+            }
+
+            if (rc == NGX_OK) {
+
+                /* a header line has been parsed successfully */
+
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                               "http proxy header: \"%V: %V\"",
+                               &ctx->name, &ctx->value);
+
+                if (ctx->name.len && ctx->name.data[0] == ':') {
+
+                    if (ctx->name.len != sizeof(":status") - 1
+                        || ngx_strncmp(ctx->name.data, ":status",
+                                       sizeof(":status") - 1)
+                           != 0)
+                    {
+                        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                      "upstream sent invalid header \"%V: %V\"",
+                                      &ctx->name, &ctx->value);
+                        return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+                    }
+
+                    if (ctx->status) {
+                        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                      "upstream sent duplicate :status header");
+                        return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+                    }
+
+                    status_line = &ctx->value;
+
+                    if (status_line->len != 3) {
+                        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                      "upstream sent invalid :status \"%V\"",
+                                      status_line);
+                        return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+                    }
+
+                    status = ngx_atoi(status_line->data, 3);
+
+                    if (status == NGX_ERROR) {
+                        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                      "upstream sent invalid :status \"%V\"",
+                                      status_line);
+                        return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+                    }
+
+                    if (status < NGX_HTTP_OK && status != NGX_HTTP_EARLY_HINTS)
+                    {
+                        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                      "upstream sent unexpected :status \"%V\"",
+                                      status_line);
+                        return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+                    }
+
+                    u->headers_in.status_n = status;
+
+                    if (u->state && u->state->status == 0) {
+                        u->state->status = status;
+                    }
+
+                    ctx->status = 1;
+
+                    continue;
+
+                } else if (!ctx->status) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent no :status header");
+                    return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+                }
+
+                h = ngx_list_push(&u->headers_in.headers);
+                if (h == NULL) {
+                    return NGX_ERROR;
+                }
+
+                h->key = ctx->name;
+                h->value = ctx->value;
+                h->lowcase_key = h->key.data;
+                h->hash = ngx_hash_key(h->key.data, h->key.len);
+
+                if (u->headers_in.status_n == NGX_HTTP_EARLY_HINTS) {
+                    continue;
+                }
+
+                hh = ngx_hash_find(&umcf->headers_in_hash, h->hash,
+                                   h->lowcase_key, h->key.len);
+
+                if (hh) {
+                    rc = hh->handler(r, h, hh->offset);
+
+                    if (rc != NGX_OK) {
+                        return rc;
+                    }
+                }
+
+                continue;
+            }
+
+            if (rc == NGX_HTTP_PARSE_HEADER_DONE) {
+
+                /* a whole header has been parsed successfully */
+
+                ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                               "http proxy header done");
+
+                if (u->headers_in.status_n == NGX_HTTP_EARLY_HINTS) {
+                    if (ctx->end_stream) {
+                        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                      "upstream prematurely closed stream");
+                        return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+                    }
+
+                    ctx->status = 0;
+                    return NGX_HTTP_UPSTREAM_EARLY_HINTS;
+                }
+
+                if (ctx->end_stream
+                    && ctx->in == NULL
+                    && ctx->out == NULL
+                    && ctx->output_closed
+                    && !ctx->output_blocked
+                    && !ctx->goaway
+                    && b->last == b->pos)
+                {
+                    u->keepalive = 1;
+                }
+
+                return NGX_OK;
+            }
+
+            /* there was error while a header line parsing */
+
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent invalid header");
+
+            return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+        }
+
+        /* rc == NGX_AGAIN */
+
+        if (ctx->rest == 0) {
+            ctx->state = ngx_http_proxy_v2_st_start;
+            continue;
+        }
+
+        return NGX_AGAIN;
+    }
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_filter_init(void *data)
+{
+    ngx_http_request_t       *r = data;
+    ngx_http_upstream_t      *u;
+    ngx_http_proxy_v2_ctx_t  *ctx;
+
+    u = r->upstream;
+    ctx = ngx_http_get_module_ctx(r, ngx_http_proxy_v2_module);
+
+    if (ctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    if (u->headers_in.status_n == NGX_HTTP_NO_CONTENT
+        || u->headers_in.status_n == NGX_HTTP_NOT_MODIFIED
+        || ctx->ctx.head)
+    {
+        ctx->length = 0;
+
+    } else {
+        ctx->length = u->headers_in.content_length_n;
+    }
+
+    if (ctx->end_stream) {
+
+        if (ctx->length > 0) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream prematurely closed stream");
+            return NGX_ERROR;
+        }
+
+        u->length = 0;
+        ctx->done = 1;
+
+    } else {
+        u->length = 1;
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_non_buffered_filter(void *data, ssize_t bytes)
+{
+    ngx_http_request_t   *r = data;
+
+    ngx_int_t                 rc;
+    ngx_buf_t                *b, *buf;
+    ngx_chain_t              *cl, **ll;
+    ngx_table_elt_t          *h;
+    ngx_http_upstream_t      *u;
+    ngx_http_proxy_v2_ctx_t  *ctx;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http proxy filter bytes:%z", bytes);
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_proxy_v2_module);
+
+    if (ctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    u = r->upstream;
+    b = &u->buffer;
+
+    b->pos = b->last;
+    b->last += bytes;
+
+    for (cl = u->out_bufs, ll = &u->out_bufs; cl; cl = cl->next) {
+        ll = &cl->next;
+    }
+
+    for ( ;; ) {
+
+        if (ctx->state < ngx_http_proxy_v2_st_payload) {
+
+            rc = ngx_http_proxy_v2_parse_frame(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+
+                if (ctx->done) {
+
+                    if (ctx->length > 0) {
+                        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                      "upstream prematurely closed stream");
+                        return NGX_ERROR;
+                    }
+
+                    /*
+                     * We have finished parsing the response and the
+                     * remaining control frames.  If there are unsent
+                     * control frames, post a write event to send them.
+                     */
+
+                    if (ctx->out) {
+                        ngx_post_event(u->peer.connection->write,
+                                       &ngx_posted_events);
+                        return NGX_AGAIN;
+                    }
+
+                    u->length = 0;
+
+                    if (ctx->in == NULL
+                        && ctx->output_closed
+                        && !ctx->output_blocked
+                        && !ctx->goaway
+                        && ctx->state == ngx_http_proxy_v2_st_start)
+                    {
+                        u->keepalive = 1;
+                    }
+
+                    break;
+                }
+
+                return NGX_AGAIN;
+            }
+
+            if (rc == NGX_ERROR) {
+                return NGX_ERROR;
+            }
+
+            if ((ctx->type == NGX_HTTP_V2_CONTINUATION_FRAME
+                 && !ctx->parsing_headers)
+                || (ctx->type != NGX_HTTP_V2_CONTINUATION_FRAME
+                    && ctx->parsing_headers))
+            {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent unexpected http2 frame: %d",
+                              ctx->type);
+                return NGX_ERROR;
+            }
+
+            if (ctx->type == NGX_HTTP_V2_DATA_FRAME) {
+
+                if (ctx->stream_id != ctx->id) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent data frame "
+                                  "for unknown stream %ui",
+                                  ctx->stream_id);
+                    return NGX_ERROR;
+                }
+
+                if (ctx->rest > ctx->recv_window) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream violated stream flow control, "
+                                  "received %uz data frame with window %uz",
+                                  ctx->rest, ctx->recv_window);
+                    return NGX_ERROR;
+                }
+
+                if (ctx->rest > ctx->connection->recv_window) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream violated connection flow control, "
+                                  "received %uz data frame with window %uz",
+                                  ctx->rest, ctx->connection->recv_window);
+                    return NGX_ERROR;
+                }
+
+                ctx->recv_window -= ctx->rest;
+                ctx->connection->recv_window -= ctx->rest;
+
+                if (ctx->connection->recv_window < NGX_HTTP_V2_MAX_WINDOW / 4
+                    || ctx->recv_window < NGX_HTTP_V2_MAX_WINDOW / 4)
+                {
+                    if (ngx_http_proxy_v2_send_window_update(r, ctx)
+                        != NGX_OK)
+                    {
+                        return NGX_ERROR;
+                    }
+
+                    ngx_post_event(u->peer.connection->write,
+                                   &ngx_posted_events);
+                }
+            }
+
+            if (ctx->stream_id && ctx->stream_id != ctx->id) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent frame for unknown stream %ui",
+                              ctx->stream_id);
+                return NGX_ERROR;
+            }
+
+            if (ctx->stream_id && ctx->done
+                && ctx->type != NGX_HTTP_V2_RST_STREAM_FRAME
+                && ctx->type != NGX_HTTP_V2_WINDOW_UPDATE_FRAME)
+            {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent frame for closed stream %ui",
+                              ctx->stream_id);
+                return NGX_ERROR;
+            }
+
+            ctx->padding = 0;
+        }
+
+        if (ctx->state == ngx_http_proxy_v2_st_padding) {
+
+            if (b->last - b->pos < (ssize_t) ctx->rest) {
+                ctx->rest -= b->last - b->pos;
+                b->pos = b->last;
+                return NGX_AGAIN;
+            }
+
+            b->pos += ctx->rest;
+            ctx->rest = 0;
+            ctx->state = ngx_http_proxy_v2_st_start;
+
+            if (ctx->flags & NGX_HTTP_V2_END_STREAM_FLAG) {
+                ctx->done = 1;
+            }
+
+            continue;
+        }
+
+        /* frame payload */
+
+        if (ctx->type == NGX_HTTP_V2_RST_STREAM_FRAME) {
+
+            rc = ngx_http_proxy_v2_parse_rst_stream(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+                return NGX_AGAIN;
+            }
+
+            if (rc == NGX_ERROR) {
+                return NGX_ERROR;
+            }
+
+            if (ctx->error || !ctx->done) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream rejected request with error %ui",
+                              ctx->error);
+                return NGX_ERROR;
+            }
+
+            if (ctx->rst) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent frame for closed stream %ui",
+                              ctx->stream_id);
+                return NGX_ERROR;
+            }
+
+            ctx->rst = 1;
+
+            continue;
+        }
+
+        if (ctx->type == NGX_HTTP_V2_GOAWAY_FRAME) {
+
+            rc = ngx_http_proxy_v2_parse_goaway(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+                return NGX_AGAIN;
+            }
+
+            if (rc == NGX_ERROR) {
+                return NGX_ERROR;
+            }
+
+            /*
+             * If stream_id is lower than one we use, our
+             * request won't be processed and needs to be retried.
+             * If stream_id is greater or equal to the one we use,
+             * we can continue normally (except we can't use this
+             * connection for additional requests).  If there is
+             * a real error, the connection will be closed.
+             */
+
+            if (ctx->stream_id < ctx->id) {
+
+                /* TODO: we can retry non-idempotent requests */
+
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent goaway with error %ui",
+                              ctx->error);
+
+                return NGX_ERROR;
+            }
+
+            ctx->goaway = 1;
+
+            continue;
+        }
+
+        if (ctx->type == NGX_HTTP_V2_WINDOW_UPDATE_FRAME) {
+
+            rc = ngx_http_proxy_v2_parse_window_update(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+                return NGX_AGAIN;
+            }
+
+            if (rc == NGX_ERROR) {
+                return NGX_ERROR;
+            }
+
+            if (ctx->in) {
+                ngx_post_event(u->peer.connection->write, &ngx_posted_events);
+            }
+
+            continue;
+        }
+
+        if (ctx->type == NGX_HTTP_V2_SETTINGS_FRAME) {
+
+            rc = ngx_http_proxy_v2_parse_settings(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+                return NGX_AGAIN;
+            }
+
+            if (rc == NGX_ERROR) {
+                return NGX_ERROR;
+            }
+
+            if (ctx->in) {
+                ngx_post_event(u->peer.connection->write, &ngx_posted_events);
+            }
+
+            continue;
+        }
+
+        if (ctx->type == NGX_HTTP_V2_PING_FRAME) {
+
+            rc = ngx_http_proxy_v2_parse_ping(r, ctx, b);
+
+            if (rc == NGX_AGAIN) {
+                return NGX_AGAIN;
+            }
+
+            if (rc == NGX_ERROR) {
+                return NGX_ERROR;
+            }
+
+            ngx_post_event(u->peer.connection->write, &ngx_posted_events);
+            continue;
+        }
+
+        if (ctx->type == NGX_HTTP_V2_PUSH_PROMISE_FRAME) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent unexpected push promise frame");
+            return NGX_ERROR;
+        }
+
+        if (ctx->type == NGX_HTTP_V2_HEADERS_FRAME
+            || ctx->type == NGX_HTTP_V2_CONTINUATION_FRAME)
+        {
+            for ( ;; ) {
+
+                rc = ngx_http_proxy_v2_parse_header(r, ctx, b);
+
+                if (rc == NGX_AGAIN) {
+                    break;
+                }
+
+                if (rc == NGX_OK) {
+
+                    /* a header line has been parsed successfully */
+
+                    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                                   "http proxy trailer: \"%V: %V\"",
+                                   &ctx->name, &ctx->value);
+
+                    if (ctx->name.len && ctx->name.data[0] == ':') {
+                        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                      "upstream sent invalid "
+                                      "trailer \"%V: %V\"",
+                                      &ctx->name, &ctx->value);
+                        return NGX_ERROR;
+                    }
+
+                    h = ngx_list_push(&u->headers_in.trailers);
+                    if (h == NULL) {
+                        return NGX_ERROR;
+                    }
+
+                    h->key = ctx->name;
+                    h->value = ctx->value;
+                    h->lowcase_key = h->key.data;
+                    h->hash = ngx_hash_key(h->key.data, h->key.len);
+
+                    continue;
+                }
+
+                if (rc == NGX_HTTP_PARSE_HEADER_DONE) {
+
+                    /* a whole header has been parsed successfully */
+
+                    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                                   "http proxy trailer done");
+
+                    if (ctx->end_stream) {
+                        ctx->done = 1;
+                        break;
+                    }
+
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent trailer without "
+                                  "end stream flag");
+                    return NGX_ERROR;
+                }
+
+                /* there was error while a header line parsing */
+
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent invalid trailer");
+
+                return NGX_ERROR;
+            }
+
+            if (rc == NGX_HTTP_PARSE_HEADER_DONE) {
+                continue;
+            }
+
+            /* rc == NGX_AGAIN */
+
+            if (ctx->rest == 0) {
+                ctx->state = ngx_http_proxy_v2_st_start;
+                continue;
+            }
+
+            return NGX_AGAIN;
+        }
+
+        if (ctx->type != NGX_HTTP_V2_DATA_FRAME) {
+
+            /* priority, unknown frames */
+
+            if (b->last - b->pos < (ssize_t) ctx->rest) {
+                ctx->rest -= b->last - b->pos;
+                b->pos = b->last;
+                return NGX_AGAIN;
+            }
+
+            b->pos += ctx->rest;
+            ctx->rest = 0;
+            ctx->state = ngx_http_proxy_v2_st_start;
+
+            continue;
+        }
+
+        /*
+         * data frame:
+         *
+         * +---------------+
+         * |Pad Length? (8)|
+         * +---------------+-----------------------------------------------+
+         * |                            Data (*)                         ...
+         * +---------------------------------------------------------------+
+         * |                           Padding (*)                       ...
+         * +---------------------------------------------------------------+
+         */
+
+        if (ctx->flags & NGX_HTTP_V2_PADDED_FLAG) {
+
+            if (ctx->rest == 0) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent too short http2 frame");
+                return NGX_ERROR;
+            }
+
+            if (b->pos == b->last) {
+                return NGX_AGAIN;
+            }
+
+            ctx->flags &= ~NGX_HTTP_V2_PADDED_FLAG;
+            ctx->padding = *b->pos++;
+            ctx->rest -= 1;
+
+            if (ctx->padding > ctx->rest) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent http2 frame with too long "
+                              "padding: %d in frame %uz",
+                              ctx->padding, ctx->rest);
+                return NGX_ERROR;
+            }
+
+            continue;
+        }
+
+        if (ctx->rest == ctx->padding) {
+            goto done;
+        }
+
+        if (b->pos == b->last) {
+            return NGX_AGAIN;
+        }
+
+        cl = ngx_chain_get_free_buf(r->pool, &u->free_bufs);
+        if (cl == NULL) {
+            return NGX_ERROR;
+        }
+
+        *ll = cl;
+        ll = &cl->next;
+
+        buf = cl->buf;
+
+        buf->flush = 1;
+        buf->memory = 1;
+
+        buf->pos = b->pos;
+        buf->tag = u->output.tag;
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy output buf %p", buf->pos);
+
+        if (b->last - b->pos < (ssize_t) ctx->rest - ctx->padding) {
+
+            ctx->rest -= b->last - b->pos;
+            b->pos = b->last;
+            buf->last = b->pos;
+
+            if (ctx->length != -1) {
+
+                if (buf->last - buf->pos > ctx->length) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent response body larger "
+                                  "than indicated content length");
+                    return NGX_ERROR;
+                }
+
+                ctx->length -= buf->last - buf->pos;
+            }
+
+            return NGX_AGAIN;
+        }
+
+        b->pos += ctx->rest - ctx->padding;
+        buf->last = b->pos;
+        ctx->rest = ctx->padding;
+
+        if (ctx->length != -1) {
+
+            if (buf->last - buf->pos > ctx->length) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent response body larger "
+                              "than indicated content length");
+                return NGX_ERROR;
+            }
+
+            ctx->length -= buf->last - buf->pos;
+        }
+
+    done:
+
+        if (ctx->padding) {
+            ctx->state = ngx_http_proxy_v2_st_padding;
+            continue;
+        }
+
+        ctx->state = ngx_http_proxy_v2_st_start;
+
+        if (ctx->flags & NGX_HTTP_V2_END_STREAM_FLAG) {
+            ctx->done = 1;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_parse_frame(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b)
+{
+    u_char                     ch, *p;
+    ngx_http_proxy_v2_state_e  state;
+
+    state = ctx->state;
+
+    for (p = b->pos; p < b->last; p++) {
+        ch = *p;
+
+#if 0
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy frame byte: %02Xd, s:%d", ch, state);
+#endif
+
+        switch (state) {
+
+        case ngx_http_proxy_v2_st_start:
+            ctx->rest = ch << 16;
+            state = ngx_http_proxy_v2_st_length_2;
+            break;
+
+        case ngx_http_proxy_v2_st_length_2:
+            ctx->rest |= ch << 8;
+            state = ngx_http_proxy_v2_st_length_3;
+            break;
+
+        case ngx_http_proxy_v2_st_length_3:
+            ctx->rest |= ch;
+
+            if (ctx->rest > NGX_HTTP_V2_DEFAULT_FRAME_SIZE) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent too large http2 frame: %uz",
+                              ctx->rest);
+                return NGX_ERROR;
+            }
+
+            state = ngx_http_proxy_v2_st_type;
+            break;
+
+        case ngx_http_proxy_v2_st_type:
+            ctx->type = ch;
+            state = ngx_http_proxy_v2_st_flags;
+            break;
+
+        case ngx_http_proxy_v2_st_flags:
+            ctx->flags = ch;
+            state = ngx_http_proxy_v2_st_stream_id;
+            break;
+
+        case ngx_http_proxy_v2_st_stream_id:
+            ctx->stream_id = (ch & 0x7f) << 24;
+            state = ngx_http_proxy_v2_st_stream_id_2;
+            break;
+
+        case ngx_http_proxy_v2_st_stream_id_2:
+            ctx->stream_id |= ch << 16;
+            state = ngx_http_proxy_v2_st_stream_id_3;
+            break;
+
+        case ngx_http_proxy_v2_st_stream_id_3:
+            ctx->stream_id |= ch << 8;
+            state = ngx_http_proxy_v2_st_stream_id_4;
+            break;
+
+        case ngx_http_proxy_v2_st_stream_id_4:
+            ctx->stream_id |= ch;
+
+            ngx_log_debug4(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http proxy frame: %d, len: %uz, f:%d, i:%ui",
+                           ctx->type, ctx->rest, ctx->flags, ctx->stream_id);
+
+            b->pos = p + 1;
+
+            ctx->state = ngx_http_proxy_v2_st_payload;
+            ctx->frame_state = 0;
+
+            return NGX_OK;
+
+        /* suppress warning */
+        case ngx_http_proxy_v2_st_payload:
+        case ngx_http_proxy_v2_st_padding:
+            break;
+        }
+    }
+
+    b->pos = p;
+    ctx->state = state;
+
+    return NGX_AGAIN;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_parse_header(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b)
+{
+    u_char     ch, *p, *last;
+    size_t     min;
+    ngx_int_t  rc;
+    enum {
+        sw_start = 0,
+        sw_padding_length,
+        sw_dependency,
+        sw_dependency_2,
+        sw_dependency_3,
+        sw_dependency_4,
+        sw_weight,
+        sw_fragment,
+        sw_padding
+    } state;
+
+    state = ctx->frame_state;
+
+    if (state == sw_start) {
+
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy parse header: start");
+
+        if (ctx->type == NGX_HTTP_V2_HEADERS_FRAME) {
+            ctx->parsing_headers = 1;
+            ctx->fragment_state = 0;
+
+            min = (ctx->flags & NGX_HTTP_V2_PADDED_FLAG ? 1 : 0)
+                  + (ctx->flags & NGX_HTTP_V2_PRIORITY_FLAG ? 5 : 0);
+
+            if (ctx->rest < min) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent headers frame "
+                              "with invalid length: %uz",
+                              ctx->rest);
+                return NGX_ERROR;
+            }
+
+            if (ctx->flags & NGX_HTTP_V2_END_STREAM_FLAG) {
+                ctx->end_stream = 1;
+            }
+
+            if (ctx->flags & NGX_HTTP_V2_PADDED_FLAG) {
+                state = sw_padding_length;
+
+            } else if (ctx->flags & NGX_HTTP_V2_PRIORITY_FLAG) {
+                state = sw_dependency;
+
+            } else {
+                state = sw_fragment;
+            }
+
+        } else if (ctx->type == NGX_HTTP_V2_CONTINUATION_FRAME) {
+            state = sw_fragment;
+        }
+
+        ctx->padding = 0;
+        ctx->frame_state = state;
+    }
+
+    if (state < sw_fragment) {
+
+        if (b->last - b->pos < (ssize_t) ctx->rest) {
+            last = b->last;
+
+        } else {
+            last = b->pos + ctx->rest;
+        }
+
+        for (p = b->pos; p < last; p++) {
+            ch = *p;
+
+#if 0
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http proxy header byte: %02Xd s:%d", ch, state);
+#endif
+
+            /*
+             * headers frame:
+             *
+             * +---------------+
+             * |Pad Length? (8)|
+             * +-+-------------+----------------------------------------------+
+             * |E|                 Stream Dependency? (31)                    |
+             * +-+-------------+----------------------------------------------+
+             * |  Weight? (8)  |
+             * +-+-------------+----------------------------------------------+
+             * |                   Header Block Fragment (*)                ...
+             * +--------------------------------------------------------------+
+             * |                           Padding (*)                      ...
+             * +--------------------------------------------------------------+
+             */
+
+            switch (state) {
+
+            case sw_padding_length:
+
+                ctx->padding = ch;
+
+                if (ctx->flags & NGX_HTTP_V2_PRIORITY_FLAG) {
+                    state = sw_dependency;
+                    break;
+                }
+
+                goto fragment;
+
+            case sw_dependency:
+                state = sw_dependency_2;
+                break;
+
+            case sw_dependency_2:
+                state = sw_dependency_3;
+                break;
+
+            case sw_dependency_3:
+                state = sw_dependency_4;
+                break;
+
+            case sw_dependency_4:
+                state = sw_weight;
+                break;
+
+            case sw_weight:
+                goto fragment;
+
+            /* suppress warning */
+            case sw_start:
+            case sw_fragment:
+            case sw_padding:
+                break;
+            }
+        }
+
+        ctx->rest -= p - b->pos;
+        b->pos = p;
+
+        ctx->frame_state = state;
+        return NGX_AGAIN;
+
+    fragment:
+
+        p++;
+        ctx->rest -= p - b->pos;
+        b->pos = p;
+
+        if (ctx->padding > ctx->rest) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent http2 frame with too long "
+                          "padding: %d in frame %uz",
+                          ctx->padding, ctx->rest);
+            return NGX_ERROR;
+        }
+
+        state = sw_fragment;
+        ctx->frame_state = state;
+    }
+
+    if (state == sw_fragment) {
+
+        rc = ngx_http_proxy_v2_parse_fragment(r, ctx, b);
+
+        if (rc == NGX_AGAIN) {
+            return NGX_AGAIN;
+        }
+
+        if (rc == NGX_ERROR) {
+            return NGX_ERROR;
+        }
+
+        if (rc == NGX_OK) {
+            return NGX_OK;
+        }
+
+        /* rc == NGX_DONE */
+
+        state = sw_padding;
+        ctx->frame_state = state;
+    }
+
+    if (state == sw_padding) {
+
+        if (b->last - b->pos < (ssize_t) ctx->rest) {
+
+            ctx->rest -= b->last - b->pos;
+            b->pos = b->last;
+
+            return NGX_AGAIN;
+        }
+
+        b->pos += ctx->rest;
+        ctx->rest = 0;
+
+        ctx->state = ngx_http_proxy_v2_st_start;
+
+        if (ctx->flags & NGX_HTTP_V2_END_HEADERS_FLAG) {
+
+            if (ctx->fragment_state) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent truncated http2 header");
+                return NGX_ERROR;
+            }
+
+            ctx->parsing_headers = 0;
+
+            return NGX_HTTP_PARSE_HEADER_DONE;
+        }
+
+        return NGX_AGAIN;
+    }
+
+    /* unreachable */
+
+    return NGX_ERROR;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_parse_fragment(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b)
+{
+    u_char      ch, *p, *last;
+    size_t      size;
+    ngx_uint_t  index, size_update;
+    enum {
+        sw_start = 0,
+        sw_index,
+        sw_name_length,
+        sw_name_length_2,
+        sw_name_length_3,
+        sw_name_length_4,
+        sw_name,
+        sw_name_bytes,
+        sw_value_length,
+        sw_value_length_2,
+        sw_value_length_3,
+        sw_value_length_4,
+        sw_value,
+        sw_value_bytes
+    } state;
+
+    /* header block fragment */
+
+#if 0
+    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http proxy header fragment %p:%p rest:%uz",
+                   b->pos, b->last, ctx->rest);
+#endif
+
+    if (b->last - b->pos < (ssize_t) ctx->rest - ctx->padding) {
+        last = b->last;
+
+    } else {
+        last = b->pos + ctx->rest - ctx->padding;
+    }
+
+    state = ctx->fragment_state;
+
+    for (p = b->pos; p < last; p++) {
+        ch = *p;
+
+#if 0
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy header byte: %02Xd s:%d", ch, state);
+#endif
+
+        switch (state) {
+
+        case sw_start:
+            ctx->index = 0;
+
+            if ((ch & 0x80) == 0x80) {
+                /*
+                 * indexed header:
+                 *
+                 *   0   1   2   3   4   5   6   7
+                 * +---+---+---+---+---+---+---+---+
+                 * | 1 |        Index (7+)         |
+                 * +---+---------------------------+
+                 */
+
+                index = ch & ~0x80;
+
+                if (index == 0 || index > 61) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent invalid http2 "
+                                  "table index: %ui", index);
+                    return NGX_ERROR;
+                }
+
+                ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                               "http proxy indexed header: %ui", index);
+
+                ctx->index = index;
+                ctx->literal = 0;
+
+                goto done;
+
+            } else if ((ch & 0xc0) == 0x40) {
+                /*
+                 * literal header with incremental indexing:
+                 *
+                 *   0   1   2   3   4   5   6   7
+                 * +---+---+---+---+---+---+---+---+
+                 * | 0 | 1 |      Index (6+)       |
+                 * +---+---+-----------------------+
+                 * | H |     Value Length (7+)     |
+                 * +---+---------------------------+
+                 * | Value String (Length octets)  |
+                 * +-------------------------------+
+                 *
+                 *   0   1   2   3   4   5   6   7
+                 * +---+---+---+---+---+---+---+---+
+                 * | 0 | 1 |           0           |
+                 * +---+---+-----------------------+
+                 * | H |     Name Length (7+)      |
+                 * +---+---------------------------+
+                 * |  Name String (Length octets)  |
+                 * +---+---------------------------+
+                 * | H |     Value Length (7+)     |
+                 * +---+---------------------------+
+                 * | Value String (Length octets)  |
+                 * +-------------------------------+
+                 */
+
+                index = ch & ~0xc0;
+
+                if (index > 61) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent invalid http2 "
+                                  "table index: %ui", index);
+                    return NGX_ERROR;
+                }
+
+                ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                               "http proxy literal header: %ui", index);
+
+                if (index == 0) {
+                    state = sw_name_length;
+                    break;
+                }
+
+                ctx->index = index;
+                ctx->literal = 1;
+
+                state = sw_value_length;
+                break;
+
+            } else if ((ch & 0xe0) == 0x20) {
+                /*
+                 * dynamic table size update:
+                 *
+                 *   0   1   2   3   4   5   6   7
+                 * +---+---+---+---+---+---+---+---+
+                 * | 0 | 0 | 1 |   Max size (5+)   |
+                 * +---+---------------------------+
+                 */
+
+                size_update = ch & ~0xe0;
+
+                if (size_update > 0) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent invalid http2 "
+                                  "dynamic table size update: %ui",
+                                  size_update);
+                    return NGX_ERROR;
+                }
+
+                ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                               "http proxy table size update: %ui",
+                               size_update);
+
+                break;
+
+            } else if ((ch & 0xf0) == 0x10) {
+                /*
+                 *  literal header field never indexed:
+                 *
+                 *   0   1   2   3   4   5   6   7
+                 * +---+---+---+---+---+---+---+---+
+                 * | 0 | 0 | 0 | 1 |  Index (4+)   |
+                 * +---+---+-----------------------+
+                 * | H |     Value Length (7+)     |
+                 * +---+---------------------------+
+                 * | Value String (Length octets)  |
+                 * +-------------------------------+
+                 *
+                 *   0   1   2   3   4   5   6   7
+                 * +---+---+---+---+---+---+---+---+
+                 * | 0 | 0 | 0 | 1 |       0       |
+                 * +---+---+-----------------------+
+                 * | H |     Name Length (7+)      |
+                 * +---+---------------------------+
+                 * |  Name String (Length octets)  |
+                 * +---+---------------------------+
+                 * | H |     Value Length (7+)     |
+                 * +---+---------------------------+
+                 * | Value String (Length octets)  |
+                 * +-------------------------------+
+                 */
+
+                index = ch & ~0xf0;
+
+                if (index == 0x0f) {
+                    ctx->index = index;
+                    ctx->literal = 1;
+                    state = sw_index;
+                    break;
+                }
+
+                if (index == 0) {
+                    state = sw_name_length;
+                    break;
+                }
+
+                ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                               "http proxy literal header never indexed: %ui",
+                               index);
+
+                ctx->index = index;
+                ctx->literal = 1;
+
+                state = sw_value_length;
+                break;
+
+            } else if ((ch & 0xf0) == 0x00) {
+                /*
+                 * literal header field without indexing:
+                 *
+                 *   0   1   2   3   4   5   6   7
+                 * +---+---+---+---+---+---+---+---+
+                 * | 0 | 0 | 0 | 0 |  Index (4+)   |
+                 * +---+---+-----------------------+
+                 * | H |     Value Length (7+)     |
+                 * +---+---------------------------+
+                 * | Value String (Length octets)  |
+                 * +-------------------------------+
+                 *
+                 *   0   1   2   3   4   5   6   7
+                 * +---+---+---+---+---+---+---+---+
+                 * | 0 | 0 | 0 | 0 |       0       |
+                 * +---+---+-----------------------+
+                 * | H |     Name Length (7+)      |
+                 * +---+---------------------------+
+                 * |  Name String (Length octets)  |
+                 * +---+---------------------------+
+                 * | H |     Value Length (7+)     |
+                 * +---+---------------------------+
+                 * | Value String (Length octets)  |
+                 * +-------------------------------+
+                 */
+
+                index = ch & ~0xf0;
+
+                if (index == 0x0f) {
+                    ctx->index = index;
+                    ctx->literal = 1;
+                    state = sw_index;
+                    break;
+                }
+
+                if (index == 0) {
+                    state = sw_name_length;
+                    break;
+                }
+
+                ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                             "http proxy literal header without indexing: %ui",
+                               index);
+
+                ctx->index = index;
+                ctx->literal = 1;
+
+                state = sw_value_length;
+                break;
+            }
+
+            /* not reached */
+
+            return NGX_ERROR;
+
+        case sw_index:
+            ctx->index = ctx->index + (ch & ~0x80);
+
+            if (ch & 0x80) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent http2 table index "
+                              "with continuation flag");
+                return NGX_ERROR;
+            }
+
+            if (ctx->index > 61) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent invalid http2 "
+                              "table index: %ui", ctx->index);
+                return NGX_ERROR;
+            }
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http proxy header index: %ui", ctx->index);
+
+            state = sw_value_length;
+            break;
+
+        case sw_name_length:
+            ctx->field_huffman = ch & 0x80 ? 1 : 0;
+            ctx->field_length = ch & ~0x80;
+
+            if (ctx->field_length == 0x7f) {
+                state = sw_name_length_2;
+                break;
+            }
+
+            if (ctx->field_length == 0) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent zero http2 "
+                              "header name length");
+                return NGX_ERROR;
+            }
+
+            state = sw_name;
+            break;
+
+        case sw_name_length_2:
+            ctx->field_length += ch & ~0x80;
+
+            if (ch & 0x80) {
+                state = sw_name_length_3;
+                break;
+            }
+
+            state = sw_name;
+            break;
+
+        case sw_name_length_3:
+            ctx->field_length += (ch & ~0x80) << 7;
+
+            if (ch & 0x80) {
+                state = sw_name_length_4;
+                break;
+            }
+
+            state = sw_name;
+            break;
+
+        case sw_name_length_4:
+            ctx->field_length += (ch & ~0x80) << 14;
+
+            if (ch & 0x80) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent too large http2 "
+                              "header name length");
+                return NGX_ERROR;
+            }
+
+            state = sw_name;
+            break;
+
+        case sw_name:
+            ctx->name.len = ctx->field_huffman ?
+                            ctx->field_length * 8 / 5 : ctx->field_length;
+
+            ctx->name.data = ngx_pnalloc(r->pool, ctx->name.len + 1);
+            if (ctx->name.data == NULL) {
+                return NGX_ERROR;
+            }
+
+            ctx->field_end = ctx->name.data;
+            ctx->field_rest = ctx->field_length;
+            ctx->field_state = 0;
+
+            state = sw_name_bytes;
+
+            /* fall through */
+
+        case sw_name_bytes:
+
+            ngx_log_debug4(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http proxy name: len:%uz h:%d last:%uz, rest:%uz",
+                           ctx->field_length,
+                           ctx->field_huffman,
+                           last - p,
+                           ctx->rest - (p - b->pos));
+
+            size = ngx_min(last - p, (ssize_t) ctx->field_rest);
+            ctx->field_rest -= size;
+
+            if (ctx->field_huffman) {
+                if (ngx_http_huff_decode(&ctx->field_state, p, size,
+                                         &ctx->field_end,
+                                         ctx->field_rest == 0,
+                                         r->connection->log)
+                    != NGX_OK)
+                {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent invalid encoded header");
+                    return NGX_ERROR;
+                }
+
+                ctx->name.len = ctx->field_end - ctx->name.data;
+                ctx->name.data[ctx->name.len] = '\0';
+
+            } else {
+                ctx->field_end = ngx_cpymem(ctx->field_end, p, size);
+                ctx->name.data[ctx->name.len] = '\0';
+            }
+
+            p += size - 1;
+
+            if (ctx->field_rest == 0) {
+                state = sw_value_length;
+            }
+
+            break;
+
+        case sw_value_length:
+            ctx->field_huffman = ch & 0x80 ? 1 : 0;
+            ctx->field_length = ch & ~0x80;
+
+            if (ctx->field_length == 0x7f) {
+                state = sw_value_length_2;
+                break;
+            }
+
+            if (ctx->field_length == 0) {
+                ngx_str_set(&ctx->value, "");
+                goto done;
+            }
+
+            state = sw_value;
+            break;
+
+        case sw_value_length_2:
+            ctx->field_length += ch & ~0x80;
+
+            if (ch & 0x80) {
+                state = sw_value_length_3;
+                break;
+            }
+
+            state = sw_value;
+            break;
+
+        case sw_value_length_3:
+            ctx->field_length += (ch & ~0x80) << 7;
+
+            if (ch & 0x80) {
+                state = sw_value_length_4;
+                break;
+            }
+
+            state = sw_value;
+            break;
+
+        case sw_value_length_4:
+            ctx->field_length += (ch & ~0x80) << 14;
+
+            if (ch & 0x80) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent too large http2 "
+                              "header value length");
+                return NGX_ERROR;
+            }
+
+            state = sw_value;
+            break;
+
+        case sw_value:
+            ctx->value.len = ctx->field_huffman ?
+                             ctx->field_length * 8 / 5 : ctx->field_length;
+
+            ctx->value.data = ngx_pnalloc(r->pool, ctx->value.len + 1);
+            if (ctx->value.data == NULL) {
+                return NGX_ERROR;
+            }
+
+            ctx->field_end = ctx->value.data;
+            ctx->field_rest = ctx->field_length;
+            ctx->field_state = 0;
+
+            state = sw_value_bytes;
+
+            /* fall through */
+
+        case sw_value_bytes:
+
+            ngx_log_debug4(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http proxy value: len:%uz h:%d last:%uz, rest:%uz",
+                           ctx->field_length,
+                           ctx->field_huffman,
+                           last - p,
+                           ctx->rest - (p - b->pos));
+
+            size = ngx_min(last - p, (ssize_t) ctx->field_rest);
+            ctx->field_rest -= size;
+
+            if (ctx->field_huffman) {
+                if (ngx_http_huff_decode(&ctx->field_state, p, size,
+                                         &ctx->field_end,
+                                         ctx->field_rest == 0,
+                                         r->connection->log)
+                    != NGX_OK)
+                {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent invalid encoded header");
+                    return NGX_ERROR;
+                }
+
+                ctx->value.len = ctx->field_end - ctx->value.data;
+                ctx->value.data[ctx->value.len] = '\0';
+
+            } else {
+                ctx->field_end = ngx_cpymem(ctx->field_end, p, size);
+                ctx->value.data[ctx->value.len] = '\0';
+            }
+
+            p += size - 1;
+
+            if (ctx->field_rest == 0) {
+                goto done;
+            }
+
+            break;
+        }
+
+        continue;
+
+    done:
+
+        p++;
+        ctx->rest -= p - b->pos;
+        ctx->fragment_state = sw_start;
+        b->pos = p;
+
+        if (ctx->index) {
+            ctx->name = *ngx_http_v2_get_static_name(ctx->index);
+        }
+
+        if (ctx->index && !ctx->literal) {
+            ctx->value = *ngx_http_v2_get_static_value(ctx->index);
+        }
+
+        if (!ctx->index) {
+            if (ngx_http_proxy_v2_validate_header_name(r, &ctx->name)
+                != NGX_OK)
+            {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent invalid header: \"%V: %V\"",
+                              &ctx->name, &ctx->value);
+                return NGX_ERROR;
+            }
+        }
+
+        if (!ctx->index || ctx->literal) {
+            if (ngx_http_proxy_v2_validate_header_value(r, &ctx->value)
+                != NGX_OK)
+            {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent invalid header: \"%V: %V\"",
+                              &ctx->name, &ctx->value);
+                return NGX_ERROR;
+            }
+        }
+
+        return NGX_OK;
+    }
+
+    ctx->rest -= p - b->pos;
+    ctx->fragment_state = state;
+    b->pos = p;
+
+    if (ctx->rest > ctx->padding) {
+        return NGX_AGAIN;
+    }
+
+    return NGX_DONE;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_validate_header_name(ngx_http_request_t *r, ngx_str_t *s)
+{
+    u_char      ch;
+    ngx_uint_t  i;
+
+    for (i = 0; i < s->len; i++) {
+        ch = s->data[i];
+
+        if (ch == ':' && i > 0) {
+            return NGX_ERROR;
+        }
+
+        if (ch >= 'A' && ch <= 'Z') {
+            return NGX_ERROR;
+        }
+
+        if (ch <= 0x20 || ch == 0x7f) {
+            return NGX_ERROR;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_validate_header_value(ngx_http_request_t *r, ngx_str_t *s)
+{
+    u_char      ch;
+    ngx_uint_t  i;
+
+    for (i = 0; i < s->len; i++) {
+        ch = s->data[i];
+
+        if (ch == '\0' || ch == CR || ch == LF) {
+            return NGX_ERROR;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_parse_rst_stream(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b)
+{
+    u_char  ch, *p, *last;
+    enum {
+        sw_start = 0,
+        sw_error_2,
+        sw_error_3,
+        sw_error_4
+    } state;
+
+    if (b->last - b->pos < (ssize_t) ctx->rest) {
+        last = b->last;
+
+    } else {
+        last = b->pos + ctx->rest;
+    }
+
+    state = ctx->frame_state;
+
+    if (state == sw_start) {
+        if (ctx->rest != 4) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent rst stream frame "
+                          "with invalid length: %uz",
+                          ctx->rest);
+            return NGX_ERROR;
+        }
+    }
+
+    for (p = b->pos; p < last; p++) {
+        ch = *p;
+
+#if 0
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy rst byte: %02Xd s:%d", ch, state);
+#endif
+
+        switch (state) {
+
+        case sw_start:
+            ctx->error = (ngx_uint_t) ch << 24;
+            state = sw_error_2;
+            break;
+
+        case sw_error_2:
+            ctx->error |= ch << 16;
+            state = sw_error_3;
+            break;
+
+        case sw_error_3:
+            ctx->error |= ch << 8;
+            state = sw_error_4;
+            break;
+
+        case sw_error_4:
+            ctx->error |= ch;
+            state = sw_start;
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http proxy error: %ui", ctx->error);
+
+            break;
+        }
+    }
+
+    ctx->rest -= p - b->pos;
+    ctx->frame_state = state;
+    b->pos = p;
+
+    if (ctx->rest > 0) {
+        return NGX_AGAIN;
+    }
+
+    ctx->state = ngx_http_proxy_v2_st_start;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_parse_goaway(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b)
+{
+    u_char  ch, *p, *last;
+    enum {
+        sw_start = 0,
+        sw_last_stream_id_2,
+        sw_last_stream_id_3,
+        sw_last_stream_id_4,
+        sw_error,
+        sw_error_2,
+        sw_error_3,
+        sw_error_4,
+        sw_debug
+    } state;
+
+    if (b->last - b->pos < (ssize_t) ctx->rest) {
+        last = b->last;
+
+    } else {
+        last = b->pos + ctx->rest;
+    }
+
+    state = ctx->frame_state;
+
+    if (state == sw_start) {
+
+        if (ctx->stream_id) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent goaway frame "
+                          "with non-zero stream id: %ui",
+                          ctx->stream_id);
+            return NGX_ERROR;
+        }
+
+        if (ctx->rest < 8) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent goaway frame "
+                          "with invalid length: %uz",
+                          ctx->rest);
+            return NGX_ERROR;
+        }
+    }
+
+    for (p = b->pos; p < last; p++) {
+        ch = *p;
+
+#if 0
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy goaway byte: %02Xd s:%d", ch, state);
+#endif
+
+        switch (state) {
+
+        case sw_start:
+            ctx->stream_id = (ch & 0x7f) << 24;
+            state = sw_last_stream_id_2;
+            break;
+
+        case sw_last_stream_id_2:
+            ctx->stream_id |= ch << 16;
+            state = sw_last_stream_id_3;
+            break;
+
+        case sw_last_stream_id_3:
+            ctx->stream_id |= ch << 8;
+            state = sw_last_stream_id_4;
+            break;
+
+        case sw_last_stream_id_4:
+            ctx->stream_id |= ch;
+            state = sw_error;
+            break;
+
+        case sw_error:
+            ctx->error = (ngx_uint_t) ch << 24;
+            state = sw_error_2;
+            break;
+
+        case sw_error_2:
+            ctx->error |= ch << 16;
+            state = sw_error_3;
+            break;
+
+        case sw_error_3:
+            ctx->error |= ch << 8;
+            state = sw_error_4;
+            break;
+
+        case sw_error_4:
+            ctx->error |= ch;
+            state = sw_debug;
+            break;
+
+        case sw_debug:
+            break;
+        }
+    }
+
+    ctx->rest -= p - b->pos;
+    ctx->frame_state = state;
+    b->pos = p;
+
+    if (ctx->rest > 0) {
+        return NGX_AGAIN;
+    }
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http proxy goaway: %ui, stream %ui",
+                   ctx->error, ctx->stream_id);
+
+    ctx->state = ngx_http_proxy_v2_st_start;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_parse_window_update(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b)
+{
+    u_char  ch, *p, *last;
+    enum {
+        sw_start = 0,
+        sw_size_2,
+        sw_size_3,
+        sw_size_4
+    } state;
+
+    if (b->last - b->pos < (ssize_t) ctx->rest) {
+        last = b->last;
+
+    } else {
+        last = b->pos + ctx->rest;
+    }
+
+    state = ctx->frame_state;
+
+    if (state == sw_start) {
+        if (ctx->rest != 4) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent window update frame "
+                          "with invalid length: %uz",
+                          ctx->rest);
+            return NGX_ERROR;
+        }
+    }
+
+    for (p = b->pos; p < last; p++) {
+        ch = *p;
+
+#if 0
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy window update byte: %02Xd s:%d", ch, state);
+#endif
+
+        switch (state) {
+
+        case sw_start:
+            ctx->window_update = (ch & 0x7f) << 24;
+            state = sw_size_2;
+            break;
+
+        case sw_size_2:
+            ctx->window_update |= ch << 16;
+            state = sw_size_3;
+            break;
+
+        case sw_size_3:
+            ctx->window_update |= ch << 8;
+            state = sw_size_4;
+            break;
+
+        case sw_size_4:
+            ctx->window_update |= ch;
+            state = sw_start;
+            break;
+        }
+    }
+
+    ctx->rest -= p - b->pos;
+    ctx->frame_state = state;
+    b->pos = p;
+
+    if (ctx->rest > 0) {
+        return NGX_AGAIN;
+    }
+
+    ctx->state = ngx_http_proxy_v2_st_start;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http proxy window update: %ui", ctx->window_update);
+
+    if (ctx->stream_id) {
+
+        if (ctx->window_update > (size_t) NGX_HTTP_V2_MAX_WINDOW
+                                 - ctx->send_window)
+        {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent too large window update");
+            return NGX_ERROR;
+        }
+
+        ctx->send_window += ctx->window_update;
+
+    } else {
+
+        if (ctx->window_update > NGX_HTTP_V2_MAX_WINDOW
+                                 - ctx->connection->send_window)
+        {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent too large window update");
+            return NGX_ERROR;
+        }
+
+        ctx->connection->send_window += ctx->window_update;
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_parse_settings(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b)
+{
+    u_char   ch, *p, *last;
+    ssize_t  window_update;
+    enum {
+        sw_start = 0,
+        sw_id,
+        sw_id_2,
+        sw_value,
+        sw_value_2,
+        sw_value_3,
+        sw_value_4
+    } state;
+
+    if (b->last - b->pos < (ssize_t) ctx->rest) {
+        last = b->last;
+
+    } else {
+        last = b->pos + ctx->rest;
+    }
+
+    state = ctx->frame_state;
+
+    if (state == sw_start) {
+
+        if (ctx->stream_id) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent settings frame "
+                          "with non-zero stream id: %ui",
+                          ctx->stream_id);
+            return NGX_ERROR;
+        }
+
+        if (ctx->flags & NGX_HTTP_V2_ACK_FLAG) {
+            ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http proxy settings ack");
+
+            if (ctx->rest != 0) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent settings frame "
+                              "with ack flag and non-zero length: %uz",
+                              ctx->rest);
+                return NGX_ERROR;
+            }
+
+            ctx->state = ngx_http_proxy_v2_st_start;
+
+            return NGX_OK;
+        }
+
+        if (ctx->rest % 6 != 0) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent settings frame "
+                          "with invalid length: %uz",
+                          ctx->rest);
+            return NGX_ERROR;
+        }
+
+        if (ctx->free == NULL && ctx->settings++ > 1000) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent too many settings frames");
+            return NGX_ERROR;
+        }
+    }
+
+    for (p = b->pos; p < last; p++) {
+        ch = *p;
+
+#if 0
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy settings byte: %02Xd s:%d", ch, state);
+#endif
+
+        switch (state) {
+
+        case sw_start:
+        case sw_id:
+            ctx->setting_id = ch << 8;
+            state = sw_id_2;
+            break;
+
+        case sw_id_2:
+            ctx->setting_id |= ch;
+            state = sw_value;
+            break;
+
+        case sw_value:
+            ctx->setting_value = (ngx_uint_t) ch << 24;
+            state = sw_value_2;
+            break;
+
+        case sw_value_2:
+            ctx->setting_value |= ch << 16;
+            state = sw_value_3;
+            break;
+
+        case sw_value_3:
+            ctx->setting_value |= ch << 8;
+            state = sw_value_4;
+            break;
+
+        case sw_value_4:
+            ctx->setting_value |= ch;
+            state = sw_id;
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http proxy setting: %ui %ui",
+                           ctx->setting_id, ctx->setting_value);
+
+            /*
+             * The following settings are defined by the protocol:
+             *
+             * SETTINGS_HEADER_TABLE_SIZE, SETTINGS_ENABLE_PUSH,
+             * SETTINGS_MAX_CONCURRENT_STREAMS, SETTINGS_INITIAL_WINDOW_SIZE,
+             * SETTINGS_MAX_FRAME_SIZE, SETTINGS_MAX_HEADER_LIST_SIZE
+             *
+             * Only SETTINGS_INITIAL_WINDOW_SIZE seems to be needed in
+             * a simple client.
+             */
+
+            if (ctx->setting_id == 0x04) {
+                /* SETTINGS_INITIAL_WINDOW_SIZE */
+
+                if (ctx->setting_value > NGX_HTTP_V2_MAX_WINDOW) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent settings frame "
+                                  "with too large initial window size: %ui",
+                                  ctx->setting_value);
+                    return NGX_ERROR;
+                }
+
+                window_update = ctx->setting_value
+                                - ctx->connection->init_window;
+                ctx->connection->init_window = ctx->setting_value;
+
+                if (ctx->send_window > 0
+                    && window_update > (ssize_t) NGX_HTTP_V2_MAX_WINDOW
+                                       - ctx->send_window)
+                {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent settings frame "
+                                  "with too large initial window size: %ui",
+                                  ctx->setting_value);
+                    return NGX_ERROR;
+                }
+
+                ctx->send_window += window_update;
+            }
+
+            break;
+        }
+    }
+
+    ctx->rest -= p - b->pos;
+    ctx->frame_state = state;
+    b->pos = p;
+
+    if (ctx->rest > 0) {
+        return NGX_AGAIN;
+    }
+
+    ctx->state = ngx_http_proxy_v2_st_start;
+
+    return ngx_http_proxy_v2_send_settings_ack(r, ctx);
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_parse_ping(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b)
+{
+    u_char  ch, *p, *last;
+    enum {
+        sw_start = 0,
+        sw_data_2,
+        sw_data_3,
+        sw_data_4,
+        sw_data_5,
+        sw_data_6,
+        sw_data_7,
+        sw_data_8
+    } state;
+
+    if (b->last - b->pos < (ssize_t) ctx->rest) {
+        last = b->last;
+
+    } else {
+        last = b->pos + ctx->rest;
+    }
+
+    state = ctx->frame_state;
+
+    if (state == sw_start) {
+
+        if (ctx->stream_id) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent ping frame "
+                          "with non-zero stream id: %ui",
+                          ctx->stream_id);
+            return NGX_ERROR;
+        }
+
+        if (ctx->rest != 8) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent ping frame "
+                          "with invalid length: %uz",
+                          ctx->rest);
+            return NGX_ERROR;
+        }
+
+        if (ctx->flags & NGX_HTTP_V2_ACK_FLAG) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent ping frame with ack flag");
+            return NGX_ERROR;
+        }
+
+        if (ctx->free == NULL && ctx->pings++ > 1000) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "upstream sent too many ping frames");
+            return NGX_ERROR;
+        }
+    }
+
+    for (p = b->pos; p < last; p++) {
+        ch = *p;
+
+#if 0
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "http proxy ping byte: %02Xd s:%d", ch, state);
+#endif
+
+        if (state < sw_data_8) {
+            ctx->ping_data[state] = ch;
+            state++;
+
+        } else {
+            ctx->ping_data[7] = ch;
+            state = sw_start;
+
+            ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http proxy ping");
+        }
+    }
+
+    ctx->rest -= p - b->pos;
+    ctx->frame_state = state;
+    b->pos = p;
+
+    if (ctx->rest > 0) {
+        return NGX_AGAIN;
+    }
+
+    ctx->state = ngx_http_proxy_v2_st_start;
+
+    return ngx_http_proxy_v2_send_ping_ack(r, ctx);
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_send_settings_ack(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx)
+{
+    ngx_chain_t                *cl, **ll;
+    ngx_http_proxy_v2_frame_t  *f;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http proxy send settings ack");
+
+    for (cl = ctx->out, ll = &ctx->out; cl; cl = cl->next) {
+        ll = &cl->next;
+    }
+
+    cl = ngx_http_proxy_v2_get_buf(r, ctx);
+    if (cl == NULL) {
+        return NGX_ERROR;
+    }
+
+    f = (ngx_http_proxy_v2_frame_t *) cl->buf->last;
+    cl->buf->last += sizeof(ngx_http_proxy_v2_frame_t);
+
+    f->length_0 = 0;
+    f->length_1 = 0;
+    f->length_2 = 0;
+    f->type = NGX_HTTP_V2_SETTINGS_FRAME;
+    f->flags = NGX_HTTP_V2_ACK_FLAG;
+    f->stream_id_0 = 0;
+    f->stream_id_1 = 0;
+    f->stream_id_2 = 0;
+    f->stream_id_3 = 0;
+
+    *ll = cl;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_send_ping_ack(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx)
+{
+    ngx_chain_t                *cl, **ll;
+    ngx_http_proxy_v2_frame_t  *f;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http proxy send ping ack");
+
+    for (cl = ctx->out, ll = &ctx->out; cl; cl = cl->next) {
+        ll = &cl->next;
+    }
+
+    cl = ngx_http_proxy_v2_get_buf(r, ctx);
+    if (cl == NULL) {
+        return NGX_ERROR;
+    }
+
+    f = (ngx_http_proxy_v2_frame_t *) cl->buf->last;
+    cl->buf->last += sizeof(ngx_http_proxy_v2_frame_t);
+
+    f->length_0 = 0;
+    f->length_1 = 0;
+    f->length_2 = 8;
+    f->type = NGX_HTTP_V2_PING_FRAME;
+    f->flags = NGX_HTTP_V2_ACK_FLAG;
+    f->stream_id_0 = 0;
+    f->stream_id_1 = 0;
+    f->stream_id_2 = 0;
+    f->stream_id_3 = 0;
+
+    cl->buf->last = ngx_copy(cl->buf->last, ctx->ping_data, 8);
+
+    *ll = cl;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_send_window_update(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx)
+{
+    size_t                      n;
+    ngx_chain_t                *cl, **ll;
+    ngx_http_proxy_v2_frame_t  *f;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http proxy send window update: %uz %uz",
+                   ctx->connection->recv_window, ctx->recv_window);
+
+    for (cl = ctx->out, ll = &ctx->out; cl; cl = cl->next) {
+        ll = &cl->next;
+    }
+
+    cl = ngx_http_proxy_v2_get_buf(r, ctx);
+    if (cl == NULL) {
+        return NGX_ERROR;
+    }
+
+    f = (ngx_http_proxy_v2_frame_t *) cl->buf->last;
+    cl->buf->last += sizeof(ngx_http_proxy_v2_frame_t);
+
+    f->length_0 = 0;
+    f->length_1 = 0;
+    f->length_2 = 4;
+    f->type = NGX_HTTP_V2_WINDOW_UPDATE_FRAME;
+    f->flags = 0;
+    f->stream_id_0 = 0;
+    f->stream_id_1 = 0;
+    f->stream_id_2 = 0;
+    f->stream_id_3 = 0;
+
+    n = NGX_HTTP_V2_MAX_WINDOW - ctx->connection->recv_window;
+    ctx->connection->recv_window = NGX_HTTP_V2_MAX_WINDOW;
+
+    *cl->buf->last++ = (u_char) ((n >> 24) & 0xff);
+    *cl->buf->last++ = (u_char) ((n >> 16) & 0xff);
+    *cl->buf->last++ = (u_char) ((n >> 8) & 0xff);
+    *cl->buf->last++ = (u_char) (n & 0xff);
+
+    f = (ngx_http_proxy_v2_frame_t *) cl->buf->last;
+    cl->buf->last += sizeof(ngx_http_proxy_v2_frame_t);
+
+    f->length_0 = 0;
+    f->length_1 = 0;
+    f->length_2 = 4;
+    f->type = NGX_HTTP_V2_WINDOW_UPDATE_FRAME;
+    f->flags = 0;
+    f->stream_id_0 = (u_char) ((ctx->id >> 24) & 0xff);
+    f->stream_id_1 = (u_char) ((ctx->id >> 16) & 0xff);
+    f->stream_id_2 = (u_char) ((ctx->id >> 8) & 0xff);
+    f->stream_id_3 = (u_char) (ctx->id & 0xff);
+
+    n = NGX_HTTP_V2_MAX_WINDOW - ctx->recv_window;
+    ctx->recv_window = NGX_HTTP_V2_MAX_WINDOW;
+
+    *cl->buf->last++ = (u_char) ((n >> 24) & 0xff);
+    *cl->buf->last++ = (u_char) ((n >> 16) & 0xff);
+    *cl->buf->last++ = (u_char) ((n >> 8) & 0xff);
+    *cl->buf->last++ = (u_char) (n & 0xff);
+
+    *ll = cl;
+
+    return NGX_OK;
+}
+
+
+static ngx_chain_t *
+ngx_http_proxy_v2_get_buf(ngx_http_request_t *r, ngx_http_proxy_v2_ctx_t *ctx)
+{
+    u_char       *start;
+    ngx_buf_t    *b;
+    ngx_chain_t  *cl;
+
+    cl = ngx_chain_get_free_buf(r->pool, &ctx->free);
+    if (cl == NULL) {
+        return NULL;
+    }
+
+    b = cl->buf;
+    start = b->start;
+
+    if (start == NULL) {
+
+        /*
+         * each buffer is large enough to hold two window update
+         * frames in a row
+         */
+
+        start = ngx_palloc(r->pool, 2 * sizeof(ngx_http_proxy_v2_frame_t) + 8);
+        if (start == NULL) {
+            return NULL;
+        }
+
+    }
+
+    ngx_memzero(b, sizeof(ngx_buf_t));
+
+    b->start = start;
+    b->pos = start;
+    b->last = start;
+    b->end = start + 2 * sizeof(ngx_http_proxy_v2_frame_t) + 8;
+
+    b->tag = (ngx_buf_tag_t) &ngx_http_proxy_v2_body_output_filter;
+    b->temporary = 1;
+    b->flush = 1;
+
+    return cl;
+}
+
+
+static ngx_http_proxy_v2_ctx_t *
+ngx_http_proxy_v2_get_ctx(ngx_http_request_t *r)
+{
+    ngx_http_upstream_t      *u;
+    ngx_http_proxy_v2_ctx_t  *ctx;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_proxy_v2_module);
+
+    if (ctx->connection == NULL) {
+        u = r->upstream;
+
+        if (ngx_http_proxy_v2_get_connection_data(r, ctx, &u->peer) != NGX_OK) {
+            return NULL;
+        }
+    }
+
+    return ctx;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_v2_get_connection_data(ngx_http_request_t *r,
+    ngx_http_proxy_v2_ctx_t *ctx, ngx_peer_connection_t *pc)
+{
+    ngx_connection_t    *c;
+    ngx_pool_cleanup_t  *cln;
+
+    c = pc->connection;
+
+    if (pc->cached) {
+
+        /*
+         * for cached connections, connection data can be found
+         * in the cleanup handler
+         */
+
+        for (cln = c->pool->cleanup; cln; cln = cln->next) {
+            if (cln->handler == ngx_http_proxy_v2_cleanup) {
+                ctx->connection = cln->data;
+                break;
+            }
+        }
+
+        if (ctx->connection == NULL) {
+            ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                          "no connection data found for "
+                          "keepalive http2 connection");
+            return NGX_ERROR;
+        }
+
+        ctx->send_window = ctx->connection->init_window;
+        ctx->recv_window = NGX_HTTP_V2_MAX_WINDOW;
+
+        ctx->connection->last_stream_id += 2;
+        ctx->id = ctx->connection->last_stream_id;
+
+        return NGX_OK;
+    }
+
+    cln = ngx_pool_cleanup_add(c->pool, sizeof(ngx_http_proxy_v2_conn_t));
+    if (cln == NULL) {
+        return NGX_ERROR;
+    }
+
+    cln->handler = ngx_http_proxy_v2_cleanup;
+    ctx->connection = cln->data;
+
+    ctx->connection->init_window = NGX_HTTP_V2_DEFAULT_WINDOW;
+    ctx->connection->send_window = NGX_HTTP_V2_DEFAULT_WINDOW;
+    ctx->connection->recv_window = NGX_HTTP_V2_MAX_WINDOW;
+
+    ctx->send_window = NGX_HTTP_V2_DEFAULT_WINDOW;
+    ctx->recv_window = NGX_HTTP_V2_MAX_WINDOW;
+
+    ctx->id = 1;
+    ctx->connection->last_stream_id = 1;
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_http_proxy_v2_cleanup(void *data)
+{
+#if 0
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http proxy cleanup");
+#endif
+    return;
+}
+
+
+static void
+ngx_http_proxy_v2_abort_request(ngx_http_request_t *r)
+{
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "abort proxy http2 request");
+    return;
+}
+
+
+static void
+ngx_http_proxy_v2_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+{
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "finalize proxy http2 request");
+    return;
+}

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -1771,6 +1771,23 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
         }
     }
 
+#ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
+
+    if (u->ssl_alpn_protocol.len) {
+        if (SSL_set_alpn_protos(c->ssl->connection, u->ssl_alpn_protocol.data,
+                                u->ssl_alpn_protocol.len)
+            != 0)
+        {
+            ngx_ssl_error(NGX_LOG_ERR, c->log, 0,
+                          "SSL_set_alpn_protos() failed");
+            ngx_http_upstream_finalize_request(r, u,
+                                               NGX_HTTP_INTERNAL_SERVER_ERROR);
+            return;
+        }
+    }
+
+#endif
+
     if (u->conf->ssl_session_reuse) {
         c->ssl->save_session = ngx_http_upstream_ssl_save_session;
 

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -390,6 +390,7 @@ struct ngx_http_upstream_s {
 
 #if (NGX_HTTP_SSL || NGX_COMPAT)
     ngx_str_t                        ssl_name;
+    ngx_str_t                        ssl_alpn_protocol;
 #endif
 
     ngx_http_cleanup_pt             *cleanup;


### PR DESCRIPTION
Supported:
- proxy http2
- request buffering and proxying buffering
- proxy cache

tests: based on grpc.t
- http2 protocol tests passed
- proxy buffering tests passed
- request buffering tests passed with new implementation
- long header/field tests passed
- trailers handling passed
- SETTINGS tests passed
- authority tests passed
- upstream keepalive tests passed
- non-buffering with upstream keepalive passed
- ssl tests passed
- better coverage tests for this feature but only replicate all the tests from grpc.t
- cache tests