### PR TITLE
HTTP/3: fixed handling :authority and Host with port.

### DIFF
--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -1003,6 +1003,7 @@ ngx_http_v3_process_request_header(ngx_http_request_t *r)
 {
     ssize_t                  n;
     ngx_buf_t               *b;
+    ngx_str_t                host;
     ngx_connection_t        *c;
     ngx_http_v3_session_t   *h3c;
     ngx_http_v3_srv_conf_t  *h3scf;
@@ -1034,11 +1035,13 @@ ngx_http_v3_process_request_header(ngx_http_request_t *r)
         goto failed;
     }
 
-    if (r->headers_in.host) {
-        if (r->headers_in.host->value.len != r->headers_in.server.len
-            || ngx_memcmp(r->headers_in.host->value.data,
-                          r->headers_in.server.data,
-                          r->headers_in.server.len)
+    if (r->headers_in.host && r->host_end) {
+
+        host.len = r->host_end - r->host_start;
+        host.data = r->host_start;
+
+        if (r->headers_in.host->value.len != host.len
+            || ngx_memcmp(r->headers_in.host->value.data, host.data, host.len)
                != 0)
         {
             ngx_log_error(NGX_LOG_INFO, c->log, 0,


### PR DESCRIPTION
RFC 9114, Section 4.3.1. specifies a  restriciton for `:authority` and `Host` coexistence in an HTTP/3 request:

> If both fields are present, they MUST contain the same value.

Currently this restriction is correctly enforced for portless values. However when a port is specified, the request fails as if `:authority` and `Host` are different.  Also, if no `:authority` is passed, but `Host` contains a port, the request fails as well.

This happens because the value of `r->headers_in.server` used for `:authority` has port stripped.  The fix is to use `r->host_start` / `r->host_end` instead.

This came up while working on https://github.com/nginx/nginx/pull/770.

Tests: https://github.com/arut/nginx-tests/commit/8eace6b1a0123ab8953f7387134de85c905d3479