### PR TITLE
OPENSSL_VERSION_NUMBER fix for OpenSSL 3.0

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5055,11 +5055,7 @@ ngx_ssl_get_curve(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
             return NGX_OK;
         }
 
-#if (OPENSSL_VERSION_NUMBER >= 0x3000000fL)
         name = SSL_group_to_name(c->ssl->connection, nid);
-#else
-        name = NULL;
-#endif
 
         s->len = name ? ngx_strlen(name) : sizeof("0x0000") - 1;
         s->data = ngx_pnalloc(pool, s->len);
@@ -5113,11 +5109,7 @@ ngx_ssl_get_curves(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
         nid = curves[i];
 
         if (nid & TLSEXT_nid_unknown) {
-#if (OPENSSL_VERSION_NUMBER >= 0x3000000fL)
             name = SSL_group_to_name(c->ssl->connection, nid);
-#else
-            name = NULL;
-#endif
 
             len += name ? ngx_strlen(name) : sizeof("0x0000") - 1;
 
@@ -5139,11 +5131,7 @@ ngx_ssl_get_curves(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
         nid = curves[i];
 
         if (nid & TLSEXT_nid_unknown) {
-#if (OPENSSL_VERSION_NUMBER >= 0x3000000fL)
             name = SSL_group_to_name(c->ssl->connection, nid);
-#else
-            name = NULL;
-#endif
 
             p = name ? ngx_cpymem(p, name, ngx_strlen(name))
                      : ngx_sprintf(p, "0x%04xd", nid & 0xffff);

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -1374,7 +1374,7 @@ ngx_ssl_dhparam(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *file)
     if (SSL_CTX_set0_tmp_dh_pkey(ssl->ctx, dh) != 1) {
         ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0,
                       "SSL_CTX_set0_tmp_dh_pkey(\"%s\") failed", file->data);
-#if (OPENSSL_VERSION_NUMBER >= 0x3000001fL)
+#if (OPENSSL_VERSION_NUMBER >= 0x30000010L)
         EVP_PKEY_free(dh);
 #endif
         BIO_free(bio);

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -96,6 +96,11 @@
 #endif
 
 
+#if (OPENSSL_VERSION_NUMBER < 0x3000000fL)
+#define SSL_group_to_name(s, nid)    NULL
+#endif
+
+
 typedef struct ngx_ssl_ocsp_s   ngx_ssl_ocsp_t;
 
 

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -96,7 +96,7 @@
 #endif
 
 
-#if (OPENSSL_VERSION_NUMBER < 0x3000000fL)
+#if (OPENSSL_VERSION_NUMBER < 0x30000000L)
 #define SSL_group_to_name(s, nid)    NULL
 #endif
 


### PR DESCRIPTION
There is a preparatory no-op change to 1) reduce clatter 2) reduce the number of affected feature tests