### PR TITLE
Add a GitHub workflow to check for whitespace issues.

### DIFF
--- a/.github/workflows/check-whitespace.yaml
+++ b/.github/workflows/check-whitespace.yaml
@@ -1,0 +1,48 @@
+name: Check Whitespace
+
+# Get the repo with the commits(+1) in the series.
+# Process `git log --check` output to extract just the check errors.
+
+on:
+  pull_request:
+    types: [ opened, synchronize ]
+
+jobs:
+  check-whitespace:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: git log --check
+      id: check_out
+      run: |
+        log=
+        commit=
+        while read dash etc
+        do
+          case "${dash}" in
+          "---")
+            commit="${etc}"
+            ;;
+          "")
+            ;;
+          *)
+            if test -n "${commit}"
+            then
+              log="${log}\n${commit}"
+              echo ""
+              echo "--- ${commit}"
+            fi
+            commit=
+            log="${log}\n${dash} ${etc}"
+            echo "${dash} ${etc}"
+            ;;
+          esac
+        done <<< $(git log --check --pretty=format:"--- %h %s" ${{github.event.pull_request.base.sha}}..)
+
+        if test -n "${log}"
+        then
+          exit 2
+        fi


### PR DESCRIPTION

```
Add a GitHub workflow to check for whitespace issues.

If it fails you can check the 'git log --check' output of the workflow
to see what the issue is. E.g. (Excess/unwanted whitespace will be
highlighted in red).

  --- afe5753fa changes made in upstream
  src/http/ngx_http_upstream.c:415: trailing whitespace.
  +
  src/http/ngx_http_upstream.c:417: trailing whitespace.
  +      ngx_http_upstream_backend_ssl_protocol, 0,
  src/http/ngx_http_upstream.c:421: trailing whitespace.
  +      ngx_http_upstream_backend_ssl_cipher, 0,

We make use of this in Unit... specific exceptions can be handled via
gitattributes(5).
```
