### PR TITLE
Set git diff driver for C source code files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.[ch]	diff=cpp


### PR DESCRIPTION
```
Git can be told to apply language-specific rules when generating diffs.
Enable this for C source code files (*.c and *.h) so that function names
are printed right. Specifically, doing so prevents "git diff" from
mistakenly considering unindented goto labels as function names.

E.g. get

  @@ -10,7 +10,7 @@ int foo(void)

instead of

  @@ -10,7 +10,7 @@ again:

This has the same effect as adding

  [diff "default"]
      xfuncname = "^[[:alpha:]$_].*[^:]$"

to your git config file.

This makes use of the gitattributes(5) infrastructure.
```