### PR TITLE
Add support for 501 Not Implemented in proxy_next_upstream

### DIFF
--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -260,6 +260,7 @@ static ngx_conf_bitmask_t  ngx_http_proxy_next_upstream_masks[] = {
     { ngx_string("invalid_header"), NGX_HTTP_UPSTREAM_FT_INVALID_HEADER },
     { ngx_string("non_idempotent"), NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT },
     { ngx_string("http_500"), NGX_HTTP_UPSTREAM_FT_HTTP_500 },
+    { ngx_string("http_501"), NGX_HTTP_UPSTREAM_FT_HTTP_501 },
     { ngx_string("http_502"), NGX_HTTP_UPSTREAM_FT_HTTP_502 },
     { ngx_string("http_503"), NGX_HTTP_UPSTREAM_FT_HTTP_503 },
     { ngx_string("http_504"), NGX_HTTP_UPSTREAM_FT_HTTP_504 },

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -21,6 +21,7 @@
 #define NGX_HTTP_UPSTREAM_FT_TIMEOUT         0x00000004
 #define NGX_HTTP_UPSTREAM_FT_INVALID_HEADER  0x00000008
 #define NGX_HTTP_UPSTREAM_FT_HTTP_500        0x00000010
+#define NGX_HTTP_UPSTREAM_FT_HTTP_501        0x00008000
 #define NGX_HTTP_UPSTREAM_FT_HTTP_502        0x00000020
 #define NGX_HTTP_UPSTREAM_FT_HTTP_503        0x00000040
 #define NGX_HTTP_UPSTREAM_FT_HTTP_504        0x00000080
@@ -35,6 +36,7 @@
 #define NGX_HTTP_UPSTREAM_FT_OFF             0x80000000
 
 #define NGX_HTTP_UPSTREAM_FT_STATUS          (NGX_HTTP_UPSTREAM_FT_HTTP_500  \
+                                             |NGX_HTTP_UPSTREAM_FT_HTTP_501  \
                                              |NGX_HTTP_UPSTREAM_FT_HTTP_502  \
                                              |NGX_HTTP_UPSTREAM_FT_HTTP_503  \
                                              |NGX_HTTP_UPSTREAM_FT_HTTP_504  \


### PR DESCRIPTION
### Proposed changes
As per https://github.com/nginx/nginx/issues/794 proxy_next_upstream only supports failover redirection on 500, 502, 503 etc. 

I added support for 501 code.
Added NGX_HTTP_UPSTREAM_FT_HTTP_501 constant macro in such a way as to not interfere with the other constants in NGX_HTTP_UPSTREAM_FT_STATUS (which seems to be a bitwise OR of all the codes for proxy_next_upstream)

Also changed  ngx_http_proxy_next_upstream_masks[] array to support the new code (in src/http/modules/ngx_http_proxy_module.c)

### Scope
These changes seem sort of localized... they shouldn't really affect the entire project.
