### PR TITLE
SSL: Add support for AWS-LC

### DIFF
--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -27,7 +27,7 @@
 #endif
 #include <openssl/evp.h>
 #if (NGX_QUIC)
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
 #include <openssl/hkdf.h>
 #include <openssl/chacha.h>
 #else

--- a/src/event/quic/ngx_event_quic.h
+++ b/src/event/quic/ngx_event_quic.h
@@ -18,7 +18,8 @@
 #elif (defined SSL_R_MISSING_QUIC_TRANSPORT_PARAMETERS_EXTENSION)
 #define NGX_QUIC_QUICTLS_API                 1
 
-#elif (defined OPENSSL_IS_BORINGSSL || defined LIBRESSL_VERSION_NUMBER)
+#elif (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC               \
+       || defined LIBRESSL_VERSION_NUMBER)
 #define NGX_QUIC_BORINGSSL_API               1
 
 #else

--- a/src/event/quic/ngx_event_quic_protection.c
+++ b/src/event/quic/ngx_event_quic_protection.c
@@ -33,7 +33,7 @@ static uint64_t ngx_quic_parse_pn(u_char **pos, ngx_int_t len, u_char *mask,
 
 static ngx_int_t ngx_quic_crypto_open(ngx_quic_secret_t *s, ngx_str_t *out,
     const u_char *nonce, ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log);
-#ifndef OPENSSL_IS_BORINGSSL
+#if !(defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
 static ngx_int_t ngx_quic_crypto_common(ngx_quic_secret_t *s, ngx_str_t *out,
     const u_char *nonce, ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log);
 #endif
@@ -58,7 +58,7 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
     switch (id) {
 
     case TLS1_3_CK_AES_128_GCM_SHA256:
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
         ciphers->c = EVP_aead_aes_128_gcm();
 #else
         ciphers->c = EVP_aes_128_gcm();
@@ -69,7 +69,7 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
         break;
 
     case TLS1_3_CK_AES_256_GCM_SHA384:
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
         ciphers->c = EVP_aead_aes_256_gcm();
 #else
         ciphers->c = EVP_aes_256_gcm();
@@ -80,12 +80,12 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
         break;
 
     case TLS1_3_CK_CHACHA20_POLY1305_SHA256:
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
         ciphers->c = EVP_aead_chacha20_poly1305();
 #else
         ciphers->c = EVP_chacha20_poly1305();
 #endif
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
         ciphers->hp = (const EVP_CIPHER *) EVP_aead_chacha20_poly1305();
 #else
         ciphers->hp = EVP_chacha20();
@@ -94,7 +94,7 @@ ngx_quic_ciphers(ngx_uint_t id, ngx_quic_ciphers_t *ciphers)
         len = 32;
         break;
 
-#ifndef OPENSSL_IS_BORINGSSL
+#if !(defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
     case TLS1_3_CK_AES_128_CCM_SHA256:
         ciphers->c = EVP_aes_128_ccm();
         ciphers->hp = EVP_aes_128_ctr();
@@ -388,7 +388,7 @@ ngx_quic_crypto_init(const ngx_quic_cipher_t *cipher, ngx_quic_secret_t *s,
     ngx_quic_md_t *key, ngx_int_t enc, ngx_log_t *log)
 {
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
     EVP_AEAD_CTX  *ctx;
 
     ctx = EVP_AEAD_CTX_new(cipher, key->data, key->len,
@@ -448,7 +448,7 @@ static ngx_int_t
 ngx_quic_crypto_open(ngx_quic_secret_t *s, ngx_str_t *out, const u_char *nonce,
     ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log)
 {
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
     if (EVP_AEAD_CTX_open(s->ctx, out->data, &out->len, out->len, nonce,
                           s->iv.len, in->data, in->len, ad->data, ad->len)
         != 1)
@@ -468,7 +468,7 @@ ngx_int_t
 ngx_quic_crypto_seal(ngx_quic_secret_t *s, ngx_str_t *out, const u_char *nonce,
     ngx_str_t *in, ngx_str_t *ad, ngx_log_t *log)
 {
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
     if (EVP_AEAD_CTX_seal(s->ctx, out->data, &out->len, out->len, nonce,
                           s->iv.len, in->data, in->len, ad->data, ad->len)
         != 1)
@@ -484,7 +484,7 @@ ngx_quic_crypto_seal(ngx_quic_secret_t *s, ngx_str_t *out, const u_char *nonce,
 }
 
 
-#ifndef OPENSSL_IS_BORINGSSL
+#if !(defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
 
 static ngx_int_t
 ngx_quic_crypto_common(ngx_quic_secret_t *s, ngx_str_t *out,
@@ -563,7 +563,7 @@ void
 ngx_quic_crypto_cleanup(ngx_quic_secret_t *s)
 {
     if (s->ctx) {
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
         EVP_AEAD_CTX_free(s->ctx);
 #else
         EVP_CIPHER_CTX_free(s->ctx);
@@ -579,7 +579,7 @@ ngx_quic_crypto_hp_init(const EVP_CIPHER *cipher, ngx_quic_secret_t *s,
 {
     EVP_CIPHER_CTX  *ctx;
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
     if (cipher == (EVP_CIPHER *) EVP_aead_chacha20_poly1305()) {
         /* no EVP interface */
         s->hp_ctx = NULL;
@@ -615,7 +615,7 @@ ngx_quic_crypto_hp(ngx_quic_secret_t *s, u_char *out, u_char *in,
 
     ctx = s->hp_ctx;
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
     uint32_t         cnt;
 
     if (ctx == NULL) {

--- a/src/event/quic/ngx_event_quic_protection.h
+++ b/src/event/quic/ngx_event_quic_protection.h
@@ -22,7 +22,7 @@
 #define NGX_QUIC_MAX_MD_SIZE          48
 
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
 #define ngx_quic_cipher_t             EVP_AEAD
 #define ngx_quic_crypto_ctx_t         EVP_AEAD_CTX
 #else

--- a/src/event/quic/ngx_event_quic_ssl.c
+++ b/src/event/quic/ngx_event_quic_ssl.c
@@ -968,7 +968,7 @@ ngx_quic_init_connection(ngx_connection_t *c)
     }
 #endif
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if (defined OPENSSL_IS_BORINGSSL || defined OPENSSL_IS_AWSLC)
     if (SSL_set_quic_early_data_context(ssl_conn, p, clen) == 0) {
         ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
                       "quic SSL_set_quic_early_data_context() failed");

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -935,7 +935,8 @@ ngx_http_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
     sscf = ngx_http_get_module_srv_conf(cscf->ctx, ngx_http_ssl_module);
 
 #if (defined TLS1_3_VERSION                                                   \
-     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL)
+     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL     \
+     && !defined OPENSSL_IS_AWSLC)
 
     /*
      * SSL_SESSION_get0_hostname() is only available in OpenSSL 1.1.1+,

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -592,7 +592,8 @@ ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
     sscf = ngx_stream_get_module_srv_conf(cscf->ctx, ngx_stream_ssl_module);
 
 #if (defined TLS1_3_VERSION                                                   \
-     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL)
+     && !defined LIBRESSL_VERSION_NUMBER && !defined OPENSSL_IS_BORINGSSL     \
+     && !defined OPENSSL_IS_AWSLC)
 
     /*
      * SSL_SESSION_get0_hostname() is only available in OpenSSL 1.1.1+,


### PR DESCRIPTION
### Proposed changes

I’m an engineer at AWS working on [AWS-LC](https://github.com/aws/aws-lc), AWS’s open-source cryptographic library maintained for AWS and their customers. AWS-LC supports CPU-specific performance optimizations for AWS Graviton 2, [AWS Graviton 3](https://github.com/aws/aws-lc/commit/ae87faf735c0241a115542b1c1022d125564bf55), and [Intel x86-64 with AVX-512 instructions](https://github.com/aws/aws-lc/commit/e22cf5065761bec8882c66cea94a9320bc8c0334). We’ve formally verified [a subset of](https://github.com/awslabs/aws-lc-verification#verified-code) AWS-LC’s cryptographic primitives, and continue to invest in expanding this coverage. AWS-LC can be also built in [FIPS mode](https://aws.amazon.com/blogs/security/aws-lc-fips-3-0-first-cryptographic-library-to-include-ml-kem-in-fips-140-3-validation/) to help consumers meet FIPS 140-3 compliance requirements. We would like to add AWS-LC support to nginx to provide our consumers with a well-documented and officially supported integration path. This would benefit both new users looking to leverage AWS-LC and existing users who already relying on our custom patch sets to use AWS-LC with nginx.

AWS-LC is a fork of BoringSSL which is already supported by nginx today. To enhance nginx compatibility, we’ve integrated key OpenSSL compatibility features including full OCSP support, multiple certificate slots, and HKDF consumption via `EVP_PKEY`. AWS-LC is also committed to backwards compatibility and we aim to keep our API stable. To ensure we continue to support nginx long term, we’ve added nginx built with AWS-LC to [our integration CI](https://github.com/aws/aws-lc/tree/main/tests/ci/integration). These tests are used to catch compatibility regressions against every change before they’re merged and to resolve potential build issues beforehand when upstream projects make relevant changes. By expanding our regular testing processes to include nginx, we proactively prevent any unanticipated breaks in the nginx/AWS-LC build.

I’ve noticed that there have been multiple attempts in the past to upstream AWS-LC support into nginx. We’ve made additional efforts to address concerns and minimize the necessary patch, but please feel free to let us know if you have any further feedback or concerns.

Best,
Samuel
