### PR TITLE
HTTP: fix content type length check.

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1574,7 +1574,7 @@ ngx_http_test_content_type(ngx_http_request_t *r, ngx_hash_t *types_hash)
         return (void *) 4;
     }
 
-    if (r->headers_out.content_type.len == 0) {
+    if (r->headers_out.content_type_len == 0) {
         return NULL;
     }
 


### PR DESCRIPTION
As `r->headers_out.content_type_len` is assigned in `ngx_http_upstream_copy_content_type`, for some malformed upstream responses like `Content-Type: ;charset=UTF-8`, we may get `r->headers_out.content_type.len = 14` but `r->headers_out.content_type_len = 0`.

This can lead to `lowcase = ngx_pnalloc(r->pool, len)` in  `ngx_http_test_content_type` allocating a zero-sized block, possibly causing memory corruption in subsequent processing.

This patch changes the check to use `r->headers_out.content_type_len == 0`, ensuring consistency and preventing related bugs.