### PR TITLE
Fix incorrect 'last' pointer reset in ngx_reset_pool() for chained blocks

### DIFF
--- a/src/core/ngx_palloc.c
+++ b/src/core/ngx_palloc.c
@@ -108,10 +108,13 @@ ngx_reset_pool(ngx_pool_t *pool)
         }
     }
 
-    for (p = pool; p; p = p->d.next) {
-        p->d.last = (u_char *) p + sizeof(ngx_pool_t);
-        p->d.failed = 0;
-    }
+	for (p = pool; p; p = p->d.next) {
+		if (p == pool)
+			p->d.last = (u_char *) p + sizeof(ngx_pool_t);
+		else
+			p->d.last = (u_char *) p + sizeof(ngx_pool_data_t);
+		p->d.failed = 0;
+	}
 
     pool->current = pool;
     pool->chain = NULL;


### PR DESCRIPTION
This patch fixes a bug in `ngx_reset_pool()` where all memory blocks reset the `last` pointer 
as if they were `ngx_pool_t`. However, only the first block uses `ngx_pool_t`, while subsequent 
blocks use the smaller `ngx_pool_data_t`.

This leads to incorrect memory reuse and potential overflows after reset when multiple blocks 
have been allocated.

### Fix:
- For the first block (`pool`), use `sizeof(ngx_pool_t)` to reset `last`
- For subsequent blocks, use `sizeof(ngx_pool_data_t)`

This change ensures that `last` always points to the beginning of the usable memory area 
in each block.