### PR TITLE
Removed legacy charset directive from default config example.

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -36,8 +36,6 @@ http {
         listen       80;
         server_name  localhost;
 
-        #charset koi8-r;
-
         #access_log  logs/host.access.log  main;
 
         location / {


### PR DESCRIPTION
The example configuration previously specified charset koi8-r, a legacy Cyrillic encoding. As koi8-r is rarely used today and modern browsers handle UTF-8 by default, explicitly specifying the charset is unnecessary.


### Proposed changes

This change removes the directive from the default nginx.conf, keeping the example concise and aligned with current best practices.

If this pull request addresses an issue on GitHub, make sure to reference that
issue using one of the
[supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).

Before creating a pull request, make sure to comply with the
[Contributing Guidelines](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md).
