### PR TITLE
Fixed file opened with O_CREAT flag but without mode argument

### DIFF
--- a/src/os/win32/ngx_files.c
+++ b/src/os/win32/ngx_files.c
@@ -24,7 +24,7 @@ uint32_t ngx_utf16_decode(u_short **u, size_t n);
 /* FILE_FLAG_BACKUP_SEMANTICS allows to obtain a handle to a directory */
 
 ngx_fd_t
-ngx_open_file(u_char *name, u_long mode, u_long create, u_long access)
+ngx_open_file(u_char *name, u_long mode, u_long create, u_long access, u_long file_mode)
 {
     size_t      len;
     u_short    *u;
@@ -468,7 +468,7 @@ ngx_create_file_mapping(ngx_file_mapping_t *fm)
     LARGE_INTEGER  size;
 
     fm->fd = ngx_open_file(fm->name, NGX_FILE_RDWR, NGX_FILE_TRUNCATE,
-                           NGX_FILE_DEFAULT_ACCESS);
+                           NGX_FILE_DEFAULT_ACCESS, NGX_FILE_DEFAULT_ACCESS);
 
     if (fm->fd == NGX_INVALID_FILE) {
         ngx_log_error(NGX_LOG_CRIT, fm->log, ngx_errno,


### PR DESCRIPTION

fix the problem, we need to ensure that whenever `ngx_open_file` is called with a creation flag (such as `NGX_FILE_TRUNCATE`), a `mode` argument specifying the file permissions is provided. This typically means updating the call to `ngx_open_file` to include a `mode` argument, and updating the function definition and all related calls to accept and pass through this argument. 

Specifically, in `src/os/win32/ngx_files.c`, we should:
- Update the signature of `ngx_open_file` to accept a `mode` argument (e.g., `u_long mode`).
- Update all calls to `ngx_open_file` to provide the `mode` argument where appropriate.
- In the call at line 470, add a suitable mode (e.g., `NGX_FILE_DEFAULT_ACCESS` or another appropriate constant).
- Update the implementation of `ngx_open_file` to use the `mode` argument when creating files.

If `NGX_FILE_DEFAULT_ACCESS` is already a mode value, we can pass it as the new argument. If not, we may need to define or use an appropriate mode constant.
