### PR TITLE
Fixed Improper Restriction of XML External Entity Reference

### DIFF
--- a/src/http/modules/ngx_http_xslt_filter_module.c
+++ b/src/http/modules/ngx_http_xslt_filter_module.c
@@ -381,8 +381,7 @@ ngx_http_xslt_add_chunk(ngx_http_request_t *r, ngx_http_xslt_filter_ctx_t *ctx,
                           "xmlCreatePushParserCtxt() failed");
             return NGX_ERROR;
         }
-        xmlCtxtUseOptions(ctxt, XML_PARSE_NOENT|XML_PARSE_DTDLOAD
-                                               |XML_PARSE_NOWARNING);
+        xmlCtxtUseOptions(ctxt, XML_PARSE_NOWARNING);
 
         ctxt->sax->externalSubset = ngx_http_xslt_sax_external_subset;
         ctxt->sax->setDocumentLocator = NULL;


### PR DESCRIPTION

fix the XXE vulnerability, we should disable external entity expansion and DTD loading when parsing untrusted XML. In `libxml2`, this is done by omitting the `XML_PARSE_NOENT` and `XML_PARSE_DTDLOAD` flags from the parser options. If DTDs are required for valid XML, use `XML_PARSE_DTDATTR` or other safer options, but never `XML_PARSE_NOENT` or `XML_PARSE_DTDLOAD` on untrusted input. The fix is to change line 384 in `src/http/modules/ngx_http_xslt_filter_module.c` to remove these flags, leaving only safe options such as `XML_PARSE_NOWARNING`. If you need to allow DTDs for validation, use `XML_PARSE_DTDVALID` instead, but do not allow loading external DTDs or entity expansion.

### References
[XML External Entity (XXE) Processing](https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing)
[XML External Entity Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)
Timothy Morgen: [XML Schema, DTD, and Entity Attacks](https://research.nccgroup.com/2014/05/19/xml-schema-dtd-and-entity-attacks-a-compendium-of-known-techniques/)
Timur Yunusov, Alexey Osipov: [XML Out-Of-Band Data Retrieval](https://www.slideshare.net/qqlan/bh-ready-v4)