### PR TITLE
SWRR: Introduce Random Smooth Weighted Round Robin to Solve Herd Effect in Cluster Deployment

### DIFF
--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -203,7 +203,8 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
                 peer[n].socklen = server[i].addrs[j].socklen;
                 peer[n].name = server[i].addrs[j].name;
                 peer[n].weight = server[i].weight;
-                peer[n].effective_weight = 1;  /* Initialize to 1 instead of server[i].weight for randomness */
+                /* Initialize to 1 instead of server[i].weight for randomness */
+                peer[n].effective_weight = 1;
                 peer[n].current_weight = 0;
                 peer[n].max_conns = server[i].max_conns;
                 peer[n].max_fails = server[i].max_fails;
@@ -329,7 +330,8 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
                 peer[n].socklen = server[i].addrs[j].socklen;
                 peer[n].name = server[i].addrs[j].name;
                 peer[n].weight = server[i].weight;
-                peer[n].effective_weight = 1;  /* Initialize to 1 instead of server[i].weight for randomness */
+                /* Initialize to 1 instead of server[i].weight for randomness */
+                peer[n].effective_weight = 1;
                 peer[n].current_weight = 0;
                 peer[n].max_conns = server[i].max_conns;
                 peer[n].max_fails = server[i].max_fails;


### PR DESCRIPTION
# Introduce Random Smooth Weighted Round Robin to Solve Herd Effect in Cluster Deployment

This PR modifies Nginx's weighted round robin load balancing algorithm by introducing randomness to solve the "herd effect" problem in cluster deployment scenarios.

## Problem Description

In the current Nginx Smooth Weighted Round Robin (SWRR) implementation, when multiple Nginx instances or multiple worker processes of the same instance run simultaneously, they make the same scheduling decisions based on the same initial state. This leads to the "herd effect" where all requests are sent to the same backend servers at the same time, causing unbalanced load.

## Solution

This PR implements the Random Smooth Weighted Round Robin (RSWRR) algorithm through two main modifications:

1. Initialize all peer nodes' `effective_weight` to 1 instead of the configured weight value
2. Introduce randomness when selecting peers with equal current weights

These modifications ensure that in the initial phase, all backend servers have equal chances to be selected, breaking the consecutive selection pattern of the traditional SWRR algorithm.

## Technical Details

1. In the `ngx_http_upstream_init_round_robin` function, initialize `peer->effective_weight` to 1
2. In the `ngx_http_upstream_get_peer` function, use a random number to decide which peer to select when two peers have the same current weight

## Effects

* Solves the herd effect problem in cluster deployment scenarios
* Maintains the adaptive characteristics of the original SWRR algorithm (weight recovery mechanism)
* After weights grow to configured values, the algorithm behaves the same as traditional SWRR
* Simple implementation with minimal changes

This improvement is particularly useful for large-scale Nginx cluster deployment environments and can significantly improve load balancing effectiveness in the initial phase.

You can access to my [demo repository](https://github.com/Augists/VN_R_S_WRR). I am trying to show the result of its scheduling order in a simple demo code.