### PR TITLE
Make it possible to return 507 on PUT requests to DAV

### DIFF
--- a/src/http/modules/ngx_http_dav_module.c
+++ b/src/http/modules/ngx_http_dav_module.c
@@ -280,6 +280,8 @@ ngx_http_dav_put_handler(ngx_http_request_t *r)
     }
 
     if (ngx_ext_rename_file(temp, &path, &ext) != NGX_OK) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!ngx_ext_rename_file failed!!!!!!!!!!!!!!!!!!!!!!!!!!");
         ngx_int_t rc;
         rc = ngx_http_dav_error(r->connection->log, ngx_errno,
                                  NGX_HTTP_NOT_FOUND, ngx_rename_file_n,

--- a/src/http/modules/ngx_http_dav_module.c
+++ b/src/http/modules/ngx_http_dav_module.c
@@ -280,7 +280,11 @@ ngx_http_dav_put_handler(ngx_http_request_t *r)
     }
 
     if (ngx_ext_rename_file(temp, &path, &ext) != NGX_OK) {
-        ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+        ngx_int_t rc;
+        rc = ngx_http_dav_error(r->connection->log, ngx_errno,
+                                 NGX_HTTP_NOT_FOUND, ngx_rename_file_n,
+                                 path.data);
+        ngx_http_finalize_request(r, rc);
         return;
     }
 

--- a/src/http/modules/ngx_http_dav_module.c
+++ b/src/http/modules/ngx_http_dav_module.c
@@ -280,8 +280,6 @@ ngx_http_dav_put_handler(ngx_http_request_t *r)
     }
 
     if (ngx_ext_rename_file(temp, &path, &ext) != NGX_OK) {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                      "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!ngx_ext_rename_file failed!!!!!!!!!!!!!!!!!!!!!!!!!!");
         ngx_int_t rc;
         rc = ngx_http_dav_error(r->connection->log, ngx_errno,
                                  NGX_HTTP_NOT_FOUND, ngx_rename_file_n,


### PR DESCRIPTION
### Proposed changes

These changes will partially fix #838. Without calling `ngx_http_dav_error`, there is no chance for a 507 status code to be returned. Instead, a 500 status code is being returned when there is no more space left on the device.

It is important to note that these changes will only work properly when temporary data is being written to a separate partition/disk. When the storage is full and there is a PUT request on DAV, the core part of nginx will successfully write a temporary file, and afterwards the WebDAV PUT handler will fail to rename it, returning 507 as expected. In cases where temporary data and the target location are on the same disk/partition, this fix will NOT work because nginx will fail to write the temporary file (which is handled by the core part of nginx, as far as I can see).

Also, as a disclaimer: I am not proficient with C, I am just using nginx, found this problem, and tried to find a workaround that will not break everything. That is the reason I am not proposing a complete fix. Sorry, I don't know how to fix it completely and properly. Nevertheless, I think this PR could still be useful.