### PR TITLE
sendfile() EIO input file read error explicit logging

### DIFF
--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -1568,6 +1568,14 @@ ngx_tcp_nodelay(ngx_connection_t *c)
 ngx_int_t
 ngx_connection_error(ngx_connection_t *c, ngx_err_t err, char *text)
 {
+    return ngx_connection_error_n(c, err, text, NULL);
+}
+
+
+ngx_int_t
+ngx_connection_error_n(ngx_connection_t *c, ngx_err_t err, char *text,
+    ngx_str_t *name)
+{
     ngx_uint_t  level;
 
     /* Winsock may return NGX_ECONNABORTED instead of NGX_ECONNRESET */
@@ -1623,7 +1631,11 @@ ngx_connection_error(ngx_connection_t *c, ngx_err_t err, char *text)
         level = NGX_LOG_ALERT;
     }
 
-    ngx_log_error(level, c->log, err, text);
+    if (name) {
+        ngx_log_error(level, c->log, err, "%s \"%V\"", text, name);
+    } else {
+        ngx_log_error(level, c->log, err, text);
+    }
 
     return NGX_ERROR;
 }

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -227,6 +227,8 @@ ngx_int_t ngx_connection_local_sockaddr(ngx_connection_t *c, ngx_str_t *s,
     ngx_uint_t port);
 ngx_int_t ngx_tcp_nodelay(ngx_connection_t *c);
 ngx_int_t ngx_connection_error(ngx_connection_t *c, ngx_err_t err, char *text);
+ngx_int_t ngx_connection_error_n(ngx_connection_t *c, ngx_err_t err,
+    char *text, ngx_str_t *name);
 
 ngx_connection_t *ngx_get_connection(ngx_socket_t s, ngx_log_t *log);
 void ngx_free_connection(ngx_connection_t *c);

--- a/src/os/unix/ngx_darwin_sendfile_chain.c
+++ b/src/os/unix/ngx_darwin_sendfile_chain.c
@@ -148,7 +148,8 @@ ngx_darwin_sendfile_chain(ngx_connection_t *c, ngx_chain_t *in, off_t limit)
 
                 default:
                     wev->error = 1;
-                    (void) ngx_connection_error(c, err, "sendfile() failed");
+                    (void) ngx_connection_error_n(c, err, "sendfile() failed",
+                                                  &file->file->name);
                     return NGX_CHAIN_ERROR;
                 }
 

--- a/src/os/unix/ngx_freebsd_sendfile_chain.c
+++ b/src/os/unix/ngx_freebsd_sendfile_chain.c
@@ -206,7 +206,8 @@ ngx_freebsd_sendfile_chain(ngx_connection_t *c, ngx_chain_t *in, off_t limit)
 
                 default:
                     wev->error = 1;
-                    (void) ngx_connection_error(c, err, "sendfile() failed");
+                    (void) ngx_connection_error_n(c, err, "sendfile() failed",
+                                                  &file->file->name);
                     return NGX_CHAIN_ERROR;
                 }
 

--- a/src/os/unix/ngx_linux_sendfile_chain.c
+++ b/src/os/unix/ngx_linux_sendfile_chain.c
@@ -276,7 +276,8 @@ eintr:
 
         default:
             c->write->error = 1;
-            ngx_connection_error(c, err, "sendfile() failed");
+            ngx_connection_error_n(c, err, "sendfile() failed",
+                                   &file->file->name);
             return NGX_ERROR;
         }
     }
@@ -360,7 +361,8 @@ ngx_linux_sendfile_thread(ngx_connection_t *c, ngx_buf_t *file, size_t size)
 
         if (ctx->err) {
             wev->error = 1;
-            ngx_connection_error(c, ctx->err, "sendfile() failed");
+            ngx_connection_error_n(c, ctx->err, "sendfile() failed",
+                                   &file->file->name);
             return NGX_ERROR;
         }
 

--- a/src/os/unix/ngx_solaris_sendfilev_chain.c
+++ b/src/os/unix/ngx_solaris_sendfilev_chain.c
@@ -176,7 +176,8 @@ ngx_solaris_sendfilev_chain(ngx_connection_t *c, ngx_chain_t *in, off_t limit)
 
             default:
                 wev->error = 1;
-                ngx_connection_error(c, err, "sendfilev() failed");
+                ngx_connection_error_n(c, err, "sendfilev() failed",
+                                       file ? &file->file->name : NULL);
                 return NGX_CHAIN_ERROR;
             }
 


### PR DESCRIPTION
sendfile() does two things under the hood
read from input fd and write to output fd
The documentation says explicitly that if the problem was in reading from input fd then errno = 5. 
But Nginx logs a generic i/o error.

https://www.man7.org/linux/man-pages/man2/sendfile.2.html#:~:text=by%20sendfile().-,EIO,-Unspecified%20error%20while