### PR TITLE
Check a pointer to logger list on null

### DIFF
--- a/src/core/ngx_log.h
+++ b/src/core/ngx_log.h
@@ -82,15 +82,18 @@ struct ngx_log_s {
 
 #define NGX_HAVE_VARIADIC_MACROS  1
 
-#define ngx_log_error(level, log, ...)                                        \
-    if ((log)->log_level >= level) ngx_log_error_core(level, log, __VA_ARGS__)
+#define ngx_log_error(level, log, ...)                                         \
+    if (((log) != NULL) && ((log)->log_level >= level)) {                      \
+        ngx_log_error_core(level, log, __VA_ARGS__);                           \
+    }
 
 void ngx_log_error_core(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
     const char *fmt, ...);
 
-#define ngx_log_debug(level, log, ...)                                        \
-    if ((log)->log_level & level)                                             \
-        ngx_log_error_core(NGX_LOG_DEBUG, log, __VA_ARGS__)
+#define ngx_log_debug(level, log, ...)                                         \
+    if (((log) != NULL) && ((log)->log_level & level)) {                       \
+        ngx_log_error_core(NGX_LOG_DEBUG, log, __VA_ARGS__);                   \
+    }
 
 /*********************************/
 
@@ -99,13 +102,13 @@ void ngx_log_error_core(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
 #define NGX_HAVE_VARIADIC_MACROS  1
 
 #define ngx_log_error(level, log, args...)                                    \
-    if ((log)->log_level >= level) ngx_log_error_core(level, log, args)
+    if ((log) != NULL && (log)->log_level >= level) ngx_log_error_core(level, log, args)
 
 void ngx_log_error_core(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
     const char *fmt, ...);
 
 #define ngx_log_debug(level, log, args...)                                    \
-    if ((log)->log_level & level)                                             \
+    if ((log) != NULL && (log)->log_level & level)                            \
         ngx_log_error_core(NGX_LOG_DEBUG, log, args)
 
 /*********************************/


### PR DESCRIPTION
If a pointer to the list of loggers is null, then when executing the 'ngx_log_error_core' function, the 'SIGSEGV' signal will be sent to a worker thread.