### PR TITLE
Auth:Preserve WWW-Authenticate for SPNEGO with satisfy any

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1138,7 +1138,17 @@ ngx_http_core_access_phase(ngx_http_request_t *r, ngx_http_phase_handler_t *ph)
             r->access_code = 0;
 
             for (h = r->headers_out.www_authenticate; h; h = h->next) {
-                h->hash = 0;
+                // WWW-Authenticate response header is also used to send the
+                // servers Mutual authentication token to client as response to
+                // a request with authentication token. Ref: RFC 4559
+
+                // Below check skips invalidating the header iff it is a
+                // GSSAPI Mutual authentication token.
+                if (ngx_strncmp(h->value.data, "Negotiate ",
+                                ngx_strlen("Negotiate ")) != 0)
+                {
+                    h->hash = 0;
+                }
             }
 
             r->phase_handler = ph->next;

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1143,7 +1143,7 @@ ngx_http_core_access_phase(ngx_http_request_t *r, ngx_http_phase_handler_t *ph)
                 // a request with authentication token. Ref: RFC 4559
 
                 // Below check skips invalidating the header iff it is a
-                // GSSAPI Mutual authentication token.
+                // SPNEGO Mutual authentication token.
                 if (ngx_strncmp(h->value.data, "Negotiate ",
                                 ngx_strlen("Negotiate ")) != 0)
                 {


### PR DESCRIPTION
Updates the header-filtering logic used with `satisfy any` so that NGINX does not drop `WWW-Authenticate` iff it contains a SPNEGO mutual-auth token. In other words, we skip setting the header hash to zero for this specific case.

Why:
- Existing behavior assumes WWW-Authenticate only appears on 401 challenges.
- In SPNEGO mutual auth, the server must return a final token to the client in WWW-Authenticate on a successful response.
- Dropping this header prevents clients from verifying the server and completing the handshake.

### Proposed changes

fixes: nginx/nginx#861

RFC: https://datatracker.ietf.org/doc/html/rfc4559?utm_source=chatgpt.com#autoid-6
