### PR TITLE
Prevent UB when processing HTTP/2 body

### DIFF
--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -4109,8 +4109,10 @@ ngx_http_v2_process_request_body(ngx_http_request_t *r, u_char *pos,
             ngx_log_debug1(NGX_LOG_DEBUG_HTTP, fc->log, 0,
                            "http2 request body recv %uz", n);
 
-            pos += n;
-            size -= n;
+            if (pos) {
+                pos += n;
+                size -= n;
+            }
 
             if (size == 0 && last) {
                 rb->rest = 0;


### PR DESCRIPTION
There's a source text that may cause undefined behavior (UB): [the line 4112 of the file "src/http/v2/ngx_http_v2.c"](https://github.com/nginx/nginx/blob/446ce033e5b9e192e228638e826f2a39328d879c/src/http/v2/ngx_http_v2.c#L4112).

UB occurs when 'n' is added to pointer 'pos' when it is NULL. If 'pos' equals NULL, 'n' equals 0, then 'pos + n' produces UB in C, but not in C++. There is a proposal to allow 'NULL + 0' situations in C: [N3322](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3322.pdf).

There're 3 calls of the function 'ngx_http_v2_process_request_body', in which a values of the arguments 'pos', 'n' arguments are fixed: 'pos' equals NULL, 'n' equals 0:
-  on the [line 3977](https://github.com/nginx/nginx/blob/446ce033e5b9e192e228638e826f2a39328d879c/src/http/v2/ngx_http_v2.c#L3977)
- on the [line 4301](https://github.com/nginx/nginx/blob/446ce033e5b9e192e228638e826f2a39328d879c/src/http/v2/ngx_http_v2.c#L4301)
- on the [line 4404](https://github.com/nginx/nginx/blob/446ce033e5b9e192e228638e826f2a39328d879c/src/http/v2/ngx_http_v2.c#L4404)

A message from [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html):
> src/http/v2/ngx_http_v2.c:4013:17: runtime error: applying zero offset to null pointer
    #0 0x55c6e5415ac2 in ngx_http_v2_process_request_body /var/lib/builder/build/nginx/src/http/v2/ngx_http_v2.c:4013:17
    #1 0x55c6e54192f2 in ngx_http_v2_read_unbuffered_request_body /var/lib/builder/build/nginx/src/http/v2/ngx_http_v2.c:4305:10
    #2 0x55c6e526c2ff in ngx_http_read_unbuffered_request_body /var/lib/builder/build/nginx/src/http/ngx_http_request_body.c:238:14
    #3 0x55c6e5306d90 in ngx_http_upstream_send_request_body /var/lib/builder/build/nginx/src/http/ngx_http_upstream.c:2323:18
    #4 0x55c6e52ed673 in ngx_http_upstream_send_request /var/lib/builder/build/nginx/src/http/ngx_http_upstream.c:2144:10
    #5 0x55c6e52e8294 in ngx_http_upstream_send_request_handler /var/lib/builder/build/nginx/src/http/ngx_http_upstream.c:2387:5
    #6 0x55c6e52e7cab in ngx_http_upstream_handler /var/lib/builder/build/nginx/src/http/ngx_http_upstream.c:1318:9
    #7 0x55c6e51412bc in ngx_epoll_process_events /var/lib/builder/build/nginx/src/event/modules/ngx_epoll_module.c:930:17
    #8 0x55c6e50e8c30 in ngx_process_events_and_timers /var/lib/builder/build/nginx/src/event/ngx_event.c:248:12
    #9 0x55c6e5135770 in ngx_worker_process_cycle /var/lib/builder/build/nginx/src/os/unix/ngx_process_cycle.c:721:9
    #10 0x55c6e5128ed8 in ngx_spawn_process /var/lib/builder/build/nginx/src/os/unix/ngx_process.c:199:9
    #11 0x55c6e512fde5 in ngx_start_worker_processes /var/lib/builder/build/nginx/src/os/unix/ngx_process_cycle.c:344:9
    #12 0x55c6e512ea68 in ngx_master_process_cycle /var/lib/builder/build/nginx/src/os/unix/ngx_process_cycle.c:130:5
    #13 0x55c6e4fb35d6 in main /var/lib/builder/build/nginx/src/core/nginx.c:384:9
    #14 0x7fc532fb0d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0x7fc532fb0e3f in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0x55c6e4f89af4 in _start (/var/lib/builder/build/build.ubsan/nginx+0x6eaaf4) (BuildId: 3757e30af8e95a8848efcba24fa9c9e8e7a65028)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/http/v2/ngx_http_v2.c:4013:17 in

Tested on nginx, builded with the last commit with hash code 481d28cb4e04c8096b9b6134856891dc52ecc68f (tag: release-1.28.0).