### PR TITLE
Cache: fixed cache stuck UPDATING if worker crashes

### DIFF
--- a/src/event/ngx_event.c
+++ b/src/event/ngx_event.c
@@ -76,7 +76,7 @@ static ngx_atomic_t   ngx_stat_waiting0;
 ngx_atomic_t         *ngx_stat_waiting = &ngx_stat_waiting0;
 
 #endif
-
+ngx_pid_t     *ngx_active_workers_pids;
 
 
 static ngx_command_t  ngx_events_commands[] = {
@@ -566,6 +566,7 @@ ngx_event_module_init(ngx_cycle_t *cycle)
            + cl;         /* ngx_stat_waiting */
 
 #endif
+    size += ngx_min(NGX_MAX_PROCESSES * sizeof(ngx_pid_t), cl);
 
     shm.size = size;
     ngx_str_set(&shm.name, "nginx_shared_zone");
@@ -610,7 +611,10 @@ ngx_event_module_init(ngx_cycle_t *cycle)
     ngx_stat_reading = (ngx_atomic_t *) (shared + 7 * cl);
     ngx_stat_writing = (ngx_atomic_t *) (shared + 8 * cl);
     ngx_stat_waiting = (ngx_atomic_t *) (shared + 9 * cl);
-
+    
+    ngx_active_workers_pids = (ngx_pid_t *) (shared + 11 * cl);
+#else
+    ngx_active_workers_pids = (ngx_pid_t *) (shared + 3 * cl);
 #endif
 
     return NGX_OK;

--- a/src/event/ngx_event.h
+++ b/src/event/ngx_event.h
@@ -476,7 +476,7 @@ extern ngx_atomic_t  *ngx_stat_writing;
 extern ngx_atomic_t  *ngx_stat_waiting;
 
 #endif
-
+extern ngx_pid_t     *ngx_active_workers_pids;
 
 #define NGX_UPDATE_TIME         1
 #define NGX_POST_EVENTS         2

--- a/src/http/ngx_http_cache.h
+++ b/src/http/ngx_http_cache.h
@@ -59,6 +59,8 @@ typedef struct {
     size_t                           body_start;
     off_t                            fs_size;
     ngx_msec_t                       lock_time;
+    ngx_int_t                        updating_updater_process_slot;
+    ngx_pid_t                        updating_updater_process_pid;
 } ngx_http_file_cache_node_t;
 
 

--- a/src/os/unix/ngx_process.c
+++ b/src/os/unix/ngx_process.c
@@ -205,6 +205,8 @@ ngx_spawn_process(ngx_cycle_t *cycle, ngx_spawn_proc_pt proc, void *data,
 
     ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "start %s %P", name, pid);
 
+    ngx_active_workers_pids[s] = pid;
+
     ngx_processes[s].pid = pid;
     ngx_processes[s].exited = 0;
 


### PR DESCRIPTION
If use_stale and cache_lock used together then if the worker process doing the update crashes, the flag never resets from updating and we will get stuck in UPDATING state forever. this PR fixes this issue. (I am not sure if this solution is what you would do, but if you have an alternative solution in mind, I will update the fix)
