### PR TITLE
QUIC: fix ssl_reject_handshake error logging

### DIFF
--- a/src/event/quic/ngx_event_quic_ssl.c
+++ b/src/event/quic/ngx_event_quic_ssl.c
@@ -696,6 +696,12 @@ ngx_quic_handshake(ngx_connection_t *c)
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL_do_handshake: %d", n);
 
     if (qc->error) {
+
+        if (c->ssl->handshake_rejected) {
+            ngx_connection_error(c, 0, "handshake rejected");
+            ERR_clear_error();
+        }
+
         return NGX_ERROR;
     }
 
@@ -706,14 +712,6 @@ ngx_quic_handshake(ngx_connection_t *c)
                        sslerr);
 
         if (sslerr != SSL_ERROR_WANT_READ) {
-
-            if (c->ssl->handshake_rejected) {
-                ngx_connection_error(c, 0, "handshake rejected");
-                ERR_clear_error();
-
-                return NGX_ERROR;
-            }
-
             ngx_ssl_connection_error(c, sslerr, 0, "SSL_do_handshake() failed");
             return NGX_ERROR;
         }


### PR DESCRIPTION
When a QUIC connection is rejected via the ssl_reject_handshake directive, the error is returned by the servername callback (`ngx_http_ssl_servername()`). A TLS alert is then sent to the client, invoking the alert handler, which sets `qc->error`.

Commit 7468a10b62 changed `qc->error` handling, breaking special handling for rejected handshake errors when the OpenSSL error queue is cleared. This results in misleading log messages "ignoring stale global SSL error" from another connection.

The fix ensures that if a handshake was rejected, the OpenSSL error queue is cleared when checking `qc->error`.


