### PR TITLE
Fix delayed long polling response headers

### DIFF
--- a/src/http/ngx_http_header_filter_module.c
+++ b/src/http/ngx_http_header_filter_module.c
@@ -622,6 +622,9 @@ ngx_http_header_filter(ngx_http_request_t *r)
         b->last_buf = 1;
     }
 
+    if (r->chunked) {
+        b->flush = 1;
+    }
     out.buf = b;
     out.next = NULL;
 


### PR DESCRIPTION
### Proposed changes

When proxying an HTTP long-polling service(based on chunk encoding), the headers can be available much sooner than the first response chunk. Fix #864, slow delivery of response headers in this situation by flushing the output when writing the headers for a chunked response.

This add a write-flush to every chunked response, which is not necessary in all cases(ex: nginx proxy receives response headers and start of chunked response body contiguously).

### Another approach that avoids additional flush

Before waiting for additional upstream data, check if there is data to flush, and flush only if needed. This seemed more complicated, though perhaps easier for someone more familiar with nginx to implement.