### PR TITLE
Fixed inaccurate index directive error report

### DIFF
--- a/src/http/modules/ngx_http_index_module.c
+++ b/src/http/modules/ngx_http_index_module.c
@@ -490,7 +490,7 @@ ngx_http_index_set_index(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         if (value[i].len == 0) {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                "index \"%V\" in \"index\" directive is invalid",
-                               &value[1]);
+                               &value[i]);
             return NGX_CONF_ERROR;
         }
 


### PR DESCRIPTION
### Proposed changes

When there is an empty string '' in index directive, the error message reported is inconsistent

### problem test cases
* empty string configured in the middle
```nginx
location / {
    index index.html "" index.htm;
}
```
<img width="3015" height="204" alt="becfc58a10b00fca4c36a13b05f90607" src="https://github.com/user-attachments/assets/587ea006-53a2-44ad-86bf-e94ae7ddfa72" />

* empty string configured in the beginning
```nginx
location / {
    index "" index.html index.htm;
}
```
<img width="2724" height="204" alt="4f391f17a960cd8f3e545ad5e8030b49" src="https://github.com/user-attachments/assets/d6e4bae3-9f82-4e6a-b424-8df19c797b30" />
