### PR TITLE
Configure: ensure we get the "built by ..." line in nginx -V.

### DIFF
--- a/auto/cc/clang
+++ b/auto/cc/clang
@@ -5,15 +5,6 @@
 # clang
 
 
-NGX_CLANG_VER=`$CC -v 2>&1 | grep 'version' 2>&1 \
-                           | sed -n -e 's/^.*clang version \(.*\)/\1/p' \
-                                    -e 's/^.*LLVM version \(.*\)/\1/p'`
-
-echo " + clang version: $NGX_CLANG_VER"
-
-have=NGX_COMPILER value="\"clang $NGX_CLANG_VER\"" . auto/define
-
-
 CC_TEST_FLAGS="-pipe"
 
 

--- a/auto/cc/gcc
+++ b/auto/cc/gcc
@@ -8,14 +8,6 @@
 #     4.0.0, 4.0.1, 4.1.0
 
 
-NGX_GCC_VER=`$CC -v 2>&1 | grep 'gcc version' 2>&1 \
-                         | sed -e 's/^.* version \(.*\)/\1/'`
-
-echo " + gcc version: $NGX_GCC_VER"
-
-have=NGX_COMPILER value="\"gcc $NGX_GCC_VER\"" . auto/define
-
-
 # Solaris 7's /usr/ccs/bin/as does not support "-pipe"
 
 CC_TEST_FLAGS="-pipe"
@@ -112,7 +104,7 @@ esac
 
 CC_AUX_FLAGS="$CC_AUX_FLAGS $CPU_OPT"
 
-case "$NGX_GCC_VER" in
+case "$NGX_CC_VER" in
     2.7*)
         # batch build
         CPU_OPT=
@@ -145,7 +137,7 @@ CFLAGS="$CFLAGS -Wall -Wpointer-arith"
 #CFLAGS="$CFLAGS -Winline"
 #CFLAGS="$CFLAGS -Wmissing-prototypes"
 
-case "$NGX_GCC_VER" in
+case "$NGX_CC_VER" in
     2.*)
         # we have a lot of the unused function arguments
         CFLAGS="$CFLAGS -Wno-unused"

--- a/auto/cc/icc
+++ b/auto/cc/icc
@@ -5,14 +5,6 @@
 
 # Intel C++ compiler 7.1, 8.0, 8.1, 9.0, 11.1
 
-NGX_ICC_VER=`$CC -V 2>&1 | grep 'Version' 2>&1 \
-                         | sed -e 's/^.* Version \([^ ]*\) *Build.*$/\1/'`
-
-echo " + icc version: $NGX_ICC_VER"
-
-have=NGX_COMPILER value="\"Intel C Compiler $NGX_ICC_VER\"" . auto/define
-
-
 # optimizations
 
 CFLAGS="$CFLAGS -O"
@@ -83,7 +75,7 @@ CFLAGS="$CFLAGS -wd1418"
 # external declaration in primary source file
 CFLAGS="$CFLAGS -wd1419"
 
-case "$NGX_ICC_VER" in
+case "$NGX_CC_VER" in
     9.*)
         # "cc" clobber ignored, warnings for Linux's htonl()/htons()
         CFLAGS="$CFLAGS -wd1469"

--- a/auto/cc/msvc
+++ b/auto/cc/msvc
@@ -11,20 +11,12 @@
 # MSVC 2015 (14.0)                        cl 19.00
 
 
-NGX_MSVC_VER=`$NGX_WINE $CC 2>&1 | grep 'C/C++.* [0-9][0-9]*\.[0-9]' 2>&1 \
-                                 | sed -e 's/^.* \([0-9][0-9]*\.[0-9].*\)/\1/'`
-
-echo " + cl version: $NGX_MSVC_VER"
-
-have=NGX_COMPILER value="\"cl $NGX_MSVC_VER\"" . auto/define
-
-
-ngx_msvc_ver=`echo $NGX_MSVC_VER | sed -e 's/^\([0-9]*\).*/\1/'`
+ngx_msvc_ver=`echo $NGX_CC_VER | sed -e 's/^\([0-9]*\).*/\1/'`
 
 
 # detect x64 builds
 
-case "$NGX_MSVC_VER" in
+case "$NGX_CC_VER" in
 
     *ARM64)
         NGX_MACHINE=arm64

--- a/auto/cc/name
+++ b/auto/cc/name
@@ -28,6 +28,13 @@ if [ "$CC" = cl ]; then
     NGX_CC_NAME=msvc
     echo " + using Microsoft Visual C++ compiler"
 
+    NGX_CC_VER=`$NGX_WINE $CC 2>&1 \
+                | grep 'C/C++.* [0-9][0-9]*\.[0-9]' 2>&1 \
+                | sed -e 's/^.* \([0-9][0-9]*\.[0-9].*\)/\1/'`
+    echo " + cl version: $NGX_CC_VER"
+
+    have=NGX_COMPILER value="\"cl $NGX_CC_VER\"" . auto/define
+
 elif [ "$CC" = wcl386 ]; then
     NGX_CC_NAME=owc
     echo " + using Open Watcom C compiler"
@@ -40,21 +47,47 @@ elif `$CC -V 2>&1 | grep '^Intel(R) C' >/dev/null 2>&1`; then
     NGX_CC_NAME=icc
     echo " + using Intel C++ compiler"
 
+    NGX_CC_VER=`$CC -V 2>&1 \
+                | sed -n -e 's/^.* Version \([^ ]*\) *Build.*$/\1/p'`
+    echo " + icc version: $NGX_CC_VER"
+
+    have=NGX_COMPILER value="\"Intel C Compiler $NGX_CC_VER\"" . auto/define
+
 elif `$CC -v 2>&1 | grep 'gcc version' >/dev/null 2>&1`; then
     NGX_CC_NAME=gcc
     echo " + using GNU C compiler"
+
+    NGX_CC_VER=`$CC -v 2>&1 | sed -n -e 's/^.*gcc version \(.*\)/\1/p'`
+    echo " + gcc version: $NGX_CC_VER"
+
+    have=NGX_COMPILER value="\"gcc $NGX_CC_VER\"" . auto/define
 
 elif `$CC -v 2>&1 | grep 'clang version' >/dev/null 2>&1`; then
     NGX_CC_NAME=clang
     echo " + using Clang C compiler"
 
+    NGX_CC_VER=`$CC -v 2>&1 | sed -n -e 's/^.*clang version \(.*\)/\1/p'`
+    echo " + clang version: $NGX_CC_VER"
+
+    have=NGX_COMPILER value="\"clang $NGX_CC_VER\"" . auto/define
+
 elif `$CC -v 2>&1 | grep 'LLVM version' >/dev/null 2>&1`; then
     NGX_CC_NAME=clang
     echo " + using Clang C compiler"
 
+    NGX_CC_VER=`$CC -v 2>&1 | sed -n -e 's/^.*LLVM version \(.*\)/\1/p'`
+    echo " + clang version: $NGX_CC_VER"
+
+    have=NGX_COMPILER value="\"clang $NGX_CC_VER\"" . auto/define
+
 elif `$CC -V 2>&1 | grep 'Sun C' >/dev/null 2>&1`; then
     NGX_CC_NAME=sunc
     echo " + using Sun C compiler"
+
+    NGX_CC_VER=`$CC -V 2>&1 | sed -n -e 's/^.* Sun C \(.*\)/\1/p'`
+    echo " + Sun C version: $NGX_CC_VER"
+
+    have=NGX_COMPILER value="\"Sun C $NGX_CC_VER\"" . auto/define
 
 elif `$CC -V 2>&1 | grep '^Compaq C' >/dev/null 2>&1`; then
     NGX_CC_NAME=ccc

--- a/auto/cc/sunc
+++ b/auto/cc/sunc
@@ -13,13 +13,6 @@
 # Sun C 5.13 SunOS_i386 2014/10/20        Oracle Solaris Studio 12.4
 # Sun C 5.14 SunOS_i386 2016/05/31        Oracle Developer Studio 12.5
 
-NGX_SUNC_VER=`$CC -V 2>&1 | grep 'Sun C' 2>&1 \
-                          | sed -e 's/^.* Sun C \(.*\)/\1/'`
-
-echo " + Sun C version: $NGX_SUNC_VER"
-
-have=NGX_COMPILER value="\"Sun C $NGX_SUNC_VER\"" . auto/define
-
 
 cat << END > $NGX_AUTOTEST.c
 


### PR DESCRIPTION
```
Configure: ensure we get the "built by ..." line in nginx -V.

For certain compilers we embed the compiler version used to build nginx
in the binary, retrievable via 'nginx -V', e.g.

  $ ./objs/nginx -V
  ...
  built by gcc 15.2.1 20250808 (Red Hat 15.2.1-1) (GCC)
  ...

 if the CFLAGS environment variable is set this would be omitted.

This is due to the compiler specific auto/cc/$NGX_CC_NAME files not
being run when the CFLAGS environment variable is set (this is by
design) and thus the NGX_COMPILER variable isn't set.

This is happening with distribution packages of nginx for current
versions of RHEL/Fedora & Debian for example.

Nonetheless it is a useful thing to have so re-work the auto scripts to
move the version gathering out of the individual auto/cc/$NGX_CC_NAME
files and merge them into auto/cc/name.

Link: <https://github.com/nginx/nginx/issues/878>
```