### PR TITLE
Better determination of runnable CPU count

### DIFF
--- a/auto/os/freebsd
+++ b/auto/os/freebsd
@@ -97,9 +97,11 @@ then
 fi
 
 
-# cpuset_setaffinity()
+# cpuset_setaffinity() / cpuset_getaffinity()
 
 if [ $version -ge 701000 ]; then
     echo " + cpuset_setaffinity() found"
+    echo " + cpuset_getaffinity() found"
     have=NGX_HAVE_CPUSET_SETAFFINITY . auto/have
+    have=NGX_HAVE_CPUSET_GETAFFINITY . auto/have
 fi

--- a/auto/os/freebsd
+++ b/auto/os/freebsd
@@ -105,3 +105,10 @@ if [ $version -ge 701000 ]; then
     have=NGX_HAVE_CPUSET_SETAFFINITY . auto/have
     have=NGX_HAVE_CPUSET_GETAFFINITY . auto/have
 fi
+
+# CPU_COUNT()
+
+if [ $version -ge 1002000 ]; then
+    echo " + CPU_COUNT() found"
+    have=NGX_HAVE_CPU_COUNT . auto/have
+fi

--- a/auto/unix
+++ b/auto/unix
@@ -292,6 +292,17 @@ ngx_feature_test="cpu_set_t mask;
 . auto/feature
 
 
+ngx_feature="sched_getaffinity()"
+ngx_feature_name="NGX_HAVE_SCHED_GETAFFINITY"
+ngx_feature_run=no
+ngx_feature_incs="#include <sched.h>"
+ngx_feature_path=
+ngx_feature_libs=
+ngx_feature_test="cpu_set_t set;
+                  sched_getaffinity(0, sizeof(set), &set);"
+. auto/feature
+
+
 ngx_feature="SO_SETFIB"
 ngx_feature_name="NGX_HAVE_SETFIB"
 ngx_feature_run=no

--- a/auto/unix
+++ b/auto/unix
@@ -303,6 +303,17 @@ ngx_feature_test="cpu_set_t set;
 . auto/feature
 
 
+ngx_feature="CPU_COUNT()"
+ngx_feature_name="NGX_HAVE_CPU_COUNT"
+ngx_feature_run=no
+ngx_feature_incs="#include <sched.h>"
+ngx_feature_path=
+ngx_feature_libs=
+ngx_feature_test="cpu_set_t set;
+                  CPU_COUNT(&set);"
+. auto/feature
+
+
 ngx_feature="SO_SETFIB"
 ngx_feature_name="NGX_HAVE_SETFIB"
 ngx_feature_run=no

--- a/src/os/unix/ngx_posix_init.c
+++ b/src/os/unix/ngx_posix_init.c
@@ -64,6 +64,28 @@ ngx_os_init(ngx_log_t *log)
     }
 #endif
 
+#if (NGX_HAVE_SCHED_GETAFFINITY)
+    if (ngx_ncpu > 0) {
+        int         err;
+        size_t      sz;
+        cpu_set_t  *mask;
+
+        mask = CPU_ALLOC(ngx_ncpu);
+        if (mask == NULL) {
+            return NGX_ERROR;
+        }
+
+        sz = CPU_ALLOC_SIZE(ngx_ncpu);
+
+        err = sched_getaffinity(0, sz, mask);
+        if (err == 0) {
+            ngx_ncpu = CPU_COUNT_S(sz, mask);
+        }
+
+        CPU_FREE(mask);
+    }
+#endif
+
     if (ngx_ncpu < 1) {
         ngx_ncpu = 1;
     }

--- a/src/os/unix/ngx_posix_init.c
+++ b/src/os/unix/ngx_posix_init.c
@@ -64,6 +64,22 @@ ngx_os_init(ngx_log_t *log)
     }
 #endif
 
+#if (NGX_HAVE_CPU_COUNT)
+
+#if (NGX_HAVE_SCHED_GETAFFINITY)
+    if (ngx_ncpu > 0) {
+        int        err;
+        cpu_set_t  mask;
+
+        err = sched_getaffinity(0, sizeof(mask), &mask);
+        if (err == 0) {
+            ngx_ncpu = CPU_COUNT(&mask);
+        }
+    }
+#endif
+
+#endif
+
     if (ngx_ncpu < 1) {
         ngx_ncpu = 1;
     }

--- a/src/os/unix/ngx_posix_init.c
+++ b/src/os/unix/ngx_posix_init.c
@@ -66,7 +66,18 @@ ngx_os_init(ngx_log_t *log)
 
 #if (NGX_HAVE_CPU_COUNT)
 
-#if (NGX_HAVE_SCHED_GETAFFINITY)
+#if (NGX_HAVE_CPUSET_GETAFFINITY)
+    if (ngx_ncpu > 0) {
+        int       err;
+        cpuset_t  mask;
+
+        err = cpuset_getaffinity(CPU_LEVEL_WHICH, CPU_WHICH_PID, -1,
+                                 sizeof(mask), &mask);
+        if (err == 0) {
+            ngx_ncpu = CPU_COUNT(&mask);
+        }
+    }
+#elif (NGX_HAVE_SCHED_GETAFFINITY)
     if (ngx_ncpu > 0) {
         int        err;
         cpu_set_t  mask;


### PR DESCRIPTION
```
This pull-request comprises five commits

- Configure: add a check for sched_getaffinity(2)

Adds a configure check for sched_getaffinity(2)

- Configure: add cpuset_getaffinity() support

Adds a configure check for cpuset_getaffinity(2)

- Configure: add a check for the CPU_COUNT() macro

Adds a configure check for CPU_COUNT()

This does detect CPU_COUNT() on FreeBSD 13.1+ twice due to the
introduction of sched.h which includes sys/cpuset.h so we end up with it
detected twice. This isn't really an issue due to the feature macros
being guarded against multiple definitions.

Fixing this cosmetic issue gets messy. I think really the right thing is
to move the sched_[gs]etaffinity() and CPU_COUNT() checks out of
auto/unix into auto/os/linux as AFAICT only Linux has those syscalls (a
part from FreeBSD with it's compatibility wrappers, but we use the
native implementation there anyway).

Or we simply drop this check and assume CPU_COUNT() is there which is
true for any Linux/FreeBSD system in the last decade and more.

- Better available cpu count determination on Linux

Uses the above to better determine the actual number of runnable CPUs.

Uses the static allocation API, this is simpler than the dynamic API,
which has tricky edge cases around trying to determine the number of
CPUs that need to be covered, and supports up to 1024 CPUs. If a system
has more, then we'll just fall back to using the original ngx_ncpu.

- Better available cpu count determination on FreeBSD

FreeBSD only has a static allocation API and while the userspace bits
support 1024 CPUs (like on Linux), however it seems the Kernel currently
limits this to 256 (MAX_CPU).

Why This?
---------

nginx currently uses 'sysconf(_SC_NPROCESSORS_ONLN)' (when available),
to determine the number of CPUs in the system to determine how many
worker process to create with 'worker_processes auto;'

Often this produces the correct result, nr worker processes == runnable
cpu count. However there are cases where this can go awry.

For example when cpuset(7)s are in use and a process has been limited to
a subset of CPUs.

E.g. a common case is docker with the '--cpuset-cpus=' argument set.

If the host has say 16 CPUs and docker has been allocated 4, then nginx
would still create 16 workers under docker. After this change it will
create 4.
```

