### PR TITLE
Core: Add argument to make module optional in load_module in config

### DIFF
--- a/src/core/ngx_module.h
+++ b/src/core/ngx_module.h
@@ -276,7 +276,7 @@ ngx_int_t ngx_count_modules(ngx_cycle_t *cycle, ngx_uint_t type);
 
 
 ngx_int_t ngx_add_module(ngx_conf_t *cf, ngx_str_t *file,
-    ngx_module_t *module, char **order);
+    ngx_module_t *module, char **order, ngx_uint_t optional);
 
 
 extern ngx_module_t  *ngx_modules[];


### PR DESCRIPTION
Added optional "optional" argument to load_module directive. If the argument is provided then failing to load the module will only emit a warning and not hinder nginx from starting. The existing behavior remains unchanged if "optional" is not provided.

### Proposed changes

This change adds the ability to mark modules as optional in the configuration file. Failing to load an optional module does not hinder nginx from starting.
The motivation behind this change is for issues with non essential modules to not prevent nginx from working. For example modules that only collect data.

A warning message is logged if an optional module could not be loaded. Also added an error message if a core module's "create_conf" call fails for modules specified via load_module.

### Usage
load_module _module_ [optional];