### PR TITLE
fix potential integer overflow

### DIFF
--- a/src/http/modules/ngx_http_mp4_module.c
+++ b/src/http/modules/ngx_http_mp4_module.c
@@ -2460,7 +2460,7 @@ found:
         start_sample -= key_prefix;
 
         while (rest < key_prefix) {
-            trak->prefix += rest * duration;
+            trak->prefix += (uint64_t) rest * duration;
             key_prefix -= rest;
 
             entry--;
@@ -2471,7 +2471,7 @@ found:
             rest = count;
         }
 
-        trak->prefix += key_prefix * duration;
+        trak->prefix += (uint64_t) key_prefix * duration;
         trak->duration += trak->prefix;
         rest -= key_prefix;
 


### PR DESCRIPTION
Multiplication of two `uint32_t` might overflow before it is widened to `uint64_t`
