### PR TITLE
Updated OpenSSL and PCRE used for win32 builds.

### DIFF
--- a/misc/GNUmakefile
+++ b/misc/GNUmakefile
@@ -6,9 +6,9 @@ TEMP =		tmp
 
 CC =		cl
 OBJS =		objs.msvc8
-OPENSSL =	openssl-3.5.2
+OPENSSL =	openssl-3.5.4
 ZLIB =		zlib-1.3.1
-PCRE =		pcre2-10.45
+PCRE =		pcre2-10.46
 
 
 release: export

--- a/src/core/nginx.h
+++ b/src/core/nginx.h
@@ -9,8 +9,8 @@
 #define _NGINX_H_INCLUDED_
 
 
-#define nginx_version      1029002
-#define NGINX_VERSION      "1.29.2"
+#define nginx_version      1029003
+#define NGINX_VERSION      "1.29.3"
 #define NGINX_VER          "nginx/" NGINX_VERSION
 
 #ifdef NGX_BUILD


### PR DESCRIPTION
This corresponds to the actually built nginx-1.29.2 win32 zip, missed as part of release preparation.