### PR TITLE
Security: Fix XXE vulnerability in xslt_filter module.

### DIFF
--- a/src/http/modules/ngx_http_xslt_filter_module.c
+++ b/src/http/modules/ngx_http_xslt_filter_module.c
@@ -381,8 +381,9 @@ ngx_http_xslt_add_chunk(ngx_http_request_t *r, ngx_http_xslt_filter_ctx_t *ctx,
                           "xmlCreatePushParserCtxt() failed");
             return NGX_ERROR;
         }
-        xmlCtxtUseOptions(ctxt, XML_PARSE_NOENT|XML_PARSE_DTDLOAD
+        xmlCtxtUseOptions(ctxt, XML_PARSE_DTDLOAD
                                                |XML_PARSE_NOWARNING);
+        xmlSetExternalEntityLoader(xmlNoNetExternalEntityLoader);
 
         ctxt->sax->externalSubset = ngx_http_xslt_sax_external_subset;
         ctxt->sax->setDocumentLocator = NULL;


### PR DESCRIPTION
The XSLT filter module was vulnerable to XML External Entity (XXE) injection due to the use of the XML_PARSE_NOENT flag. This patch mitigates the vulnerability by removing the flag and explicitly disabling external entity loading, which is the recommended best practice for parsing untrusted XML.
