### PR TITLE
Validate headers according to rfc2616

### DIFF
--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -968,8 +968,8 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
                 || (ch >= 0x3b && ch <= 0x40)
                 || (ch >= 0x5b && ch <= 0x5d)
                 || ch == 0x7b
-                || ch == 0x7d
-                ) {
+                || ch == 0x7d)
+            {
                 r->header_end = p;
                 return NGX_HTTP_PARSE_INVALID_HEADER;
             }

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -959,7 +959,17 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
                 break;
             }
 
-            if (ch <= 0x20 || ch == 0x7f) {
+            if (ch <= 0x20
+                || ch == 0x22
+                || ch == 0x28
+                || ch == 0x29
+                || ch == 0x2c
+                || ch == 0x2f
+                || (ch >= 0x3b && ch <= 0x40)
+                || (ch >= 0x5b && ch <= 0x5d)
+                || ch == 0x7b
+                || ch == 0x7d
+                ) {
                 r->header_end = p;
                 return NGX_HTTP_PARSE_INVALID_HEADER;
             }


### PR DESCRIPTION
This will invalidate separators in header names according to [rfc2616](https://www.ietf.org/rfc/rfc2616.txt); fixes #899
