### PR TITLE
OCSP: fixed invalid type for the 'ssl_ocsp' directive.

### DIFF
--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -237,7 +237,7 @@ static ngx_command_t  ngx_http_ssl_commands[] = {
       NULL },
 
     { ngx_string("ssl_ocsp"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_enum_slot,
       NGX_HTTP_SRV_CONF_OFFSET,
       offsetof(ngx_http_ssl_srv_conf_t, ocsp),

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -239,7 +239,7 @@ static ngx_command_t  ngx_stream_ssl_commands[] = {
       NULL },
 
     { ngx_string("ssl_ocsp"),
-      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_enum_slot,
       NGX_STREAM_SRV_CONF_OFFSET,
       offsetof(ngx_stream_ssl_srv_conf_t, ocsp),


### PR DESCRIPTION
### Proposed changes

The directive 'ssl_ocsp' accepts 3 options and is defined as an enum, but the type is set to NGX_CONF_FLAG.

This is not a functionality issue but a semantics problem.  nginx -t -c validates the config file successfully even without the fix.

However, this issue affects external tools that validate configuration files, including the Nginx Agent.

A few months ago, Crossplane adopted an approach where Nginx source code is scanned to collect a dictionary of valid directives, and their valid contexts and parameters are inferred from the masks used. Since ssl_oscp is marked as a flag parameter in the source code, Crossplane applies that same validation (and therefore anything using Crossplane, like the Agent or NIM, will do the same).

Even though the configuration looks fine from Nginx point of vew, Nginx Agent may report error like:
```error reading config from /etc/nginx/nginx.conf, error: invalid value "leaf" in "ssl_ocsp" directive, it must be "on" or "off"```


Resolves: #937 

