### PR TITLE
Upstream: proxy_bind_dynamic and friends.

### DIFF
--- a/src/http/modules/ngx_http_fastcgi_module.c
+++ b/src/http/modules/ngx_http_fastcgi_module.c
@@ -289,6 +289,13 @@ static ngx_command_t  ngx_http_fastcgi_commands[] = {
       offsetof(ngx_http_fastcgi_loc_conf_t, upstream.local),
       NULL },
 
+    { ngx_string("fastcgi_bind_dynamic"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_fastcgi_loc_conf_t, upstream.local_dynamic),
+      NULL },
+
     { ngx_string("fastcgi_socket_keepalive"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
@@ -2889,6 +2896,7 @@ ngx_http_fastcgi_create_loc_conf(ngx_conf_t *cf)
     conf->upstream.force_ranges = NGX_CONF_UNSET;
 
     conf->upstream.local = NGX_CONF_UNSET_PTR;
+    conf->upstream.local_dynamic = NGX_CONF_UNSET;
     conf->upstream.socket_keepalive = NGX_CONF_UNSET;
 
     conf->upstream.connect_timeout = NGX_CONF_UNSET_MSEC;
@@ -2992,6 +3000,9 @@ ngx_http_fastcgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_ptr_value(conf->upstream.local,
                               prev->upstream.local, NULL);
+
+    ngx_conf_merge_value(conf->upstream.local_dynamic,
+                         prev->upstream.local_dynamic, 0);
 
     ngx_conf_merge_value(conf->upstream.socket_keepalive,
                               prev->upstream.socket_keepalive, 0);

--- a/src/http/modules/ngx_http_geo_module.c
+++ b/src/http/modules/ngx_http_geo_module.c
@@ -63,6 +63,7 @@ typedef struct {
     unsigned                         allow_binary_include:1;
     unsigned                         binary_include:1;
     unsigned                         proxy_recursive:1;
+    unsigned                         no_cacheable:1;
 } ngx_http_geo_conf_ctx_t;
 
 
@@ -464,6 +465,8 @@ ngx_http_geo_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                   + 0x10000 * sizeof(ngx_http_geo_range_t *);
     ctx.allow_binary_include = 1;
 
+    ctx.no_cacheable = 0;
+
     save = *cf;
     cf->pool = pool;
     cf->ctx = &ctx;
@@ -476,6 +479,10 @@ ngx_http_geo_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (rv != NGX_CONF_OK) {
         goto failed;
+    }
+
+    if (ctx.no_cacheable) {
+        var->flags |= NGX_HTTP_VAR_NOCACHEABLE;
     }
 
     geo->proxies = ctx.proxies;
@@ -620,6 +627,12 @@ ngx_http_geo(ngx_conf_t *cf, ngx_command_t *dummy, void *conf)
 
         else if (ngx_strcmp(value[0].data, "proxy_recursive") == 0) {
             ctx->proxy_recursive = 1;
+            rv = NGX_CONF_OK;
+            goto done;
+        }
+
+        else if (ngx_strcmp(value[0].data, "volatile") == 0) {
+            ctx->no_cacheable = 1;
             rv = NGX_CONF_OK;
             goto done;
         }

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -269,6 +269,13 @@ static ngx_command_t  ngx_http_grpc_commands[] = {
       offsetof(ngx_http_grpc_loc_conf_t, upstream.local),
       NULL },
 
+    { ngx_string("grpc_bind_dynamic"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_grpc_loc_conf_t, upstream.local_dynamic),
+      NULL },
+
     { ngx_string("grpc_socket_keepalive"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
@@ -4389,6 +4396,7 @@ ngx_http_grpc_create_loc_conf(ngx_conf_t *cf)
      */
 
     conf->upstream.local = NGX_CONF_UNSET_PTR;
+    conf->upstream.local_dynamic = NGX_CONF_UNSET;
     conf->upstream.socket_keepalive = NGX_CONF_UNSET;
     conf->upstream.next_upstream_tries = NGX_CONF_UNSET_UINT;
     conf->upstream.connect_timeout = NGX_CONF_UNSET_MSEC;
@@ -4452,6 +4460,9 @@ ngx_http_grpc_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_ptr_value(conf->upstream.local,
                               prev->upstream.local, NULL);
+
+    ngx_conf_merge_value(conf->upstream.local_dynamic,
+                         prev->upstream.local_dynamic, 0);
 
     ngx_conf_merge_value(conf->upstream.socket_keepalive,
                               prev->upstream.socket_keepalive, 0);

--- a/src/http/modules/ngx_http_memcached_module.c
+++ b/src/http/modules/ngx_http_memcached_module.c
@@ -67,6 +67,13 @@ static ngx_command_t  ngx_http_memcached_commands[] = {
       offsetof(ngx_http_memcached_loc_conf_t, upstream.local),
       NULL },
 
+    { ngx_string("memcached_bind_dynamic"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_memcached_loc_conf_t, upstream.local_dynamic),
+      NULL },
+
     { ngx_string("memcached_socket_keepalive"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
@@ -606,6 +613,7 @@ ngx_http_memcached_create_loc_conf(ngx_conf_t *cf)
      */
 
     conf->upstream.local = NGX_CONF_UNSET_PTR;
+    conf->upstream.local_dynamic = NGX_CONF_UNSET;
     conf->upstream.socket_keepalive = NGX_CONF_UNSET;
     conf->upstream.next_upstream_tries = NGX_CONF_UNSET_UINT;
     conf->upstream.connect_timeout = NGX_CONF_UNSET_MSEC;
@@ -645,6 +653,9 @@ ngx_http_memcached_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_ptr_value(conf->upstream.local,
                               prev->upstream.local, NULL);
+
+    ngx_conf_merge_value(conf->upstream.local_dynamic,
+                         prev->upstream.local_dynamic, 0);
 
     ngx_conf_merge_value(conf->upstream.socket_keepalive,
                               prev->upstream.socket_keepalive, 0);

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -379,6 +379,13 @@ static ngx_command_t  ngx_http_proxy_commands[] = {
       offsetof(ngx_http_proxy_loc_conf_t, upstream.local),
       NULL },
 
+    { ngx_string("proxy_bind_dynamic"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_proxy_loc_conf_t, upstream.local_dynamic),
+      NULL },
+
     { ngx_string("proxy_socket_keepalive"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
@@ -3599,6 +3606,7 @@ ngx_http_proxy_create_loc_conf(ngx_conf_t *cf)
     conf->upstream.force_ranges = NGX_CONF_UNSET;
 
     conf->upstream.local = NGX_CONF_UNSET_PTR;
+    conf->upstream.local_dynamic = NGX_CONF_UNSET;
     conf->upstream.socket_keepalive = NGX_CONF_UNSET;
 
     conf->upstream.connect_timeout = NGX_CONF_UNSET_MSEC;
@@ -3731,6 +3739,9 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_ptr_value(conf->upstream.local,
                               prev->upstream.local, NULL);
+
+    ngx_conf_merge_value(conf->upstream.local_dynamic,
+                         prev->upstream.local_dynamic, 0);
 
     ngx_conf_merge_value(conf->upstream.socket_keepalive,
                               prev->upstream.socket_keepalive, 0);

--- a/src/http/modules/ngx_http_scgi_module.c
+++ b/src/http/modules/ngx_http_scgi_module.c
@@ -144,6 +144,13 @@ static ngx_command_t ngx_http_scgi_commands[] = {
       offsetof(ngx_http_scgi_loc_conf_t, upstream.local),
       NULL },
 
+    { ngx_string("scgi_bind_dynamic"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_scgi_loc_conf_t, upstream.local_dynamic),
+      NULL },
+
     { ngx_string("scgi_socket_keepalive"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
@@ -1307,6 +1314,7 @@ ngx_http_scgi_create_loc_conf(ngx_conf_t *cf)
     conf->upstream.force_ranges = NGX_CONF_UNSET;
 
     conf->upstream.local = NGX_CONF_UNSET_PTR;
+    conf->upstream.local_dynamic = NGX_CONF_UNSET;
     conf->upstream.socket_keepalive = NGX_CONF_UNSET;
 
     conf->upstream.connect_timeout = NGX_CONF_UNSET_MSEC;
@@ -1405,6 +1413,9 @@ ngx_http_scgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_ptr_value(conf->upstream.local,
                               prev->upstream.local, NULL);
+
+    ngx_conf_merge_value(conf->upstream.local_dynamic,
+                         prev->upstream.local_dynamic, 0);
 
     ngx_conf_merge_value(conf->upstream.socket_keepalive,
                               prev->upstream.socket_keepalive, 0);

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -212,6 +212,13 @@ static ngx_command_t ngx_http_uwsgi_commands[] = {
       offsetof(ngx_http_uwsgi_loc_conf_t, upstream.local),
       NULL },
 
+    { ngx_string("uwsgi_bind_dynamic"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_uwsgi_loc_conf_t, upstream.local_dynamic),
+      NULL },
+
     { ngx_string("uwsgi_socket_keepalive"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
@@ -1554,6 +1561,7 @@ ngx_http_uwsgi_create_loc_conf(ngx_conf_t *cf)
     conf->upstream.force_ranges = NGX_CONF_UNSET;
 
     conf->upstream.local = NGX_CONF_UNSET_PTR;
+    conf->upstream.local_dynamic = NGX_CONF_UNSET;
     conf->upstream.socket_keepalive = NGX_CONF_UNSET;
 
     conf->upstream.connect_timeout = NGX_CONF_UNSET_MSEC;
@@ -1665,6 +1673,9 @@ ngx_http_uwsgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_ptr_value(conf->upstream.local,
                               prev->upstream.local, NULL);
+
+    ngx_conf_merge_value(conf->upstream.local_dynamic,
+                         prev->upstream.local_dynamic, 0);
 
     ngx_conf_merge_value(conf->upstream.socket_keepalive,
                               prev->upstream.socket_keepalive, 0);

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -665,7 +665,9 @@ ngx_http_upstream_init_request(ngx_http_request_t *r)
         return;
     }
 
-    if (ngx_http_upstream_set_local(r, u, u->conf->local) != NGX_OK) {
+    if (!u->conf->local_dynamic
+        && ngx_http_upstream_set_local(r, u, u->conf->local) != NGX_OK)
+    {
         ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
         return;
     }
@@ -1585,6 +1587,13 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
     rc = u->peer.get(&u->peer, u->peer.data);
 
     if (rc == NGX_OK) {
+        if (u->conf->local_dynamic
+            && ngx_http_upstream_set_local(r, u, u->conf->local) != NGX_OK)
+        {
+            ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
         get = u->peer.get;
         u->peer.get = ngx_event_get_peer;
 

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -200,6 +200,7 @@ typedef struct {
     ngx_array_t                     *pass_headers;
 
     ngx_http_upstream_local_t       *local;
+    ngx_flag_t                       local_dynamic;
     ngx_flag_t                       socket_keepalive;
 
 #if (NGX_HTTP_CACHE)

--- a/src/stream/ngx_stream_geo_module.c
+++ b/src/stream/ngx_stream_geo_module.c
@@ -61,6 +61,7 @@ typedef struct {
     unsigned                           outside_entries:1;
     unsigned                           allow_binary_include:1;
     unsigned                           binary_include:1;
+    unsigned                           no_cacheable:1;
 } ngx_stream_geo_conf_ctx_t;
 
 
@@ -434,6 +435,8 @@ ngx_stream_geo_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                   + 0x10000 * sizeof(ngx_stream_geo_range_t *);
     ctx.allow_binary_include = 1;
 
+    ctx.no_cacheable = 0;
+
     save = *cf;
     cf->pool = pool;
     cf->ctx = &ctx;
@@ -446,6 +449,10 @@ ngx_stream_geo_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (rv != NGX_CONF_OK) {
         goto failed;
+    }
+
+    if (ctx.no_cacheable) {
+        var->flags |= NGX_STREAM_VAR_NOCACHEABLE;
     }
 
     if (ctx.ranges) {
@@ -581,6 +588,12 @@ ngx_stream_geo(ngx_conf_t *cf, ngx_command_t *dummy, void *conf)
 
             rv = NGX_CONF_OK;
 
+            goto done;
+        }
+
+        else if (ngx_strcmp(value[0].data, "volatile") == 0) {
+            ctx->no_cacheable = 1;
+            rv = NGX_CONF_OK;
             goto done;
         }
     }

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -58,6 +58,8 @@ typedef struct {
 
     ngx_stream_upstream_srv_conf_t  *upstream;
     ngx_stream_complex_value_t      *upstream_value;
+
+    ngx_flag_t                       local_dynamic;
 } ngx_stream_proxy_srv_conf_t;
 
 
@@ -153,6 +155,13 @@ static ngx_command_t  ngx_stream_proxy_commands[] = {
       ngx_stream_proxy_bind,
       NGX_STREAM_SRV_CONF_OFFSET,
       0,
+      NULL },
+
+    { ngx_string("proxy_bind_dynamic"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_proxy_srv_conf_t, local_dynamic),
       NULL },
 
     { ngx_string("proxy_socket_keepalive"),
@@ -437,7 +446,9 @@ ngx_stream_proxy_handler(ngx_stream_session_t *s)
     u->peer.log = c->log;
     u->peer.log_error = NGX_ERROR_ERR;
 
-    if (ngx_stream_proxy_set_local(s, u, pscf->local) != NGX_OK) {
+    if (!pscf->local_dynamic
+        && ngx_stream_proxy_set_local(s, u, pscf->local) != NGX_OK)
+    {
         ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
         return;
     }
@@ -747,6 +758,13 @@ ngx_stream_proxy_connect(ngx_stream_session_t *s)
     rc = u->peer.get(&u->peer, u->peer.data);
 
     if (rc == NGX_OK) {
+        if (pscf->local_dynamic
+            && ngx_stream_proxy_set_local(s, u, pscf->local) != NGX_OK)
+        {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
         get = u->peer.get;
         u->peer.get = ngx_event_get_peer;
 
@@ -2225,6 +2243,7 @@ ngx_stream_proxy_create_srv_conf(ngx_conf_t *cf)
     conf->next_upstream = NGX_CONF_UNSET;
     conf->proxy_protocol = NGX_CONF_UNSET;
     conf->local = NGX_CONF_UNSET_PTR;
+    conf->local_dynamic = NGX_CONF_UNSET;
     conf->socket_keepalive = NGX_CONF_UNSET;
     conf->half_close = NGX_CONF_UNSET;
 
@@ -2282,6 +2301,8 @@ ngx_stream_proxy_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->proxy_protocol, prev->proxy_protocol, 0);
 
     ngx_conf_merge_ptr_value(conf->local, prev->local, NULL);
+
+    ngx_conf_merge_value(conf->local_dynamic, prev->local_dynamic, 0);
 
     ngx_conf_merge_value(conf->socket_keepalive,
                               prev->socket_keepalive, 0);

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -711,6 +711,7 @@ ngx_stream_proxy_connect(ngx_stream_session_t *s)
 {
     ngx_int_t                     rc;
     ngx_connection_t             *c, *pc;
+    ngx_event_get_peer_pt         get;
     ngx_stream_upstream_t        *u;
     ngx_stream_proxy_srv_conf_t  *pscf;
 
@@ -743,7 +744,16 @@ ngx_stream_proxy_connect(ngx_stream_session_t *s)
     u->state->first_byte_time = (ngx_msec_t) -1;
     u->state->response_time = (ngx_msec_t) -1;
 
-    rc = ngx_event_connect_peer(&u->peer);
+    rc = u->peer.get(&u->peer, u->peer.data);
+
+    if (rc == NGX_OK) {
+        get = u->peer.get;
+        u->peer.get = ngx_event_get_peer;
+
+        rc = ngx_event_connect_peer(&u->peer);
+
+        u->peer.get = get;
+    }
 
     ngx_log_debug1(NGX_LOG_DEBUG_STREAM, c->log, 0, "proxy connect: %i", rc);
 


### PR DESCRIPTION
When proxy_bind_dynamic is "on" it evaluates proxy_bind for each attempted upstream peer.