### PR TITLE
Add MIME type for Android APK files

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -35,6 +35,7 @@ types {
     application/pdf                                  pdf;
     application/postscript                           ps eps ai;
     application/rtf                                  rtf;
+    application/vnd.android.package-archive          apk;
     application/vnd.apple.mpegurl                    m3u8;
     application/vnd.google-earth.kml+xml             kml;
     application/vnd.google-earth.kmz                 kmz;


### PR DESCRIPTION
## Summary

Fixes #886

This PR adds the missing MIME type entry for Android APK files to the `mime.types` configuration file.

## Problem

Android APK files were being served with `Content-Type: text/plain` instead of the correct `application/vnd.android.package-archive` MIME type. This caused browsers to attempt to display APK files as text instead of prompting for download.

## Solution

Added the following entry to `conf/mime.types`:
```
application/vnd.android.package-archive          apk;
```

The entry has been placed alphabetically among other `application/vnd.*` entries for consistency.

## Testing

After applying this change, APK files will be served with the correct `Content-Type` header:
```
Content-Type: application/vnd.android.package-archive
```