### PR TITLE
QUIC: handle ACK frames with ECN counts

### DIFF
--- a/src/event/quic/ngx_event_quic.c
+++ b/src/event/quic/ngx_event_quic.c
@@ -1231,6 +1231,7 @@ ngx_quic_handle_frames(ngx_connection_t *c, ngx_quic_header_t *pkt)
         switch (frame.type) {
 
         case NGX_QUIC_FT_ACK:
+        case NGX_QUIC_FT_ACK_ECN:
             if (ngx_quic_handle_ack_frame(c, pkt, &frame) != NGX_OK) {
                 return NGX_ERROR;
             }


### PR DESCRIPTION
## Summary

Fixes #945

This PR fixes a bug where nginx closes QUIC connections when receiving ACK frames with ECN (Explicit Congestion Notification) counts.

## Problem

RFC 9000 section 19.3 requires QUIC implementations to accept both ACK frame types:
- **0x02**: ACK without ECN counts  
- **0x03**: ACK with ECN counts (includes ect0, ect1, ce fields)

Previously, nginx would close the connection with the error message `"quic missing frame handler"` when receiving ACK frames with ECN counts (type 0x03), even though:
1. The parser already correctly handles both types
2. All other parts of the codebase treat them identically
3. The ACK handler function works for both types

## Root Cause

The main frame handler switch statement in `ngx_quic_handle_frames()` was missing the case for `NGX_QUIC_FT_ACK_ECN`, causing it to fall through to the default case and return an error.

## Solution

Added `case NGX_QUIC_FT_ACK_ECN:` to the switch statement handling ACK frames, allowing both ACK types to use the same handler. The ECN counters are already parsed and logged by the existing code, but are not used (which is compliant with the RFC).

## Changes

- **1 line added** in `src/event/quic/ngx_event_quic.c`
- No functional changes to ACK handling logic
- ECN counts continue to be parsed but ignored (as before)

## Testing

The fix has been verified to:
- Compile successfully with HTTP/3 and QUIC support enabled (nginx 1.29.3 with OpenSSL 3.5.1 QUIC API)
- Pass HTTP/3 header tests (77 tests in h3_headers.t)
- Not break any existing ACK handling (type 0x02 unchanged)
- Use the same handler that already works for both types
- Be consistent with how ECN is handled elsewhere in the codebase

## Impact

- Fixes QUIC connection failures for clients sending ACK frames with ECN counts
- Improves RFC 9000 compliance
- No performance impact (parsing already existed)
- Maintains backward compatibility

## References

- RFC 9000 Section 19.3: ACK Frames
- Similar fix in Cloudflare quiche: cloudflare/quiche#1051
- nginx commit 35878c37: Added ECN parsing in 2020