### PR TITLE
Modules compatibility: increased compat section size.

### DIFF
--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -253,7 +253,7 @@ typedef struct {
 
     ngx_str_t                        module;
 
-    NGX_COMPAT_BEGIN(2)
+    NGX_COMPAT_BEGIN(6)
     NGX_COMPAT_END
 } ngx_http_upstream_conf_t;
 


### PR DESCRIPTION
The change increases compat section size for `ngx_http_upstream_conf_t` to maintain binary compatibility with NGINX Plus.