### PR TITLE
Upstream: max_fails doesn't respect the next_upstream config

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -4553,13 +4553,12 @@ ngx_http_upstream_next(ngx_http_request_t *r, ngx_http_upstream_t *u,
             u->state->bytes_sent = u->peer.connection->sent;
         }
 
-        if (ft_type == NGX_HTTP_UPSTREAM_FT_HTTP_403
-            || ft_type == NGX_HTTP_UPSTREAM_FT_HTTP_404)
+        if ((u->conf->next_upstream & ft_type) == ft_type)
         {
-            state = NGX_PEER_NEXT;
+            state = NGX_PEER_FAILED;
 
         } else {
-            state = NGX_PEER_FAILED;
+            state = NGX_PEER_NEXT;
         }
 
         u->peer.free(&u->peer, u->peer.data, state);


### PR DESCRIPTION
In the description of `max_fails`, it says:
What is considered an unsuccessful attempt is defined by the `proxy_next_upstream`, `fastcgi_next_upstreami`,
`uwsgi_next_upstream`, `scgi_next_upstream`,
`memcached_next_upstream`, and `grpc_next_upstream` directives.

But actually 403 and 404 are always considered an successful attempt, while other cases are always considered an unsuccessful attempt.

The `ngx_http_upstream_free_round_robin_peer` function depends on this to update the health check state. As a result, the health checker/circuit breaker doesn't work properly.

### Proposed changes

Describe the use case and detail of the change.

If this pull request addresses an issue on GitHub, make sure to reference that
issue using one of the
[supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).

Before creating a pull request, make sure to comply with the
[Contributing Guidelines](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md).
