### PR TITLE
Fix: fallback to accept() when accept4() returns EINVAL on RedHat 9

### DIFF
--- a/src/event/ngx_event_accept.c
+++ b/src/event/ngx_event_accept.c
@@ -58,15 +58,23 @@ ngx_event_accept(ngx_event_t *ev)
     do {
         socklen = sizeof(ngx_sockaddr_t);
 
+/* Runtime fallback for RedHat 9 kernel bug (accept4() EINVAL).
+   Ensures NGINX continues operation by switching to accept(). */
+
 #if (NGX_HAVE_ACCEPT4)
         if (use_accept4) {
             s = accept4(lc->fd, &sa.sockaddr, &socklen, SOCK_NONBLOCK);
-
-            if (s == -1 && errno == EINVAL) {
-                /* Fallback: certain Linux kernels return EINVAL when SOCK_NONBLOCK is used with accept4() */
+        
+            if (s == (ngx_socket_t) -1 && ngx_socket_errno == NGX_EINVAL) {
+                /* 
+                * Fallback: certain Linux kernels return EINVAL 
+                * when SOCK_NONBLOCK is used with accept4() 
+                */
                 ngx_log_error(NGX_LOG_NOTICE, ev->log, ngx_errno,
                               "accept4() failed with EINVAL, falling back to accept()");
+
                 s = accept(lc->fd, &sa.sockaddr, &socklen);
+                
                 if (s != -1) {
                     if (fcntl(s, F_SETFL, O_NONBLOCK) == -1) {
                         ngx_log_error(NGX_LOG_ALERT, ev->log, ngx_errno,


### PR DESCRIPTION
This is my first open-source contribution
I added a compatibility fallback inside the ngx_event_accept() function (in src/event/ngx_event_accept.c)
to handle the case where accept4() fails with EINVAL (Invalid argument) on RedHat Enterprise Linux 9 systems.

This fix ensures that NGINX continues accepting connections gracefully by falling back to accept()
when accept4() is unsupported or behaves inconsistently with the SOCK_NONBLOCK flag.
