### PR TITLE
SSL: changed interface of ngx_ssl_set_client_hello_callback().

### DIFF
--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -286,7 +286,7 @@ ngx_int_t ngx_ssl_session_ticket_keys(ngx_conf_t *cf, ngx_ssl_t *ssl,
     ngx_array_t *paths);
 ngx_int_t ngx_ssl_session_cache_init(ngx_shm_zone_t *shm_zone, void *data);
 
-void ngx_ssl_set_client_hello_callback(SSL_CTX *ssl_ctx,
+ngx_int_t ngx_ssl_set_client_hello_callback(ngx_ssl_t *ssl,
     ngx_ssl_client_hello_arg *cb);
 #ifdef SSL_CLIENT_HELLO_SUCCESS
 int ngx_ssl_client_hello_callback(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg);

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -758,7 +758,9 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     {
     static ngx_ssl_client_hello_arg cb = { ngx_http_ssl_servername };
 
-    ngx_ssl_set_client_hello_callback(conf->ssl.ctx, &cb);
+    if (ngx_ssl_set_client_hello_callback(&conf->ssl, &cb) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
 
     if (SSL_CTX_set_tlsext_servername_callback(conf->ssl.ctx,
                                                ngx_http_ssl_servername)

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -1008,7 +1008,9 @@ ngx_stream_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     {
     static ngx_ssl_client_hello_arg cb = { ngx_stream_ssl_servername };
 
-    ngx_ssl_set_client_hello_callback(conf->ssl.ctx, &cb);
+    if (ngx_ssl_set_client_hello_callback(&conf->ssl, &cb) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
 
     SSL_CTX_set_tlsext_servername_callback(conf->ssl.ctx,
                                            ngx_stream_ssl_servername);


### PR DESCRIPTION
The function interface is changed to use a standard approach of "ngx_int_t func(.., ngx_ssl_t *ssl, ..)" similar to other functions used to setup SSL_CTX, with the exception that "ngx_conf_t *cf" is omitted for simplicity as it is not bound to nginx configuration.

This is required to properly handle and report SSL_CTX_set_ex_data() errors, as reminded by Coverity (CID 1668589).
