### PR TITLE
HTTP/3: fixed misaligned access with Huffman encoding.

### DIFF
--- a/src/http/v3/ngx_http_v3_encode.h
+++ b/src/http/v3/ngx_http_v3_encode.h
@@ -23,12 +23,12 @@ uintptr_t ngx_http_v3_encode_field_section_prefix(u_char *p,
 uintptr_t ngx_http_v3_encode_field_ri(u_char *p, ngx_uint_t dynamic,
     ngx_uint_t index);
 uintptr_t ngx_http_v3_encode_field_lri(u_char *p, ngx_uint_t dynamic,
-    ngx_uint_t index, u_char *data, size_t len);
+    ngx_uint_t index, u_char *data, size_t len, u_char *tmp);
 uintptr_t ngx_http_v3_encode_field_l(u_char *p, ngx_str_t *name,
-    ngx_str_t *value);
+    ngx_str_t *value, u_char *tmp);
 uintptr_t ngx_http_v3_encode_field_pbi(u_char *p, ngx_uint_t index);
 uintptr_t ngx_http_v3_encode_field_lpbi(u_char *p, ngx_uint_t index,
-    u_char *data, size_t len);
+    u_char *data, size_t len, u_char *tmp);
 
 
 #endif /* _NGX_HTTP_V3_ENCODE_H_INCLUDED_ */

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -584,7 +584,8 @@ ngx_http_v3_process_request(ngx_event_t *rev)
 
         h3c->payload_bytes += ngx_http_v3_encode_field_l(NULL,
                                                    &st->field_rep.field.name,
-                                                   &st->field_rep.field.value);
+                                                   &st->field_rep.field.value,
+                                                   NULL);
 
         if (ngx_http_v3_process_header(r, &st->field_rep.field.name,
                                        &st->field_rep.field.value)


### PR DESCRIPTION
The function expects to operate on aligned memory allocation. The fix is store encoded output in an aligned buffer passed via HTTP/3 encoder functions, similar to ngx_http_v2_filter_module.c.

Tested with UndefinedBehaviorSanitizer.
