### PR TITLE
Request body: fixed empty body buffering special case.

### DIFF
--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -581,7 +581,9 @@ ngx_http_write_request_body(ngx_http_request_t *r)
 
         rb->temp_file = tf;
 
-        if (rb->bufs == NULL) {
+        if (rb->bufs == NULL
+            || (!ngx_buf_in_memory(rb->bufs->buf) && rb->bufs->buf->last_buf))
+        {
             /* empty body with r->request_body_in_file_only */
 
             if (ngx_create_temp_file(&tf->file, tf->path, tf->pool,


### PR DESCRIPTION
Empty request body buffering is specially handled to avoid extra write+seek syscalls as initially introduced in 4c7f51136 (0.4.4). This was later broken in chunked body filter in 5fc85439d (1.3.9) where rb->bufs cannot be NULL as it holds at least the final chunk, and further regressed in length body filter in 2a7092138 (1.21.2) where rb->bufs started to indicate the last buffer received.

The fix is to additionally check if it is the only empty buffer.

Found with UndefinedBehaviorSanitizer (pointer-overflow)
