### PR TITLE
crash dump at some certain conditions when both try_files and proxy_pass are configured

### DIFF
--- a/src/http/modules/ngx_http_try_files_module.c
+++ b/src/http/modules/ngx_http_try_files_module.c
@@ -249,39 +249,37 @@ ngx_http_try_files_handler(ngx_http_request_t *r)
             continue;
         }
 
-        /*only tries to change the r->uri when nginx tries to serve as a web file server*/
-        if (clcf->handler == NULL) {
-            path.len -= root;
-            path.data += root;
+        path.len -= root;
+        path.data += root;
 
-            if (!alias) {
+        if (!alias) {
+            r->uri = path;
+
+        } else if (alias == NGX_MAX_SIZE_T_VALUE) {
+            if (!test_dir) {
                 r->uri = path;
-
-            } else if (alias == NGX_MAX_SIZE_T_VALUE) {
-                if (!test_dir) {
-                    r->uri = path;
-                    r->add_uri_to_alias = 1;
-                }
-
-            } else {
-                name = r->uri.data;
-
-                r->uri.len = alias + path.len;
-                r->uri.data = ngx_pnalloc(r->pool, r->uri.len);
-                if (r->uri.data == NULL) {
-                    r->uri.len = 0;
-                    return NGX_HTTP_INTERNAL_SERVER_ERROR;
-                }
-
-                p = ngx_copy(r->uri.data, name, alias);
-                ngx_memcpy(p, path.data, path.len);
+                r->add_uri_to_alias = 1;
             }
 
-            ngx_http_set_exten(r);
+        } else {
+            name = r->uri.data;
 
-            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                    "try file uri: \"%V\"", &r->uri);
+            r->uri.len = alias + path.len;
+            r->uri.data = ngx_pnalloc(r->pool, r->uri.len);
+            if (r->uri.data == NULL) {
+                r->uri.len = 0;
+                return NGX_HTTP_INTERNAL_SERVER_ERROR;
+            }
+
+            p = ngx_copy(r->uri.data, name, alias);
+            ngx_memcpy(p, path.data, path.len);
         }
+
+        ngx_http_set_exten(r);
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "try file uri: \"%V\"", &r->uri);
+
         return NGX_DECLINED;
     }
 

--- a/src/http/modules/ngx_http_try_files_module.c
+++ b/src/http/modules/ngx_http_try_files_module.c
@@ -96,6 +96,14 @@ ngx_http_try_files_handler(ngx_http_request_t *r)
         return NGX_DECLINED;
     }
 
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    if (clcf->handler) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                "skip try files handler since a handler is configured");
+        return NGX_DECLINED;
+    }
+
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "try files handler");
 
@@ -106,9 +114,6 @@ ngx_http_try_files_handler(ngx_http_request_t *r)
     path.data = NULL;
 
     tf = tlcf->try_files;
-
-    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
-
     alias = clcf->alias;
 
     for ( ;; ) {


### PR DESCRIPTION
### Proposed changes

Skip the try_files handler if  the location's handler is configured.

If this pull request addresses an issue on GitHub, make sure to reference that
issue using one of the
[https://github.com/nginx/nginx/issues/983](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).

Before creating a pull request, make sure to comply with the
[Contributing Guidelines](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md).

### Root cause analysis
For the above configuration when we try to access the /ttll/ location via "curl http://server:port/ttll/" and when the file /abcd exists at /var/www/ directory, the crash dump will happen.

If the existed file's name length is larger than the matched location /ttll/ then the filename will be extracted and pass to the backend server.

If the existed file's name is smaller than the length of matched location /ttll/ , the crash or Internal Server Error happens.

What's more the proxy_pass directive MUST ends up with /. for example proxy_pass http://10.197.32.191/;

The root cause is clear, when try_files detects there is an exists file in the location defined in either root or alias, then r->uri is changed to the existing file name. When proxy_pass is executed, it will use the modified r->uri to create the new location which will introduce this bug.




