### PR TITLE
crash dump when both try_files and proxy_pass are configured.

### DIFF
--- a/src/http/modules/ngx_http_try_files_module.c
+++ b/src/http/modules/ngx_http_try_files_module.c
@@ -96,6 +96,14 @@ ngx_http_try_files_handler(ngx_http_request_t *r)
         return NGX_DECLINED;
     }
 
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    if (clcf->handler) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                "skip try files handler since a handler is configured");
+        return NGX_DECLINED;
+    }
+
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "try files handler");
 
@@ -106,9 +114,6 @@ ngx_http_try_files_handler(ngx_http_request_t *r)
     path.data = NULL;
 
     tf = tlcf->try_files;
-
-    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
-
     alias = clcf->alias;
 
     for ( ;; ) {


### PR DESCRIPTION
crash dump when both try_files and proxy_pass are configured.



### Proposed changes

Describe the use case and detail of the change.

location /ttll/ {
      root /var/www/;
      try_files  /abcd /abc12 /abc123 /abcd; # =404;
      proxy_pass http://10.197.32.191:9090/;
 }

For the above configuration when we try to access the /ttll/ location via "curl http://server:port/ttll/" and when the file /abcd exists at /var/www/ directory, the crash dump will happen.

If the existed file's name length is larger than the matched location /ttll/ then the filename will be extracted and pass to the backend server.

If the existed file's name is smaller than the length of matched location /ttll/ , the crash or Internal Server Error happens.

What's more the proxy_pass directive MUST ends up with /. for example proxy_pass http://10.197.32.191/;

The root cause is clear, when try_files detects there is an existing file in the location defined in either root or alias, then r->uri will be changed to thefile name. When proxy_pass is executed, it will use the modified r->uri to create the new location which will introduce this bug.

The fix is just simply skip the try_files handler if the location is configured with a proxy_pass related handlers. 

If this pull request addresses an issue on GitHub, make sure to reference that
issue using one of the
[supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
https://github.com/nginx/nginx/issues/983


Before creating a pull request, make sure to comply with the
[Contributing Guidelines](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md).
