### PR TITLE
Core: skip modules with NGX_MODULE_UNSET_INDEX in ngx_count_modules()

### DIFF
--- a/src/core/ngx_module.c
+++ b/src/core/ngx_module.c
@@ -139,6 +139,10 @@ ngx_count_modules(ngx_cycle_t *cycle, ngx_uint_t type)
                 continue;
             }
 
+            if (module->ctx_index == NGX_MODULE_UNSET_INDEX) {
+                continue;
+            }
+
             if (module->ctx_index > max) {
                 max = module->ctx_index;
             }


### PR DESCRIPTION
## Problem
When reloading nginx configuration, ngx_count_modules() processes modules
from both the new cycle and old_cycle. Modules that were loaded in the
old configuration but are no longer present (e.g. a dynamic stream module
when the "stream" block is removed) retain ctx_index == NGX_MODULE_UNSET_INDEX
in old_cycle->modules.

Since NGX_MODULE_UNSET_INDEX is defined as (ngx_uint_t) -1 (i.e. the
maximum value of ngx_uint_t), comparing it with the unsigned 'max'
variable causes 'max' to be set to this large value. The subsequent
'max + 1' wraps around to 0 due to unsigned integer overflow.

This results in ngx_count_modules() returning 0, leading to zero-sized
memory allocations for module contexts. Later, during stream module
initialization, this causes a segmentation fault (e.g. in
ngx_stream_add_listen()).

## Reproduction Steps
1. Start nginx with the attached configuration file
2. Uncomment the stream section and comment out the stream module load_module directive
3. Perform a configuration reload (nginx -s reload)
4. Master process crashes with SIGSEGV.
 configuration file:
```
load_module /opt/nginx/modules/ngx_stream_server_traffic_status_module.so;
worker_processes  1;

events {
    worker_connections  8192;
}

# stream {
#     server {
#         listen 8898;
#         return "aboba";
#     }
# }

http {
    server {
        listen 127.0.0.1:8888;
        location / {            return 200 "Ok";}
    }
}
```

## Solution
Skip modules with `NGX_MODULE_UNSET_INDEX` in the `old_cycle` processing loop to prevent the underflow and ensure correct module counting.

Special thanks to Yuri Vitalievich Apalkov and Kirill Eduardovich Bolshakov for their assistance in discovering this bug.