### PR TITLE
Overflow in ngx_palloc_small() with alignment

### DIFF
--- a/src/core/ngx_palloc.c
+++ b/src/core/ngx_palloc.c
@@ -160,7 +160,7 @@ ngx_palloc_small(ngx_pool_t *pool, size_t size, ngx_uint_t align)
             m = ngx_align_ptr(m, NGX_ALIGNMENT);
         }
 
-        if ((size_t) (p->d.end - m) >= size) {
+        if (p->d.end - size >= m) {
             p->d.last = m + size;
 
             return m;


### PR DESCRIPTION
Hi,

I admit there are only a few situations in which this bug can be triggered. One such case is when a memory block is allocated with `ngx_create_pool()` using a size that is not aligned to the `NGX_ALIGNMENT` boundary. Then, if chunks are allocated from that block using `ngx_palloc()`, the block boundary may eventually be overrun. I understand that `ngx_create_pool()` is never called with a misaligned size in the NGINX code itself, but some third-party modules may be unaware of this.