### PR TITLE
Proxy: fixed segfault in URI change (issue #983).

### DIFF
--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -1206,7 +1206,8 @@ ngx_http_proxy_create_key(ngx_http_request_t *r)
         return NGX_OK;
     }
 
-    loc_len = (r->valid_location && ctx->vars.uri.len) ? plcf->location.len : 0;
+    loc_len = (r->valid_location && ctx->vars.uri.len)
+              ? ngx_min(plcf->location.len, r->uri.len) : 0;
 
     if (r->quoted_uri || r->internal) {
         escape = 2 * ngx_escape_uri(NULL, r->uri.data + loc_len,
@@ -1318,8 +1319,8 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
         uri_len = r->unparsed_uri.len;
 
     } else {
-        loc_len = (r->valid_location && ctx->vars.uri.len) ?
-                      plcf->location.len : 0;
+        loc_len = (r->valid_location && ctx->vars.uri.len)
+                  ? ngx_min(plcf->location.len, r->uri.len) : 0;
 
         if (r->quoted_uri || r->internal) {
             escape = 2 * ngx_escape_uri(NULL, r->uri.data + loc_len,


### PR DESCRIPTION
Proxy: fixed segfault in URI change.

The problem occurred in proxy_pass specified with URI, if request URI
was shorter than location prefix, as after replacement with try_files.
The fix is to replace full request URI in this case.  In the following
configuration request "/123" sent to backend is changed to "/".

    location /1234 {
        try_files /123 =404;
        proxy_pass http://127.0.0.1:8080/;
    }

Closes #983 on GitHub.