### PR TITLE
QUIC: handle ACK_ECN frames (fixes #945)

### DIFF
--- a/src/event/quic/ngx_event_quic.c
+++ b/src/event/quic/ngx_event_quic.c
@@ -1231,6 +1231,7 @@ ngx_quic_handle_frames(ngx_connection_t *c, ngx_quic_header_t *pkt)
         switch (frame.type) {
 
         case NGX_QUIC_FT_ACK:
+        case NGX_QUIC_FT_ACK_ECN:
             if (ngx_quic_handle_ack_frame(c, pkt, &frame) != NGX_OK) {
                 return NGX_ERROR;
             }


### PR DESCRIPTION
The QUIC frame dispatcher was missing the case for ACK_ECN frames (type 0x03), causing connections to be closed with "missing frame handler" error when clients send ECN counts.

RFC 9000 §19.3 requires implementations to handle both ACK (0x02) and ACK_ECN (0x03) frame types. Since ngx_quic_handle_ack_frame() already correctly processes both types, adding the case statement is sufficient to fix the issue.

Identified and fixed through AI-orchestrated development: bug identified by https://need2talk.it founder, root cause analysis and fix implementation by Claude Code (Anthropic).

Tested in production on https://need2talk.it with HTTP/3 enabled. The fix follows the same approach as Cloudflare quiche #1053.

### Proposed changes

Describe the use case and detail of the change.

If this pull request addresses an issue on GitHub, make sure to reference that
issue using one of the
[supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).

Before creating a pull request, make sure to comply with the
[Contributing Guidelines](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md).
