### PR TITLE
HTTP/2: Fix window size calculation to consider data frames only.

### DIFF
--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -4342,7 +4342,9 @@ ngx_http_v2_read_client_request_body_handler(ngx_http_request_t *r)
 
     window = buf->end - buf->start;
 
-    if (h2c->state.stream == stream) {
+    if (h2c->state.stream == stream
+        && h2c->state.handler == ngx_http_v2_state_read_data)
+    {
         window -= h2c->state.length;
     }
 


### PR DESCRIPTION
### Proposed changes

The frame type must be considered when subtracting the frame length from the window size.
This code path can be reached if nginx receives an incomplete window update frame, where its length will be considered for the window size and an internal server error will occur along with the 'http2 negative window update' log, even if the remainder of the window update bytes arrives later.