### PR TITLE
SSL: avoid warning when ECH is not configured and not supported.

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -1741,9 +1741,12 @@ cleanup:
     return rc;
 
 #else
-    ngx_log_error(NGX_LOG_WARN, ssl->log, 0,
-                  "\"ssl_ech_file\" is not supported on this platform, "
-                  "ignored");
+    if (filenames != NULL) {
+        ngx_log_error(NGX_LOG_WARN, ssl->log, 0,
+                      "\"ssl_ech_file\" is not supported on this platform, "
+                      "ignored");
+    }
+
     return NGX_OK;
 #endif
 }


### PR DESCRIPTION
### Summary

Avoid an unconditional  
`"ssl_ech_file" is not supported on this platform, ignored`  warning when nginx is built against a TLS library without ECH support (`SSL_OP_ECH_GREASE` is absent) and no `ssl_ech_file` directive is configured.

### Details

- Currently, `ngx_ssl_ech_files()` logs this warning in the `#ifndef SSL_OP_ECH_GREASE` path regardless of whether `ech_files` is `NULL`.
- As a result, users who do not use ECH still see a spurious warning on `nginx -t` / `nginx -T` when nginx is linked against libraries such as LibreSSL or OpenSSL builds without ECH support.
- This change makes `ngx_ssl_ech_files()` log the warning only when `ech_files` is not `NULL` (i.e. an `ssl_ech_file` directive is actually configured), while still returning `NGX_OK` when ECH is not available.

### Testing

- Built nginx from `master` against LibreSSL 4.2.0.
- Verified `nginx -t` with no `ssl_ech_file` directive no longer emits the warning.
