### PR TITLE
HTTP: allow hyphens in variable names inside ${}.

### DIFF
--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -535,6 +535,10 @@ ngx_http_script_compile(ngx_http_script_compile_t *sc)
                     continue;
                 }
 
+                if (ch == '-' && bracket) {
+                    continue;
+                }
+
                 break;
             }
 


### PR DESCRIPTION
Currently, nginx variables cannot contain hyphens. This makes it impossible to access request arguments like "?my-param=123" directly.

The expression "$arg_my-param" is currently parsed as the variable "$arg_my" followed by the literal string "-param", rather than a single variable "$arg_my-param".

This patch adds support for hyphens in variable names, but only when enclosed in curly braces. Now it is possible to use "${arg_my-param}".

Variables without braces (e.g. "$foo-bar") remain unchanged to preserve compatibility with existing configurations where hyphens are used as separators.
