### PR TITLE
Fix log message formatting in request limiting

### DIFF
--- a/src/http/modules/ngx_http_limit_req_module.c
+++ b/src/http/modules/ngx_http_limit_req_module.c
@@ -267,7 +267,7 @@ ngx_http_limit_req_handler(ngx_http_request_t *r)
 
         if (rc == NGX_BUSY) {
             ngx_log_error(lrcf->limit_log_level, r->connection->log, 0,
-                        "limiting requests%s, excess: %ui.%03ui by zone \"%V\"",
+                        "limiting request%s, excess: %ui.%03ui, by zone \"%V\"",
                         lrcf->dry_run ? ", dry run" : "",
                         excess / 1000, excess % 1000,
                         &limit->shm_zone->shm.name);


### PR DESCRIPTION
Eliminate differences between this log message and the related log message in line 302 which is written when requests are merely delayed. Makes it easier to decompose the log entries with tools like Filebeat (ELK stack).