### PR TITLE
Disabled bare LF in chunked transfer encoding.

### DIFF
--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -2119,7 +2119,7 @@ ngx_http_proxy_input_filter_init(void *data)
         /* chunked */
 
         u->pipe->input_filter = ngx_http_proxy_chunked_filter;
-        u->pipe->length = 3; /* "0" LF LF */
+        u->pipe->length = 5; /* "0" CRLF CRLF */
 
         u->input_filter = ngx_http_proxy_non_buffered_chunked_filter;
         u->length = 1;


### PR DESCRIPTION
Chunked transfer encoding, since originally introduced in HTTP/1.1 in RFC 2068, is specified to use CRLF as the only line terminator.

Although tolerant applications may recognize a single LF (discussed previously at [1]), formally this covers the start line and fields, and doesn't apply to chunks.  Strict chunked parsing is reaffirmed as intentional in RFC errata ID 7633, notably "because it does not have to retain backwards compatibility with 1.0 parsers".

A general RFC 2616 recommendation to tolerate deviations interpreted unambiguously barely applies to chunks as they are used to determine HTTP message framing, and ambiguity may result in potentially broken delimitation.  In contrast, accepting a single LF may pose an extra condition for potential request smuggling in complex scenarios.  For instance, this is possible when receiving chunks from intermediates that misinterpret LF as part of a valid chunk-ext-name and pass it further without re-coding.  The change aims to address this as well.

[1] https://mailman.nginx.org/pipermail/nginx-devel/2024-January/5CQQCHFYQMXTBAK7H2FITLVQQS5ECFFM.html
