### PR TITLE
Quic: fixed segfault on handshake failure

### DIFF
--- a/src/event/quic/ngx_event_quic_ssl.c
+++ b/src/event/quic/ngx_event_quic_ssl.c
@@ -185,7 +185,13 @@ ngx_quic_cbs_release_rcd(ngx_ssl_conn_t *ssl_conn, size_t bytes_read, void *arg)
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
                    "quic ngx_quic_cbs_release_rcd len:%uz", bytes_read);
 
+    /* already closed on handshake failure */
+
     qc = ngx_quic_get_connection(c);
+    if (qc == NULL) {
+        return 1;
+    }
+
     ctx = ngx_quic_get_send_ctx(qc, qc->read_level);
 
     cl = ngx_quic_read_buffer(c, &ctx->crypto, bytes_read);


### PR DESCRIPTION
Return if ngx_quic_get_connection is NULL to avoid segfault, as in ngx_quic_cbs_alert.

Fixes #1021

### Proposed changes

Fix segfault in ngx_quic_cbs_release_rcd when ngx_quic_get_connection returns NULL during handshake failure, similar to the check in ngx_quic_cbs_alert.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [ x ] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [ x ] I have checked that NGINX compiles and runs after adding my changes.

