### PR TITLE
nginx-1.29.4-RELEASE

### DIFF
--- a/docs/xml/nginx/changes.xml
+++ b/docs/xml/nginx/changes.xml
@@ -5,6 +5,85 @@
 <change_log title="nginx">
 
 
+<changes ver="1.29.4" date="2025-12-09">
+
+<change type="feature">
+<para lang="ru">
+модуль ngx_http_proxy_module поддерживает HTTP/2.
+</para>
+<para lang="en">
+the ngx_http_proxy_module supports HTTP/2.
+</para>
+</change>
+
+<change type="feature">
+<para lang="ru">
+поддержка расширения TLS Encrypted ClientHello
+при использовании ветки разработки ECH OpenSSL;
+директива ssl_ech_file.<br/>
+Спасибо Stephen Farrell.
+</para>
+<para lang="en">
+Encrypted ClientHello TLS extension support
+when using OpenSSL ECH feature branch;
+the "ssl_ech_file" directive.<br/>
+Thanks to Stephen Farrell.
+</para>
+</change>
+
+<change type="change">
+<para lang="ru">
+валидация хоста и порта в строке запроса,
+в заголовке "Host" и псевдо-заголовке ":authority"
+изменена на соответствующую RFC 3986.
+</para>
+<para lang="en">
+validation of host and port in the request line,
+"Host" header field, and ":authority" pseudo-header field
+has been changed to follow RFC 3986.
+</para>
+</change>
+
+<change type="change">
+<para lang="ru">
+теперь одиночный символ LF, используемый для перевода строки
+в chunked-теле запроса или ответа, считается ошибкой.
+</para>
+<para lang="en">
+now a single LF used as a line terminator
+in a chunked request or response body is considered an error.
+</para>
+</change>
+
+<change type="bugfix">
+<para lang="ru">
+при использовании HTTP/3 с OpenSSL 3.5.1 и новее
+в рабочем процессе мог произойти segmentation fault;
+ошибка появилась в 1.29.1.<br/>
+Спасибо Jan Svojanovsky.
+</para>
+<para lang="en">
+when using HTTP/3 with OpenSSL 3.5.1 or newer
+a segmentation fault might occur in a worker process;
+the bug had appeared in 1.29.1.<br/>
+Thanks to Jan Svojanovsky.
+</para>
+</change>
+
+<change type="bugfix">
+<para lang="ru">
+при совместном использовании директив try_files и proxy_pass с URI
+в рабочем процессе мог произойти segmentation fault.
+</para>
+<para lang="en">
+a segmentation fault might occur in a worker process
+if the "try_files" directive and "proxy_pass" with a URI were used.
+</para>
+</change>
+
+</changes>
+
+
 <changes ver="1.29.3" date="2025-10-28">
 
 <change type="feature">


### PR DESCRIPTION
en
```
Changes with nginx 1.29.4                                        09 Dec 2025

    *) Feature: the ngx_http_proxy_module supports HTTP/2.

    *) Feature: Encrypted ClientHello TLS extension support when using
       OpenSSL ECH feature branch; the "ssl_ech_file" directive.
       Thanks to Stephen Farrell.

    *) Change: validation of host and port in the request line, "Host"
       header field, and ":authority" pseudo-header field has been changed
       to follow RFC 3986.

    *) Change: now a single LF used as a line terminator in a chunked
       request or response body is considered an error.

    *) Bugfix: when using HTTP/3 with OpenSSL 3.5.1 or newer a segmentation
       fault might occur in a worker process; the bug had appeared in
       1.29.1.
       Thanks to Jan Svojanovsky.

    *) Bugfix: a segmentation fault might occur in a worker process if the
       "try_files" directive and "proxy_pass" with a URI were used.
```
ru
```
Изменения в nginx 1.29.4                                          09.12.2025

    *) Добавление: модуль ngx_http_proxy_module поддерживает HTTP/2.

    *) Добавление: поддержка расширения TLS Encrypted ClientHello при
       использовании ветки разработки ECH OpenSSL; директива ssl_ech_file.
       Спасибо Stephen Farrell.

    *) Изменение: валидация хоста и порта в строке запроса, в заголовке
       "Host" и псевдо-заголовке ":authority" изменена на соответствующую
       RFC 3986.

    *) Изменение: теперь одиночный символ LF, используемый для перевода
       строки в chunked-теле запроса или ответа, считается ошибкой.

    *) Исправление: при использовании HTTP/3 с OpenSSL 3.5.1 и новее в
       рабочем процессе мог произойти segmentation fault; ошибка появилась в
       1.29.1.
       Спасибо Jan Svojanovsky.

    *) Исправление: при совместном использовании директив try_files и
       proxy_pass с URI в рабочем процессе мог произойти segmentation fault.
```