### PR TITLE
Stream: fix possible NULL pointer dereference

### DIFF
--- a/src/stream/ngx_stream_upstream_hash_module.c
+++ b/src/stream/ngx_stream_upstream_hash_module.c
@@ -535,7 +535,7 @@ ngx_stream_upstream_init_chash_peer(ngx_stream_session_t *s,
     }
 #endif
 
-    if (hcf->points->number) {
+    if (hcf->points && hcf->points->number) {
         hp->hash = ngx_stream_upstream_find_chash_point(hcf->points, hash);
     }
 


### PR DESCRIPTION
### Proposed changes

This change adds an extra NULL-check for `hcf->points` in `ngx_stream_upstream_init_chash_peer()`.

The condition

```
if (hp->rrp.peers->config
    && (hcf->points == NULL || hcf->config != *hp->rrp.peers->config))
```

does not clearly guarantee that `hcf->points` will be set after the update. Because of that, `hcf->points` may still be NULL when the code later accesses `hcf->points->number`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [+] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [+] I have checked that NGINX compiles and runs after adding my changes.
