### PR TITLE
Decopling of the proxy and HTTP/2 modules, and related fun

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -102,7 +102,16 @@ if [ $HTTP = YES ]; then
     fi
 
 
-    if [ $HTTP_V2 = YES -o $HTTP_V3 = YES ]; then
+    if [ $HTTP_V2 = YES ]; then
+        have=NGX_HTTP_V2_SUPPORT . auto/have
+        USE_HTTP_V2=YES
+
+        HTTP_INCS="$HTTP_INCS $HTTP_V2_INCS"
+        HTTP_DEPS="$HTTP_DEPS $HTTP_V2_DEPS"
+        HTTP_SRCS="$HTTP_SRCS $HTTP_V2_SRCS"
+    fi
+
+    if [ $USE_HTTP_V2 = YES -o $HTTP_V3 = YES ]; then
         HTTP_SRCS="$HTTP_SRCS $HTTP_HUFF_SRCS"
     fi
 
@@ -425,12 +434,9 @@ if [ $HTTP = YES ]; then
         have=NGX_HTTP_V2 . auto/have
 
         ngx_module_name=ngx_http_v2_module
-        ngx_module_incs=src/http/v2
-        ngx_module_deps="src/http/v2/ngx_http_v2.h \
-                         src/http/v2/ngx_http_v2_module.h"
+        ngx_module_incs=
+        ngx_module_deps=src/http/v2/ngx_http_v2_module.h
         ngx_module_srcs="src/http/v2/ngx_http_v2.c \
-                         src/http/v2/ngx_http_v2_table.c \
-                         src/http/v2/ngx_http_v2_encode.c \
                          src/http/v2/ngx_http_v2_module.c"
         ngx_module_libs=
         ngx_module_link=$HTTP_V2

--- a/auto/modules
+++ b/auto/modules
@@ -102,7 +102,7 @@ if [ $HTTP = YES ]; then
     fi
 
 
-    if [ $HTTP_V2 = YES ]; then
+    if [ $HTTP_V2 = YES -o $HTTP_PROXY = YES ]; then
         have=NGX_HTTP_V2_SUPPORT . auto/have
         USE_HTTP_V2=YES
 
@@ -741,6 +741,15 @@ if [ $HTTP = YES ]; then
         ngx_module_link=$HTTP_PROXY
 
         . auto/module
+
+        ngx_module_name=ngx_http_proxy_v2_module
+        ngx_module_incs=
+        ngx_module_deps=
+        ngx_module_srcs=src/http/modules/ngx_http_proxy_v2_module.c
+        ngx_module_libs=
+        ngx_module_link=$HTTP_PROXY
+
+        . auto/module
     fi
 
     if [ $HTTP_FASTCGI = YES ]; then
@@ -783,17 +792,6 @@ if [ $HTTP = YES ]; then
         ngx_module_srcs=src/http/modules/ngx_http_grpc_module.c
         ngx_module_libs=
         ngx_module_link=$HTTP_GRPC
-
-        . auto/module
-    fi
-
-    if [ $HTTP_PROXY = YES -a $HTTP_V2 = YES ]; then
-        ngx_module_name=ngx_http_proxy_v2_module
-        ngx_module_incs=
-        ngx_module_deps=
-        ngx_module_srcs=src/http/modules/ngx_http_proxy_v2_module.c
-        ngx_module_libs=
-        ngx_module_link=$HTTP_V2
 
         . auto/module
     fi

--- a/auto/modules
+++ b/auto/modules
@@ -102,7 +102,7 @@ if [ $HTTP = YES ]; then
     fi
 
 
-    if [ $HTTP_V2 = YES -o $HTTP_PROXY = YES ]; then
+    if [ $HTTP_V2 = YES -o $HTTP_PROXY = YES -o $HTTP_GRPC = YES ]; then
         have=NGX_HTTP_V2_SUPPORT . auto/have
         USE_HTTP_V2=YES
 
@@ -785,7 +785,7 @@ if [ $HTTP = YES ]; then
         . auto/module
     fi
 
-    if [ $HTTP_GRPC = YES -a $HTTP_V2 = YES ]; then
+    if [ $HTTP_GRPC = YES ]; then
         ngx_module_name=ngx_http_grpc_module
         ngx_module_incs=
         ngx_module_deps=

--- a/auto/sources
+++ b/auto/sources
@@ -259,3 +259,8 @@ HTTP_FILE_CACHE_SRCS=src/http/ngx_http_file_cache.c
 
 HTTP_HUFF_SRCS="src/http/ngx_http_huff_decode.c
                 src/http/ngx_http_huff_encode.c"
+
+HTTP_V2_INCS=src/http/v2
+HTTP_V2_DEPS=src/http/v2/ngx_http_v2.h
+HTTP_V2_SRCS="src/http/v2/ngx_http_v2_table.c
+              src/http/v2/ngx_http_v2_encode.c"

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -198,9 +198,7 @@ static ngx_conf_post_t  ngx_http_proxy_ssl_conf_command_post =
 static ngx_conf_enum_t  ngx_http_proxy_http_version[] = {
     { ngx_string("1.0"), NGX_HTTP_VERSION_10 },
     { ngx_string("1.1"), NGX_HTTP_VERSION_11 },
-#if (NGX_HTTP_V2)
     { ngx_string("2"), NGX_HTTP_VERSION_20 },
-#endif
     { ngx_null_string, 0 }
 };
 
@@ -880,11 +878,9 @@ ngx_http_proxy_handler(ngx_http_request_t *r)
 
     plcf = ngx_http_get_module_loc_conf(r, ngx_http_proxy_module);
 
-#if (NGX_HTTP_V2)
     if (plcf->http_version == NGX_HTTP_VERSION_20) {
         return ngx_http_proxy_v2_handler(r);
     }
-#endif
 
     if (ngx_http_upstream_create(r) != NGX_OK) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;

--- a/src/http/modules/ngx_http_proxy_module.h
+++ b/src/http/modules/ngx_http_proxy_module.h
@@ -116,9 +116,7 @@ ngx_int_t ngx_http_proxy_rewrite_redirect(ngx_http_request_t *r,
 ngx_int_t ngx_http_proxy_rewrite_cookie(ngx_http_request_t *r,
     ngx_table_elt_t *h);
 
-#if (NGX_HTTP_V2)
 ngx_int_t ngx_http_proxy_v2_handler(ngx_http_request_t *r);
-#endif
 
 
 extern ngx_module_t  ngx_http_proxy_module;

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -37,7 +37,7 @@ typedef u_char *(*ngx_http_log_handler_pt)(ngx_http_request_t *r,
 #include <ngx_http_upstream_round_robin.h>
 #include <ngx_http_core_module.h>
 
-#if (NGX_HTTP_V2)
+#if (NGX_HTTP_V2_SUPPORT)
 #include <ngx_http_v2.h>
 #endif
 #if (NGX_HTTP_V3)
@@ -177,7 +177,7 @@ ngx_uint_t  ngx_http_degraded(ngx_http_request_t *);
 #endif
 
 
-#if (NGX_HTTP_V2 || NGX_HTTP_V3)
+#if (NGX_HTTP_V2_SUPPORT || NGX_HTTP_V3)
 ngx_int_t ngx_http_huff_decode(u_char *state, u_char *src, size_t len,
     u_char **dst, ngx_uint_t last, ngx_log_t *log);
 size_t ngx_http_huff_encode(u_char *src, size_t len, u_char *dst,


### PR DESCRIPTION
Inspired mostly by a bogus requirement to enable ngx_http_v2_module
in order to configure "proxy_http_version 2;".

This becomes noticeable with a generic HTTP/2 upstream support,
which unlike gRPC is not bound to HTTP/2 on the client side.

The series mostly follows the previous huffman decoupling from ngx_http_v2_module.