### PR TITLE
Fixed duplicate ids in the bug report template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,7 +58,7 @@ body:
       required: true
 
   - type: textarea
-    id: environment
+    id: version
     attributes:
       label: NGINX version and build configuration options
       description: Please provide details about your NGINX build.
@@ -79,7 +79,7 @@ body:
       required: true
 
   - type: textarea
-    id: environment
+    id: architecture
     attributes:
       label: Architecture where NGINX is being built and/or deployed
       description: Please provide details about your deployment environment.

--- a/src/core/nginx.h
+++ b/src/core/nginx.h
@@ -9,8 +9,8 @@
 #define _NGINX_H_INCLUDED_
 
 
-#define nginx_version      1029004
-#define NGINX_VERSION      "1.29.4"
+#define nginx_version      1029005
+#define NGINX_VERSION      "1.29.5"
 #define NGINX_VER          "nginx/" NGINX_VERSION
 
 #ifdef NGX_BUILD


### PR DESCRIPTION
The new set of issue templates does not allow reporting bugs. Apparently, GitHub ignores bug_report.yml because it does not pass validation: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#body-must-have-unique-ids