### PR TITLE
Dynamic configuration reload

### DIFF
--- a/auto/configure
+++ b/auto/configure
@@ -59,8 +59,8 @@ if [ "$NGX_PLATFORM" != win32 ]; then
     . auto/unix
 fi
 
-. auto/threads
 . auto/modules
+. auto/threads
 . auto/lib/conf
 
 case ".$NGX_PREFIX" in

--- a/auto/modules
+++ b/auto/modules
@@ -1406,6 +1406,15 @@ fi
 modules="$CORE_MODULES $EVENT_MODULES"
 
 
+if [ $NGX_DYNAMIC_CONF = YES ]; then
+    USE_THREADS=YES
+    have=NGX_DYNAMIC_CONF . auto/have
+    modules="$modules $DYNAMIC_CONF_MODULE"
+    CORE_DEPS="$CORE_DEPS $DYNAMIC_CONF_DEPS"
+    CORE_SRCS="$CORE_SRCS $DYNAMIC_CONF_SRCS"
+fi
+
+
 # thread pool module should be initialized after events
 if [ $USE_THREADS = YES ]; then
     modules="$modules $THREAD_POOL_MODULE"

--- a/auto/options
+++ b/auto/options
@@ -45,6 +45,8 @@ USE_THREADS=NO
 
 NGX_FILE_AIO=NO
 
+NGX_DYNAMIC_CONF=NO
+
 QUIC_BPF=NO
 
 HTTP=YES
@@ -217,6 +219,8 @@ do
         --with-threads)                  USE_THREADS=YES            ;;
 
         --with-file-aio)                 NGX_FILE_AIO=YES           ;;
+
+        --with-dynamic-conf)             NGX_DYNAMIC_CONF=YES       ;;
 
         --without-quic_bpf_module)       QUIC_BPF=NONE              ;;
 
@@ -453,6 +457,8 @@ cat << END
   --with-threads                     enable thread pool support
 
   --with-file-aio                    enable file AIO support
+
+  --with-dynamic-conf                enable dynamic configuration support
 
   --without-quic_bpf_module          disable ngx_quic_bpf_module
 

--- a/auto/sources
+++ b/auto/sources
@@ -191,6 +191,10 @@ THREAD_POOL_SRCS="src/core/ngx_thread_pool.c
                   src/os/unix/ngx_thread_mutex.c
                   src/os/unix/ngx_thread_id.c"
 
+DYNAMIC_CONF_MODULE=ngx_dynamic_conf_module
+DYNAMIC_CONF_DEPS=src/core/ngx_dynamic_conf.h
+DYNAMIC_CONF_SRCS="src/core/ngx_dynamic_conf.c"
+
 FREEBSD_DEPS="src/os/unix/ngx_freebsd_config.h src/os/unix/ngx_freebsd.h"
 FREEBSD_SRCS=src/os/unix/ngx_freebsd_init.c
 FREEBSD_SENDFILE_SRCS=src/os/unix/ngx_freebsd_sendfile_chain.c

--- a/auto/threads
+++ b/auto/threads
@@ -7,7 +7,7 @@ if [ $USE_THREADS = YES ]; then
     if [ "$NGX_PLATFORM" = win32 ]; then
         cat << END
 
-$0: --with-threads is not supported on Windows
+$0: threads are not supported on Windows
 
 END
         exit 1

--- a/auto/unix
+++ b/auto/unix
@@ -833,6 +833,16 @@ ngx_feature_test="void *p; p = memalign(4096, 4096);
 . auto/feature
 
 
+ngx_feature="malloc_trim()"
+ngx_feature_name="NGX_HAVE_MALLOC_TRIM"
+ngx_feature_run=no
+ngx_feature_incs="#include <malloc.h>"
+ngx_feature_path=
+ngx_feature_libs=
+ngx_feature_test="malloc_trim(0)"
+. auto/feature
+
+
 ngx_feature="mmap(MAP_ANON|MAP_SHARED)"
 ngx_feature_name="NGX_HAVE_MAP_ANON"
 ngx_feature_run=yes

--- a/src/core/ngx_config.h
+++ b/src/core/ngx_config.h
@@ -70,6 +70,10 @@
 #define NGX_CHANGEBIN_SIGNAL     USR2
 #endif
 
+#if (NGX_DYNAMIC_CONF)
+#define NGX_UPDATE_SIGNAL        URG
+#endif
+
 #define ngx_cdecl
 #define ngx_libc_cdecl
 

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -47,6 +47,7 @@ struct ngx_listening_s {
     size_t              post_accept_buffer_size;
 
     ngx_listening_t    *previous;
+    ngx_listening_t    *next;
     ngx_connection_t   *connection;
 
     ngx_rbtree_t        rbtree;

--- a/src/core/ngx_cycle.h
+++ b/src/core/ngx_cycle.h
@@ -76,6 +76,8 @@ struct ngx_cycle_s {
 
     ngx_cycle_t              *old_cycle;
 
+    ngx_uint_t                dynamic;         /* unsigned  dynamic:1; */
+
     ngx_str_t                 conf_file;
     ngx_str_t                 conf_param;
     ngx_str_t                 conf_prefix;

--- a/src/core/ngx_dynamic_conf.c
+++ b/src/core/ngx_dynamic_conf.c
@@ -864,6 +864,10 @@ ngx_dynamic_conf_unload(ngx_dynamic_conf_ctx_t *ctx)
                    ctx->cycle, ctx->id);
 
     ngx_destroy_pool(ctx->pool);
+
+#if (NGX_HAVE_MALLOC_TRIM)
+    malloc_trim(0);
+#endif
 }
 
 

--- a/src/core/ngx_dynamic_conf.c
+++ b/src/core/ngx_dynamic_conf.c
@@ -1,0 +1,866 @@
+
+/*
+ * Copyright (C) Roman Arutyunyan
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <nginx.h>
+#include <ngx_thread_pool.h>
+#include <ngx_dynamic_conf.h>
+
+
+typedef struct {
+    ngx_pool_t               *pool;
+    ngx_log_t                *log;
+    ngx_cycle_t              *main_cycle;
+    ngx_cycle_t              *cycle;
+    ngx_thread_task_t        *task;
+    ngx_uint_t                count;
+#if (NGX_DEBUG)
+    ngx_uint_t                id;
+#endif
+} ngx_dynamic_conf_ctx_t;
+
+
+typedef struct {
+    ngx_str_t                 threads;
+    ngx_thread_pool_t        *thread_pool;
+    ngx_dynamic_conf_ctx_t   *ctx;
+#if (NGX_DEBUG)
+    ngx_uint_t                id;
+#endif
+} ngx_dynamic_conf_t;
+
+
+static void *ngx_dynamic_conf_create_conf(ngx_cycle_t *cycle);
+static char *ngx_dynamic_conf_init_conf(ngx_cycle_t *cycle, void *conf);
+static void ngx_dynamic_conf_exit_worker(ngx_cycle_t *cycle);
+static void ngx_dynamic_conf_load_handler(void *data, ngx_log_t *log);
+static void ngx_dynamic_conf_loaded(ngx_event_t *event);
+static void ngx_dynamic_conf_cleanup(void *data);
+static void ngx_dynamic_conf_unload(ngx_dynamic_conf_ctx_t *ctx);
+static void ngx_dynamic_conf_install(ngx_dynamic_conf_ctx_t *ctx);
+static void ngx_dynamic_conf_pass_connection(ngx_connection_t *c);
+
+
+static ngx_command_t  ngx_dynamic_conf_commands[] = {
+
+    { ngx_string("dynamic_conf_threads"),
+      NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      0,
+      offsetof(ngx_dynamic_conf_t, threads),
+      NULL },
+
+      ngx_null_command
+};
+
+
+static ngx_core_module_t  ngx_dynamic_conf_module_ctx = {
+    ngx_string("dynamic_conf"),
+    ngx_dynamic_conf_create_conf,
+    ngx_dynamic_conf_init_conf
+};
+
+
+ngx_module_t  ngx_dynamic_conf_module = {
+    NGX_MODULE_V1,
+    &ngx_dynamic_conf_module_ctx,          /* module context */
+    ngx_dynamic_conf_commands,             /* module directives */
+    NGX_CORE_MODULE,                       /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    NULL,                                  /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    ngx_dynamic_conf_exit_worker,          /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+static void *
+ngx_dynamic_conf_create_conf(ngx_cycle_t *cycle)
+{
+    ngx_dynamic_conf_t  *dcf;
+
+    dcf = ngx_pcalloc(cycle->pool, sizeof(ngx_dynamic_conf_t));
+    if (dcf == NULL) {
+        return NULL;
+    }
+
+    /*
+     * set by ngx_pcalloc():
+     *
+     *     dcf->threads = { 0, NULL };
+     */
+
+    return dcf;
+}
+
+
+static char *
+ngx_dynamic_conf_init_conf(ngx_cycle_t *cycle, void *conf)
+{
+    ngx_dynamic_conf_t  *dcf = conf;
+
+    if (dcf->threads.data == NULL) {
+        dcf->thread_pool = ngx_thread_pool_add(cycle, NULL);
+
+    } else {
+        dcf->thread_pool = ngx_thread_pool_add(cycle, &dcf->threads);
+    }
+
+    if (dcf->thread_pool == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+static void
+ngx_dynamic_conf_exit_worker(ngx_cycle_t *cycle)
+{
+    ngx_dynamic_conf_t      *dcf;
+    ngx_dynamic_conf_ctx_t  *ctx;
+
+    if (ngx_process != NGX_PROCESS_WORKER
+        && ngx_process != NGX_PROCESS_SINGLE)
+    {
+        return;
+    }
+
+    dcf = (ngx_dynamic_conf_t *) ngx_get_conf(cycle->conf_ctx,
+                                              ngx_dynamic_conf_module);
+
+    ctx = dcf->ctx;
+
+    if (ctx == NULL) {
+        return;
+    }
+
+    if (ctx->cycle == NULL) {
+        ngx_destroy_pool(ctx->pool);
+        return;
+    }
+
+    ngx_dynamic_conf_unload(ctx);
+}
+
+
+ngx_int_t
+ngx_dynamic_conf_update(ngx_cycle_t *cycle)
+{
+    ngx_pool_t              *pool;
+    ngx_thread_task_t       *task;
+    ngx_dynamic_conf_t      *dcf;
+    ngx_dynamic_conf_ctx_t  *ctx;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_CORE, cycle->log, 0, "dynamic conf update");
+
+    pool = ngx_create_pool(NGX_CYCLE_POOL_SIZE, cycle->log);
+    if (pool == NULL) {
+        return NGX_ERROR;
+    }
+
+    task = ngx_thread_task_alloc(pool, sizeof(ngx_dynamic_conf_ctx_t));
+    if (task == NULL) {
+        ngx_destroy_pool(pool);
+        return NGX_ERROR;
+    }
+
+    task->handler = ngx_dynamic_conf_load_handler;
+    task->event.handler = ngx_dynamic_conf_loaded;
+    task->event.log = cycle->log;
+    task->event.data = task->ctx;
+
+    ctx = task->ctx;
+    ctx->pool = pool;
+    ctx->log = cycle->log;
+    ctx->main_cycle = cycle;
+    ctx->task = task;
+
+    dcf = (ngx_dynamic_conf_t *) ngx_get_conf(cycle->conf_ctx,
+                                              ngx_dynamic_conf_module);
+#if (NGX_DEBUG)
+    ctx->id = dcf->id++;
+#endif
+
+    return ngx_thread_task_post(dcf->thread_pool, task);
+}
+
+
+static void
+ngx_dynamic_conf_load_handler(void *data, ngx_log_t *log)
+{
+    ngx_dynamic_conf_ctx_t  *ctx = data;
+
+    void               *rv;
+    ngx_int_t           rc;
+    ngx_uint_t          i, n;
+    ngx_conf_t          conf;
+    ngx_pool_t         *pool;
+    ngx_cycle_t        *cycle, *main_cycle;
+    ngx_shm_zone_t     *shm_zone, *oshm_zone;
+    ngx_listening_t    *ls, *nls;
+    ngx_list_part_t    *part, *opart;
+    ngx_open_file_t    *file, *ofile;
+    ngx_core_conf_t    *main_ccf;
+    ngx_core_module_t  *module;
+
+    main_cycle = ctx->main_cycle;
+    pool = ctx->pool;
+
+    cycle = ngx_pcalloc(pool, sizeof(ngx_cycle_t));
+    if (cycle == NULL) {
+        return;
+    }
+
+    cycle->pool = pool;
+    cycle->log = pool->log;
+    cycle->old_cycle = main_cycle;
+    cycle->dynamic = 1;
+    cycle->conf_prefix = main_cycle->conf_prefix;
+    cycle->prefix = main_cycle->prefix;
+    cycle->error_log = main_cycle->error_log;
+    cycle->conf_file = main_cycle->conf_file;
+    cycle->conf_param = main_cycle->conf_param;
+    cycle->hostname = main_cycle->hostname;
+    cycle->modules = main_cycle->modules;
+    cycle->modules_n = main_cycle->modules_n;
+
+    n = main_cycle->paths.nelts;
+
+    if (ngx_array_init(&cycle->paths, pool, n, sizeof(ngx_path_t *))
+        != NGX_OK)
+    {
+        return;
+    }
+
+    ngx_memzero(cycle->paths.elts, n * sizeof(ngx_path_t *));
+
+
+    if (ngx_array_init(&cycle->config_dump, pool, 1, sizeof(ngx_conf_dump_t))
+        != NGX_OK)
+    {
+        return;
+    }
+
+    ngx_rbtree_init(&cycle->config_dump_rbtree, &cycle->config_dump_sentinel,
+                    ngx_str_rbtree_insert_value);
+
+    if (main_cycle->open_files.part.nelts) {
+        n = main_cycle->open_files.part.nelts;
+        for (part = main_cycle->open_files.part.next; part; part = part->next) {
+            n += part->nelts;
+        }
+
+    } else {
+        n = 20;
+    }
+
+    if (ngx_list_init(&cycle->open_files, pool, n, sizeof(ngx_open_file_t))
+        != NGX_OK)
+    {
+        return;
+    }
+
+    if (main_cycle->shared_memory.part.nelts) {
+        n = main_cycle->shared_memory.part.nelts;
+        for (part = main_cycle->shared_memory.part.next; part;
+             part = part->next)
+        {
+            n += part->nelts;
+        }
+
+    } else {
+        n = 1;
+    }
+
+    if (ngx_list_init(&cycle->shared_memory, pool, n, sizeof(ngx_shm_zone_t))
+        != NGX_OK)
+    {
+        return;
+    }
+
+    n = main_cycle->listening.nelts ? main_cycle->listening.nelts : 1;
+
+    if (ngx_array_init(&cycle->listening, pool, n, sizeof(ngx_listening_t))
+        != NGX_OK)
+    {
+        return;
+    }
+
+    ngx_memzero(cycle->listening.elts, n * sizeof(ngx_listening_t));
+
+    cycle->conf_ctx = ngx_pcalloc(pool, ngx_max_module * sizeof(void *));
+    if (cycle->conf_ctx == NULL) {
+        return;
+    }
+
+
+    for (i = 0; cycle->modules[i]; i++) {
+        if (cycle->modules[i]->type != NGX_CORE_MODULE) {
+            continue;
+        }
+
+        module = cycle->modules[i]->ctx;
+
+        if (module->create_conf) {
+            rv = module->create_conf(cycle);
+            if (rv == NULL) {
+                return;
+            }
+            cycle->conf_ctx[cycle->modules[i]->index] = rv;
+        }
+    }
+
+
+    ngx_memzero(&conf, sizeof(ngx_conf_t));
+    /* STUB: init array ? */
+    conf.args = ngx_array_create(pool, 10, sizeof(ngx_str_t));
+    if (conf.args == NULL) {
+        return;
+    }
+
+    conf.temp_pool = ngx_create_pool(NGX_CYCLE_POOL_SIZE, log);
+    if (conf.temp_pool == NULL) {
+        return;
+    }
+
+
+    conf.ctx = cycle->conf_ctx;
+    conf.cycle = cycle;
+    conf.pool = pool;
+    conf.log = log;
+    conf.module_type = NGX_CORE_MODULE;
+    conf.cmd_type = NGX_MAIN_CONF;
+
+#if 0
+    log->log_level = NGX_LOG_DEBUG_ALL;
+#endif
+
+    if (ngx_conf_param(&conf) != NGX_CONF_OK) {
+        goto destroy_pools;
+    }
+
+    if (ngx_conf_parse(&conf, &cycle->conf_file) != NGX_CONF_OK) {
+        goto destroy_pools;
+    }
+
+    for (i = 0; cycle->modules[i]; i++) {
+        if (cycle->modules[i]->type != NGX_CORE_MODULE) {
+            continue;
+        }
+
+        module = cycle->modules[i]->ctx;
+
+        if (module->init_conf) {
+            if (module->init_conf(cycle,
+                                  cycle->conf_ctx[cycle->modules[i]->index])
+                == NGX_CONF_ERROR)
+            {
+                goto destroy_pools;
+            }
+        }
+    }
+
+    main_ccf = (ngx_core_conf_t *) ngx_get_conf(main_cycle->conf_ctx,
+                                                ngx_core_module);
+
+    if (ngx_create_paths(cycle, main_ccf->user) != NGX_OK) {
+        goto failed;
+    }
+
+    if (ngx_log_open_default(cycle) != NGX_OK) {
+        goto failed;
+    }
+
+    /* open the new files */
+
+    part = &cycle->open_files.part;
+    file = part->elts;
+
+    for (i = 0; /* void */ ; i++) {
+
+        if (i >= part->nelts) {
+            if (part->next == NULL) {
+                break;
+            }
+            part = part->next;
+            file = part->elts;
+            i = 0;
+        }
+
+        if (file[i].name.len == 0) {
+            continue;
+        }
+
+        opart = (ngx_list_part_t *) &main_cycle->open_files.part;
+        ofile = opart->elts;
+
+        for (n = 0; /* void */ ; n++) {
+
+            if (n >= opart->nelts) {
+                if (opart->next == NULL) {
+                    break;
+                }
+                opart = opart->next;
+                ofile = opart->elts;
+                n = 0;
+            }
+
+            if (file[i].name.len != ofile[n].name.len) {
+                continue;
+            }
+
+            if (ngx_strncmp(file[i].name.data, ofile[n].name.data,
+                            file[i].name.len)
+                != 0)
+            {
+                continue;
+            }
+
+            file[i].fd = ngx_dup(ofile[n].fd);
+
+            ngx_log_debug4(NGX_LOG_DEBUG_CORE, log, 0,
+                           "log: %p %d (dup %d) \"%s\"",
+                           &file[i], file[i].fd, ofile[i].fd,
+                           file[i].name.data);
+
+            if (file[i].fd == NGX_INVALID_FILE) {
+                ngx_log_error(NGX_LOG_EMERG, log, ngx_errno,
+                              ngx_dup_n " \"%s\" failed",
+                              file[i].name.data);
+                goto failed;
+            }
+
+            goto file_found;
+        }
+
+        file[i].fd = ngx_open_file(file[i].name.data,
+                                   NGX_FILE_APPEND,
+                                   NGX_FILE_CREATE_OR_OPEN,
+                                   NGX_FILE_DEFAULT_ACCESS);
+
+        ngx_log_debug3(NGX_LOG_DEBUG_CORE, log, 0,
+                       "log: %p %d \"%s\"",
+                       &file[i], file[i].fd, file[i].name.data);
+
+        if (file[i].fd == NGX_INVALID_FILE) {
+            ngx_log_error(NGX_LOG_EMERG, log, ngx_errno,
+                          ngx_open_file_n " \"%s\" failed",
+                          file[i].name.data);
+            goto failed;
+        }
+
+    file_found:
+
+        continue;
+    }
+
+    cycle->log = &cycle->new_log;
+    pool->log = &cycle->new_log;
+
+
+    /* create shared memory */
+
+    part = &cycle->shared_memory.part;
+    shm_zone = part->elts;
+
+    for (i = 0; /* void */ ; i++) {
+
+        if (i >= part->nelts) {
+            if (part->next == NULL) {
+                break;
+            }
+            part = part->next;
+            shm_zone = part->elts;
+            i = 0;
+        }
+
+        shm_zone[i].shm.log = cycle->log;
+
+        opart = (ngx_list_part_t *) &main_cycle->shared_memory.part;
+        oshm_zone = opart->elts;
+
+        for (n = 0; /* void */ ; n++) {
+
+            if (n >= opart->nelts) {
+                if (opart->next == NULL) {
+                    break;
+                }
+                opart = opart->next;
+                oshm_zone = opart->elts;
+                n = 0;
+            }
+
+            if (shm_zone[i].shm.name.len != oshm_zone[n].shm.name.len) {
+                continue;
+            }
+
+            if (ngx_strncmp(shm_zone[i].shm.name.data,
+                            oshm_zone[n].shm.name.data,
+                            shm_zone[i].shm.name.len)
+                != 0)
+            {
+                continue;
+            }
+
+            if (shm_zone[i].tag == oshm_zone[n].tag && shm_zone[i].noreuse) {
+                ngx_log_error(NGX_LOG_ERR, cycle->log, 0,
+                              "non-reusable shared zone \"%V\"",
+                              &shm_zone[i].shm.name);
+                goto failed;
+            }
+
+            if (shm_zone[i].tag == oshm_zone[n].tag
+                && shm_zone[i].shm.size == oshm_zone[n].shm.size)
+            {
+                shm_zone[i].shm.addr = oshm_zone[n].shm.addr;
+#if (NGX_WIN32)
+                shm_zone[i].shm.handle = oshm_zone[n].shm.handle;
+#endif
+
+                rc = shm_zone[i].init(&shm_zone[i], oshm_zone[n].data);
+
+                if (rc == NGX_DECLINED) {
+                    shm_zone[i].shm.addr = NULL;
+#if (NGX_WIN32)
+                    shm_zone[i].shm.handle = NULL;
+#endif
+                    ngx_log_error(NGX_LOG_ERR, cycle->log, 0,
+                                  "cannot reuse shared zone \"%V\"",
+                                  &shm_zone[i].shm.name);
+                    goto failed;
+                }
+
+                if (rc != NGX_OK) {
+                    goto failed;
+                }
+
+                goto shm_zone_found;
+            }
+
+            ngx_log_error(NGX_LOG_ERR, cycle->log, 0,
+                          "cannot reuse shared zone \"%V\"",
+                          &shm_zone[i].shm.name);
+
+            goto failed;
+        }
+
+        ngx_log_error(NGX_LOG_ERR, cycle->log, 0,
+                      "cannot find a matching shared zone \"%V\"",
+                      &shm_zone[i].shm.name);
+
+        goto failed;
+
+    shm_zone_found:
+
+        continue;
+    }
+
+
+    /* handle the listening sockets */
+
+    ls = (ngx_listening_t *) main_cycle->listening.elts;
+    nls = cycle->listening.elts;
+
+    for (n = 0; n < cycle->listening.nelts; n++) {
+
+        for (i = 0; i < main_cycle->listening.nelts; i++) {
+
+#if (NGX_HAVE_REUSEPORT)
+            if (ls[i].reuseport && ls[i].worker != ngx_worker) {
+                continue;
+            }
+#endif
+
+            if (ls[i].type != nls[n].type) {
+                continue;
+            }
+
+#if (NGX_QUIC)
+            if (ls[i].quic != nls[n].quic) {
+                continue;
+            }
+#endif
+
+#if (NGX_HAVE_REUSEPORT)
+            if (ls[i].reuseport != nls[n].reuseport) {
+                continue;
+            }
+#endif
+
+            if (ngx_cmp_sockaddr(ls[i].sockaddr, ls[i].socklen,
+                                 nls[n].sockaddr, nls[n].socklen, 1)
+                != NGX_OK)
+            {
+                continue;
+            }
+
+            nls[n].previous = &ls[i];
+
+#if (NGX_HAVE_REUSEPORT)
+            if (nls[n].reuseport) {
+                nls[n].worker = ngx_worker;
+            }
+#endif
+
+            goto listening_found;
+        }
+
+        if (ngx_exiting) {
+            /*
+             * An exiting worker calls ngx_close_listening_sockets()
+             * which resets the c->listening array.  Avoid logging an
+             * error in this case
+             */
+            goto failed;
+        }
+
+        ngx_log_error(NGX_LOG_ERR, cycle->log, 0,
+                      "unexpected listen port for \"%V\"", &nls[n].addr_text);
+        goto failed;
+
+    listening_found:
+
+        continue;
+    }
+
+
+    /* commit the new cycle configuration */
+
+    pool->log = cycle->log;
+
+    if (ngx_init_modules(cycle) != NGX_OK) {
+        /* fatal */
+        exit(1);
+    }
+
+    ngx_destroy_pool(conf.temp_pool);
+
+    ctx->cycle = cycle;
+
+    return;
+
+
+failed:
+
+    /* rollback the new cycle configuration */
+
+    part = &cycle->open_files.part;
+    file = part->elts;
+
+    for (i = 0; /* void */ ; i++) {
+
+        if (i >= part->nelts) {
+            if (part->next == NULL) {
+                break;
+            }
+            part = part->next;
+            file = part->elts;
+            i = 0;
+        }
+
+        if (file[i].fd == NGX_INVALID_FILE || file[i].fd == ngx_stderr) {
+            continue;
+        }
+
+        if (ngx_close_file(file[i].fd) == NGX_FILE_ERROR) {
+            ngx_log_error(NGX_LOG_EMERG, log, ngx_errno,
+                          ngx_close_file_n " \"%s\" failed",
+                          file[i].name.data);
+        }
+    }
+
+destroy_pools:
+
+    ngx_destroy_pool(conf.temp_pool);
+}
+
+
+static void
+ngx_dynamic_conf_loaded(ngx_event_t *event)
+{
+    ngx_dynamic_conf_t      *dcf;
+    ngx_dynamic_conf_ctx_t  *ctx;
+
+    ctx = event->data;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_CORE, ctx->log, 0,
+                   "dynamic conf load %p n:%ui", ctx->cycle, ctx->id);
+
+    if (ctx->cycle == NULL && !ngx_exiting) {
+        ngx_log_error(NGX_LOG_ALERT, ctx->log, 0,
+                      "dynamic configuration load failed");
+    }
+
+    if (ctx->cycle == NULL || ngx_exiting) {
+        ngx_destroy_pool(ctx->pool);
+        return;
+    }
+
+    ngx_dynamic_conf_install(ctx);
+
+    dcf = (ngx_dynamic_conf_t *) ngx_get_conf(ctx->main_cycle->conf_ctx,
+                                              ngx_dynamic_conf_module);
+
+    if (dcf->ctx) {
+        ngx_dynamic_conf_cleanup(dcf->ctx);
+    }
+
+    dcf->ctx = ctx;
+    ctx->count++;
+}
+
+
+static void
+ngx_dynamic_conf_cleanup(void *data)
+{
+    ngx_dynamic_conf_ctx_t *ctx = data;
+
+    if (--ctx->count) {
+        ngx_log_debug3(NGX_LOG_DEBUG_CORE, ctx->log, 0,
+                       "dynamic conf hold %p n:%ui c:%ui",
+                       ctx->cycle, ctx->id, ctx->count);
+        return;
+    }
+
+    ngx_dynamic_conf_unload(ctx);
+}
+
+
+static void
+ngx_dynamic_conf_unload(ngx_dynamic_conf_ctx_t *ctx)
+{
+    ngx_uint_t        i;
+    ngx_list_part_t  *part;
+    ngx_open_file_t  *file;
+
+    part = &ctx->cycle->open_files.part;
+    file = part->elts;
+
+    for (i = 0; /* void */ ; i++) {
+
+        if (i >= part->nelts) {
+            if (part->next == NULL) {
+                break;
+            }
+            part = part->next;
+            file = part->elts;
+            i = 0;
+        }
+
+        if (file[i].flush) {
+            file[i].flush(&file[i], ctx->log);
+        }
+
+        if (file[i].fd == NGX_INVALID_FILE || file[i].fd == ngx_stderr) {
+            continue;
+        }
+
+        if (ngx_close_file(file[i].fd) == NGX_FILE_ERROR) {
+            ngx_log_error(NGX_LOG_EMERG, ctx->log, ngx_errno,
+                          ngx_close_file_n " \"%s\" failed", file[i].name.data);
+        }
+    }
+
+    ngx_log_debug2(NGX_LOG_DEBUG_CORE, ctx->log, 0,
+                   "dynamic conf free %p n:%ui", 
+                   ctx->cycle, ctx->id);
+
+    ngx_destroy_pool(ctx->pool);
+}
+
+
+static void
+ngx_dynamic_conf_install(ngx_dynamic_conf_ctx_t *ctx)
+{
+    ngx_uint_t        n, i;
+    ngx_listening_t  *ls, *nls;
+
+    ls = (ngx_listening_t *) ctx->main_cycle->listening.elts;
+    nls = (ngx_listening_t *) ctx->cycle->listening.elts;
+
+    for (n = 0; n < ctx->main_cycle->listening.nelts; n++) {
+
+        ls[n].handler = ngx_dynamic_conf_pass_connection;
+        ls[n].next = NULL;
+
+        for (i = 0; i < ctx->cycle->listening.nelts; i++) {
+            if (&ls[n] == nls[i].previous) {
+                ls[n].next = &nls[i];
+                break;
+            }
+        }
+    }
+}
+
+
+static void
+ngx_dynamic_conf_pass_connection(ngx_connection_t *c)
+{
+    ngx_pool_t              *pool;
+    ngx_pool_cleanup_t      *cln;
+    ngx_dynamic_conf_t      *dcf;
+    ngx_dynamic_conf_ctx_t  *ctx;
+
+    dcf = (ngx_dynamic_conf_t *) ngx_get_conf(ngx_cycle->conf_ctx,
+                                              ngx_dynamic_conf_module);
+
+    ctx = dcf->ctx;
+
+    if (ctx == NULL || c->listening->next == NULL) {
+        goto close;
+    }
+
+    ngx_log_debug2(NGX_LOG_DEBUG_CORE, c->log, 0,
+                   "dynamic conf pass %p n:%ui", ctx->cycle, ctx->id);
+
+    cln = ngx_pool_cleanup_add(c->pool, 0);
+    if (cln == NULL) {
+        goto close;
+    }
+
+    cln->handler = ngx_dynamic_conf_cleanup;
+    cln->data = ctx;
+    ctx->count++;
+
+    c->listening = c->listening->next;
+    c->listening->handler(c);
+
+    return;
+
+close:
+
+    pool = c->pool;
+    ngx_close_connection(c);
+    ngx_destroy_pool(pool);
+}
+
+
+void
+ngx_dynamic_conf_reopen_files(ngx_cycle_t *cycle)
+{
+    ngx_dynamic_conf_t      *dcf;
+    ngx_dynamic_conf_ctx_t  *ctx;
+
+    dcf = (ngx_dynamic_conf_t *) ngx_get_conf(cycle->conf_ctx,
+                                              ngx_dynamic_conf_module);
+
+    ctx = dcf->ctx;
+
+    if (ctx == NULL || ctx->cycle == NULL) {
+        return;
+    }
+
+    ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
+                   "dynamic conf reopen files %p n:%ui", ctx->cycle, ctx->id);
+
+    ngx_reopen_files(ctx->cycle, -1);
+}

--- a/src/core/ngx_dynamic_conf.h
+++ b/src/core/ngx_dynamic_conf.h
@@ -1,0 +1,21 @@
+
+/*
+ * Copyright (C) Roman Arutyunyan
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#ifndef _NGX_DYNAMIC_CONF_H_INCLUDED_
+#define _NGX_DYNAMIC_CONF_H_INCLUDED_
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <nginx.h>
+
+
+ngx_int_t ngx_dynamic_conf_update(ngx_cycle_t *cycle);
+void ngx_dynamic_conf_reopen_files(ngx_cycle_t *cycle);
+
+
+#endif /* _NGX_DYNAMIC_CONF_H_INCLUDED_ */

--- a/src/core/ngx_thread_pool.c
+++ b/src/core/ngx_thread_pool.c
@@ -463,6 +463,12 @@ ngx_thread_pool(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return NGX_CONF_ERROR;
     }
 
+#if (NGX_DYNAMIC_CONF)
+    if (cf->cycle->dynamic) {
+        return NGX_CONF_OK;
+    }
+#endif
+
     if (tp->threads) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                            "duplicate thread pool \"%V\"", &tp->name);
@@ -520,6 +526,22 @@ ngx_thread_pool_add(ngx_cycle_t *cycle, ngx_str_t *name)
     if (name == NULL) {
         name = &ngx_thread_pool_default;
     }
+
+#if (NGX_DYNAMIC_CONF)
+
+    if (cycle->dynamic) {
+        tp = ngx_thread_pool_get(cycle->old_cycle, name);
+
+        if (tp == NULL) {
+            ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,
+                          "thread pool \"%V\" not found", name);
+            return NULL;
+        }
+
+        return tp;
+    }
+
+#endif
 
     tp = ngx_thread_pool_get(cycle, name);
 

--- a/src/core/ngx_thread_pool.h
+++ b/src/core/ngx_thread_pool.h
@@ -26,7 +26,7 @@ struct ngx_thread_task_s {
 typedef struct ngx_thread_pool_s  ngx_thread_pool_t;
 
 
-ngx_thread_pool_t *ngx_thread_pool_add(ngx_conf_t *cf, ngx_str_t *name);
+ngx_thread_pool_t *ngx_thread_pool_add(ngx_cycle_t *cycle, ngx_str_t *name);
 ngx_thread_pool_t *ngx_thread_pool_get(ngx_cycle_t *cycle, ngx_str_t *name);
 
 ngx_thread_task_t *ngx_thread_task_alloc(ngx_pool_t *pool, size_t size);

--- a/src/event/ngx_event.c
+++ b/src/event/ngx_event.c
@@ -438,6 +438,12 @@ ngx_event_init_conf(ngx_cycle_t *cycle, void *conf)
     ngx_listening_t  *ls;
 #endif
 
+#if (NGX_DYNAMIC_CONF)
+    if (cycle->dynamic) {
+        return NGX_CONF_OK;
+    }
+#endif
+
     if (ngx_get_conf(cycle->conf_ctx, ngx_events_module) == NULL) {
         ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,
                       "no \"events\" section in configuration");

--- a/src/event/ngx_event_udp.c
+++ b/src/event/ngx_event_udp.c
@@ -459,6 +459,7 @@ ngx_insert_udp_connection(ngx_connection_t *c)
         return NGX_ERROR;
     }
 
+    udp->rbtree = &c->listening->rbtree;
     udp->connection = c;
 
     ngx_crc32_init(hash);
@@ -482,7 +483,7 @@ ngx_insert_udp_connection(ngx_connection_t *c)
     cln->data = c;
     cln->handler = ngx_delete_udp_connection;
 
-    ngx_rbtree_insert(&c->listening->rbtree, &udp->node);
+    ngx_rbtree_insert(udp->rbtree, &udp->node);
 
     c->udp = udp;
 
@@ -499,7 +500,7 @@ ngx_delete_udp_connection(void *data)
         return;
     }
 
-    ngx_rbtree_delete(&c->listening->rbtree, &c->udp->node);
+    ngx_rbtree_delete(c->udp->rbtree, &c->udp->node);
 
     c->udp = NULL;
 }

--- a/src/event/ngx_event_udp.h
+++ b/src/event/ngx_event_udp.h
@@ -25,6 +25,7 @@
 
 struct ngx_udp_connection_s {
     ngx_rbtree_node_t   node;
+    ngx_rbtree_t       *rbtree;
     ngx_connection_t   *connection;
     ngx_buf_t          *buffer;
     ngx_str_t           key;

--- a/src/event/quic/ngx_event_quic.h
+++ b/src/event/quic/ngx_event_quic.h
@@ -46,6 +46,7 @@
 
 typedef ngx_int_t (*ngx_quic_init_pt)(ngx_connection_t *c);
 typedef void (*ngx_quic_shutdown_pt)(ngx_connection_t *c);
+typedef void (*ngx_quic_handle_stream_pt)(ngx_connection_t *c);
 
 
 typedef enum {
@@ -96,6 +97,7 @@ typedef struct {
 
     ngx_quic_init_pt               init;
     ngx_quic_shutdown_pt           shutdown;
+    ngx_quic_handle_stream_pt      handle_stream;
 
     u_char                         av_token_key[NGX_QUIC_AV_KEY_LEN];
     u_char                         sr_token_key[NGX_QUIC_SR_KEY_LEN];

--- a/src/event/quic/ngx_event_quic_connid.c
+++ b/src/event/quic/ngx_event_quic_connid.c
@@ -51,7 +51,7 @@ ngx_quic_bpf_attach_id(ngx_connection_t *c, u_char *id)
     uint64_t   cookie;
     socklen_t  optlen;
 
-    fd = c->listening->fd;
+    fd = c->fd;
 
     optlen = sizeof(cookie);
 

--- a/src/event/quic/ngx_event_quic_streams.c
+++ b/src/event/quic/ngx_event_quic_streams.c
@@ -554,11 +554,14 @@ ngx_quic_reject_stream(ngx_connection_t *c, uint64_t id)
 static void
 ngx_quic_init_stream_handler(ngx_event_t *ev)
 {
-    ngx_connection_t   *c;
-    ngx_quic_stream_t  *qs;
+    ngx_connection_t       *c, *pc;
+    ngx_quic_stream_t      *qs;
+    ngx_quic_connection_t  *qc;
 
     c = ev->data;
     qs = c->quic;
+    pc = qs->parent;
+    qc = ngx_quic_get_connection(pc);
 
     ngx_log_debug0(NGX_LOG_DEBUG_EVENT, c->log, 0, "quic init stream");
 
@@ -571,7 +574,7 @@ ngx_quic_init_stream_handler(ngx_event_t *ev)
 
     ngx_queue_remove(&qs->queue);
 
-    c->listening->handler(c);
+    qc->conf->handle_stream(c);
 }
 
 

--- a/src/http/modules/ngx_http_upstream_zone_module.c
+++ b/src/http/modules/ngx_http_upstream_zone_module.c
@@ -14,6 +14,8 @@ static char *ngx_http_upstream_zone(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static ngx_int_t ngx_http_upstream_init_zone(ngx_shm_zone_t *shm_zone,
     void *data);
+static ngx_int_t ngx_http_upstream_zone_servers_equal(
+    ngx_http_upstream_srv_conf_t *uscf, ngx_http_upstream_srv_conf_t *ouscf);
 static ngx_http_upstream_rr_peers_t *ngx_http_upstream_zone_copy_peers(
     ngx_slab_pool_t *shpool, ngx_http_upstream_srv_conf_t *uscf,
     ngx_http_upstream_srv_conf_t *ouscf);
@@ -124,8 +126,6 @@ ngx_http_upstream_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     uscf->shm_zone->init = ngx_http_upstream_init_zone;
     uscf->shm_zone->data = umcf;
 
-    uscf->shm_zone->noreuse = 1;
-
     return NGX_CONF_OK;
 }
 
@@ -133,16 +133,73 @@ ngx_http_upstream_zone(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 static ngx_int_t
 ngx_http_upstream_init_zone(ngx_shm_zone_t *shm_zone, void *data)
 {
+    ngx_http_upstream_main_conf_t  *oumcf = data;
+
     size_t                          len;
     ngx_uint_t                      i, j;
     ngx_slab_pool_t                *shpool;
     ngx_http_upstream_rr_peers_t   *peers, **peersp;
     ngx_http_upstream_srv_conf_t   *uscf, *ouscf, **uscfp, **ouscfp;
-    ngx_http_upstream_main_conf_t  *umcf, *oumcf;
+    ngx_http_upstream_main_conf_t  *umcf;
 
     shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
     umcf = shm_zone->data;
     uscfp = umcf->upstreams.elts;
+
+    if (oumcf && shpool->data) {
+
+        for (i = 0; i < umcf->upstreams.nelts; i++) {
+            uscf = uscfp[i];
+
+            if (uscf->shm_zone != shm_zone) {
+                continue;
+            }
+
+            for (j = 0; j < oumcf->upstreams.nelts; j++) {
+                ouscfp = oumcf->upstreams.elts;
+
+                 if (ouscfp[j]->shm_zone == NULL) {
+                     continue;
+                 }
+
+                 if (ouscfp[j]->shm_zone->shm.name.len != shm_zone->shm.name.len
+                     || ngx_memcmp(ouscfp[j]->shm_zone->shm.name.data,
+                                   shm_zone->shm.name.data,
+                                   shm_zone->shm.name.len)
+                        != 0)
+                 {
+                     continue;
+                 }
+
+                 if (ngx_http_upstream_zone_servers_equal(uscf, ouscfp[j])
+                     == NGX_OK)
+                 {
+                     uscf->peer.data = ouscfp[j]->peer.data;
+                     goto server_found;
+                 }
+            }
+
+            /* new or modified upstream, decline zone reuse */
+
+            for ( /* void */ ; i > 0; i--) {
+                uscf = uscfp[i - 1];
+
+                if (uscf->shm_zone != shm_zone) {
+                    continue;
+                }
+
+                uscf->peer.data = NULL;
+            }
+
+            return NGX_DECLINED;
+
+        server_found:
+
+            continue;
+        }
+
+        return NGX_OK;
+    }
 
     if (shm_zone->shm.exists) {
         peers = shpool->data;
@@ -175,7 +232,6 @@ ngx_http_upstream_init_zone(ngx_shm_zone_t *shm_zone, void *data)
     /* copy peers to shared memory */
 
     peersp = (ngx_http_upstream_rr_peers_t **) (void *) &shpool->data;
-    oumcf = data;
 
     for (i = 0; i < umcf->upstreams.nelts; i++) {
         uscf = uscfp[i];
@@ -222,6 +278,66 @@ ngx_http_upstream_init_zone(ngx_shm_zone_t *shm_zone, void *data)
 
         *peersp = peers;
         peersp = &peers->zone_next;
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_zone_servers_equal(ngx_http_upstream_srv_conf_t *uscf,
+    ngx_http_upstream_srv_conf_t *ouscf)
+{
+    ngx_uint_t                   n;
+    ngx_http_upstream_server_t  *us, *ous;
+
+    if (uscf->host.len != ouscf->host.len
+        || ngx_strncmp(uscf->host.data, ouscf->host.data, uscf->host.len) != 0)
+    {
+        return NGX_DECLINED;
+    }
+
+    if (uscf->servers == NULL
+        || ouscf->servers == NULL
+        || uscf->servers->nelts != ouscf->servers->nelts)
+    {
+        return NGX_DECLINED;
+    }
+
+    us = uscf->servers->elts;
+    ous = ouscf->servers->elts;
+
+    for (n = 0; n < uscf->servers->nelts; n++) {
+
+        if (us->name.len != ous->name.len
+            || ngx_strncmp(us->name.data, ous->name.data, us->name.len) != 0)
+        {
+            return NGX_DECLINED;
+        }
+
+        if (us->host.len != ous->host.len
+            || ngx_strncmp(us->host.data, ous->host.data, us->host.len) != 0)
+        {
+            return NGX_DECLINED;
+        }
+
+        if (us->service.len != ous->service.len
+            || ngx_strncmp(us->service.data, ous->service.data, us->service.len)
+               != 0)
+        {
+            return NGX_DECLINED;
+        }
+
+        if (us->weight != ous->weight
+            || us->max_conns != ous->max_conns
+            || us->max_fails != ous->max_fails
+            || us->fail_timeout != ous->fail_timeout
+            || us->slow_start != ous->slow_start
+            || us->down != ous->down
+            || us->backup != ous->backup)
+        {
+            return NGX_DECLINED;
+        }
     }
 
     return NGX_OK;

--- a/src/http/ngx_http.c
+++ b/src/http/ngx_http.c
@@ -76,6 +76,11 @@ ngx_http_output_header_filter_pt  ngx_http_top_early_hints_filter;
 ngx_http_output_body_filter_pt    ngx_http_top_body_filter;
 ngx_http_request_body_filter_pt   ngx_http_top_request_body_filter;
 
+ngx_http_output_header_filter_pt  ngx_http_safe_top_header_filter;
+ngx_http_output_header_filter_pt  ngx_http_safe_top_early_hints_filter;
+ngx_http_output_body_filter_pt    ngx_http_safe_top_body_filter;
+ngx_http_request_body_filter_pt   ngx_http_safe_top_request_body_filter;
+
 
 ngx_str_t  ngx_http_html_default_types[] = {
     ngx_string("text/html"),
@@ -312,6 +317,10 @@ ngx_http_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 return NGX_CONF_ERROR;
             }
         }
+    }
+
+    if (ngx_http_init_filters(cf) != NGX_OK) {
+        return NGX_CONF_ERROR;
     }
 
     if (ngx_http_variables_init_vars(cf) != NGX_OK) {

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -172,6 +172,8 @@ char *ngx_http_merge_types(ngx_conf_t *cf, ngx_array_t **keys,
 ngx_int_t ngx_http_set_default_types(ngx_conf_t *cf, ngx_array_t **types,
     ngx_str_t *default_type);
 
+char *ngx_http_init_filters(ngx_conf_t *cf);
+
 #if (NGX_HTTP_DEGRADATION)
 ngx_uint_t  ngx_http_degraded(ngx_http_request_t *);
 #endif
@@ -194,6 +196,11 @@ extern ngx_http_output_header_filter_pt  ngx_http_top_header_filter;
 extern ngx_http_output_header_filter_pt  ngx_http_top_early_hints_filter;
 extern ngx_http_output_body_filter_pt    ngx_http_top_body_filter;
 extern ngx_http_request_body_filter_pt   ngx_http_top_request_body_filter;
+
+extern ngx_http_output_header_filter_pt  ngx_http_safe_top_header_filter;
+extern ngx_http_output_header_filter_pt  ngx_http_safe_top_early_hints_filter;
+extern ngx_http_output_body_filter_pt    ngx_http_safe_top_body_filter;
+extern ngx_http_request_body_filter_pt   ngx_http_safe_top_request_body_filter;
 
 
 #endif /* _NGX_HTTP_H_INCLUDED_ */

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1860,7 +1860,7 @@ ngx_http_send_header(ngx_http_request_t *r)
         r->headers_out.status_line.len = 0;
     }
 
-    return ngx_http_top_header_filter(r);
+    return ngx_http_safe_top_header_filter(r);
 }
 
 
@@ -1891,7 +1891,7 @@ ngx_http_send_early_hints(ngx_http_request_t *r)
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http send early hints \"%V?%V\"", &r->uri, &r->args);
 
-    return ngx_http_top_early_hints_filter(r);
+    return ngx_http_safe_top_early_hints_filter(r);
 }
 
 
@@ -1906,7 +1906,7 @@ ngx_http_output_filter(ngx_http_request_t *r, ngx_chain_t *in)
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
                    "http output filter \"%V?%V\"", &r->uri, &r->args);
 
-    rc = ngx_http_top_body_filter(r, in);
+    rc = ngx_http_safe_top_body_filter(r, in);
 
     if (rc == NGX_ERROR) {
         /* NGX_ERROR may be returned by any filter */
@@ -5403,6 +5403,18 @@ ngx_http_core_pool_size(ngx_conf_t *cf, void *post, void *data)
                            NGX_POOL_ALIGNMENT);
         return NGX_CONF_ERROR;
     }
+
+    return NGX_CONF_OK;
+}
+
+
+char *
+ngx_http_init_filters(ngx_conf_t *cf)
+{
+    ngx_http_safe_top_header_filter = ngx_http_top_header_filter;
+    ngx_http_safe_top_early_hints_filter = ngx_http_top_early_hints_filter;
+    ngx_http_safe_top_body_filter = ngx_http_top_body_filter;
+    ngx_http_safe_top_request_body_filter = ngx_http_top_request_body_filter;
 
     return NGX_CONF_OK;
 }

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -4832,10 +4832,10 @@ ngx_http_core_set_aio(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 return NGX_CONF_OK;
             }
 
-            tp = ngx_thread_pool_add(cf, &name);
+            tp = ngx_thread_pool_add(cf->cycle, &name);
 
         } else {
-            tp = ngx_thread_pool_add(cf, NULL);
+            tp = ngx_thread_pool_add(cf->cycle, NULL);
         }
 
         if (tp == NULL) {

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -1075,7 +1075,7 @@ ngx_http_request_body_length_filter(ngx_http_request_t *r, ngx_chain_t *in)
         ll = &tl->next;
     }
 
-    rc = ngx_http_top_request_body_filter(r, out);
+    rc = ngx_http_safe_top_request_body_filter(r, out);
 
     ngx_chain_update_chains(r->pool, &rb->free, &rb->busy, &out,
                             (ngx_buf_tag_t) &ngx_http_read_client_request_body);
@@ -1259,7 +1259,7 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
         }
     }
 
-    rc = ngx_http_top_request_body_filter(r, out);
+    rc = ngx_http_safe_top_request_body_filter(r, out);
 
     ngx_chain_update_chains(r->pool, &rb->free, &rb->busy, &out,
                             (ngx_buf_tag_t) &ngx_http_read_client_request_body);

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3921,7 +3921,7 @@ ngx_http_v2_read_request_body(ngx_http_request_t *r)
 
     /* set rb->filter_need_buffering */
 
-    rc = ngx_http_top_request_body_filter(r, NULL);
+    rc = ngx_http_safe_top_request_body_filter(r, NULL);
 
     if (rc != NGX_OK) {
         stream->skip_data = 1;
@@ -4255,7 +4255,7 @@ ngx_http_v2_filter_request_body(ngx_http_request_t *r)
 
 update:
 
-    rc = ngx_http_top_request_body_filter(r, cl);
+    rc = ngx_http_safe_top_request_body_filter(r, cl);
 
     ngx_chain_update_chains(r->pool, &rb->free, &rb->busy, &cl,
                             (ngx_buf_tag_t) &ngx_http_v2_filter_request_body);

--- a/src/http/v3/ngx_http_v3_module.c
+++ b/src/http/v3/ngx_http_v3_module.c
@@ -212,6 +212,7 @@ ngx_http_v3_create_srv_conf(ngx_conf_t *cf)
 
     h3scf->quic.init = ngx_http_v3_init;
     h3scf->quic.shutdown = ngx_http_v3_shutdown;
+    h3scf->quic.handle_stream = ngx_http_init_connection;
 
     return h3scf;
 }

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -1723,7 +1723,7 @@ done:
         rb->rest = (off_t) cscf->large_client_header_buffers.size;
     }
 
-    rc = ngx_http_top_request_body_filter(r, out);
+    rc = ngx_http_safe_top_request_body_filter(r, out);
 
     ngx_chain_update_chains(r->pool, &rb->free, &rb->busy, &out,
                             (ngx_buf_tag_t) &ngx_http_read_client_request_body);

--- a/src/os/unix/ngx_files.h
+++ b/src/os/unix/ngx_files.h
@@ -114,6 +114,10 @@ typedef struct {
 #define ngx_delete_file_n        "unlink()"
 
 
+#define ngx_dup                  dup
+#define ngx_dup_n                "dup()"
+
+
 ngx_fd_t ngx_open_tempfile(u_char *name, ngx_uint_t persistent,
     ngx_uint_t access);
 #define ngx_open_tempfile_n      "open()"

--- a/src/os/unix/ngx_process.c
+++ b/src/os/unix/ngx_process.c
@@ -67,6 +67,13 @@ ngx_signal_t  signals[] = {
       "",
       ngx_signal_handler },
 
+#if (NGX_DYNAMIC_CONF)
+    { ngx_signal_value(NGX_UPDATE_SIGNAL),
+      "SIG" ngx_value(NGX_UPDATE_SIGNAL),
+      "update",
+      ngx_signal_handler },
+#endif
+
     { SIGALRM, "SIGALRM", "", ngx_signal_handler },
 
     { SIGINT, "SIGINT", "", ngx_signal_handler },
@@ -390,6 +397,13 @@ ngx_signal_handler(int signo, siginfo_t *siginfo, void *ucontext)
             action = ", changing binary";
             break;
 
+#if (NGX_DYNAMIC_CONF)
+        case ngx_signal_value(NGX_UPDATE_SIGNAL):
+            ngx_update = 1;
+            action = ", updating configuration";
+            break;
+#endif
+
         case SIGALRM:
             ngx_sigalrm = 1;
             break;
@@ -430,6 +444,13 @@ ngx_signal_handler(int signo, siginfo_t *siginfo, void *ucontext)
             ngx_reopen = 1;
             action = ", reopening logs";
             break;
+
+#if (NGX_DYNAMIC_CONF)
+        case ngx_signal_value(NGX_UPDATE_SIGNAL):
+            ngx_update = 1;
+            action = ", updating configuration";
+            break;
+#endif
 
         case ngx_signal_value(NGX_RECONFIGURE_SIGNAL):
         case ngx_signal_value(NGX_CHANGEBIN_SIGNAL):

--- a/src/os/unix/ngx_process_cycle.h
+++ b/src/os/unix/ngx_process_cycle.h
@@ -18,6 +18,7 @@
 #define NGX_CMD_QUIT           3
 #define NGX_CMD_TERMINATE      4
 #define NGX_CMD_REOPEN         5
+#define NGX_CMD_UPDATE         6
 
 
 #define NGX_PROCESS_SINGLE     0
@@ -56,6 +57,9 @@ extern sig_atomic_t    ngx_noaccept;
 extern sig_atomic_t    ngx_reconfigure;
 extern sig_atomic_t    ngx_reopen;
 extern sig_atomic_t    ngx_change_binary;
+#if (NGX_DYNAMIC_CONF)
+extern sig_atomic_t    ngx_update;
+#endif
 
 
 #endif /* _NGX_PROCESS_CYCLE_H_INCLUDED_ */

--- a/src/stream/ngx_stream.c
+++ b/src/stream/ngx_stream.c
@@ -50,6 +50,7 @@ ngx_uint_t  ngx_stream_max_module;
 
 
 ngx_stream_filter_pt  ngx_stream_top_filter;
+ngx_stream_filter_pt  ngx_stream_safe_top_filter;
 
 
 static ngx_command_t  ngx_stream_commands[] = {
@@ -255,6 +256,10 @@ ngx_stream_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 return NGX_CONF_ERROR;
             }
         }
+    }
+
+    if (ngx_stream_init_filters(cf) != NGX_OK) {
+        return NGX_CONF_ERROR;
     }
 
     if (ngx_stream_variables_init_vars(cf) != NGX_OK) {

--- a/src/stream/ngx_stream.h
+++ b/src/stream/ngx_stream.h
@@ -363,6 +363,8 @@ ngx_int_t ngx_stream_validate_host(ngx_str_t *host, ngx_pool_t *pool,
 ngx_int_t ngx_stream_find_virtual_server(ngx_stream_session_t *s,
     ngx_str_t *host, ngx_stream_core_srv_conf_t **cscfp);
 
+char *ngx_stream_init_filters(ngx_conf_t *cf);
+
 void ngx_stream_init_connection(ngx_connection_t *c);
 void ngx_stream_session_handler(ngx_event_t *rev);
 void ngx_stream_finalize_session(ngx_stream_session_t *s, ngx_uint_t rc);
@@ -378,6 +380,7 @@ typedef ngx_int_t (*ngx_stream_filter_pt)(ngx_stream_session_t *s,
 
 
 extern ngx_stream_filter_pt  ngx_stream_top_filter;
+extern ngx_stream_filter_pt  ngx_stream_safe_top_filter;
 
 
 #endif /* _NGX_STREAM_H_INCLUDED_ */

--- a/src/stream/ngx_stream_core_module.c
+++ b/src/stream/ngx_stream_core_module.c
@@ -1502,3 +1502,12 @@ ngx_stream_core_resolver(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     return NGX_CONF_OK;
 }
+
+
+char *
+ngx_stream_init_filters(ngx_conf_t *cf)
+{
+    ngx_stream_safe_top_filter = ngx_stream_top_filter;
+
+    return NGX_CONF_OK;
+}

--- a/src/stream/ngx_stream_pass_module.c
+++ b/src/stream/ngx_stream_pass_module.c
@@ -222,10 +222,6 @@ ngx_stream_pass_cleanup(void *data)
 static ngx_int_t
 ngx_stream_pass_match(ngx_listening_t *ls, ngx_addr_t *addr)
 {
-    if (ls->type == SOCK_DGRAM) {
-        return NGX_DECLINED;
-    }
-
     if (!ls->wildcard) {
         return ngx_cmp_sockaddr(ls->sockaddr, ls->socklen,
                                 addr->sockaddr, addr->socklen, 1);

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -1784,7 +1784,7 @@ ngx_stream_proxy_process(ngx_stream_session_t *s, ngx_uint_t from_upstream,
             if (*out || *busy || dst->buffered) {
                 c->log->action = send_action;
 
-                rc = ngx_stream_top_filter(s, *out, from_upstream);
+                rc = ngx_stream_safe_top_filter(s, *out, from_upstream);
 
                 if (rc == NGX_ERROR) {
                     ngx_stream_proxy_finalize(s, NGX_STREAM_OK);

--- a/src/stream/ngx_stream_return_module.c
+++ b/src/stream/ngx_stream_return_module.c
@@ -148,7 +148,7 @@ ngx_stream_return_write_handler(ngx_event_t *ev)
 
     ctx = ngx_stream_get_module_ctx(s, ngx_stream_return_module);
 
-    if (ngx_stream_top_filter(s, ctx->out, 1) == NGX_ERROR) {
+    if (ngx_stream_safe_top_filter(s, ctx->out, 1) == NGX_ERROR) {
         ngx_stream_finalize_session(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
         return;
     }


### PR DESCRIPTION
The change allows to reload NGINX configuration in workers by sending `SIGURG` to the master process, or by using `-s update` command line option. A dynamic configuration MUST reuse existing listen ports, shared zones, modules, and thread pools.

The `dynamic_conf_preload` directive is enabled when compiled with `-DNGX_DYNAMIC_CONF_PRELOAD` and can be used to force configuration reload on worker start. This allows to perform basic testing.
```
~/nginx-tests$ TEST_NGINX_GLOBALS="dynamic_conf_preload on;" prove .
```