### PR TITLE
SSL: logging level of the "ech_required" TLS alert.

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -4012,6 +4012,7 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
             || n == SSL_R_TLSV1_ALERT_USER_CANCELLED                 /* 1090 */
             || n == SSL_R_TLSV1_ALERT_NO_RENEGOTIATION               /* 1100 */
 #endif
+            || n == 1121 /* SSL_R_TLSV1_ALERT_ECH_REQUIRED */
             )
         {
             switch (c->log_error) {


### PR DESCRIPTION
The alert is sent by a client after its ECH configuration was rejected by a server. Normally this happens after the client receives ECH retry config.

The change avoids logging the error with critical error level. Instead of this:
```
2025/12/16 17:23:02 [crit] 384291#0: *4 SSL_do_handshake() failed
(SSL: error:0A000461:SSL routines::reason(1121):SSL alert number 121)
while SSL handshaking, client: 127.0.0.1, server: 0.0.0.0:8443 
```
we now have this:
```
2025/12/16 17:58:18 [info] 384634#0: *1 SSL_do_handshake() failed
(SSL: error:0A000461:SSL routines::reason(1121):SSL alert number 121)
while SSL handshaking, client: 127.0.0.1, server: 0.0.0.0:8443

```