### PR TITLE
HTTP/3: close stream with H3_MESSAGE_ERROR on malformed pseudo-headers

### DIFF
--- a/src/http/v3/ngx_http_v3.h
+++ b/src/http/v3/ngx_http_v3.h
@@ -69,6 +69,7 @@
 #define NGX_HTTP_V3_ERR_REQUEST_REJECTED           0x10b
 #define NGX_HTTP_V3_ERR_REQUEST_CANCELLED          0x10c
 #define NGX_HTTP_V3_ERR_REQUEST_INCOMPLETE         0x10d
+#define NGX_HTTP_V3_ERR_MESSAGE_ERROR              0x10e
 #define NGX_HTTP_V3_ERR_CONNECT_ERROR              0x10f
 #define NGX_HTTP_V3_ERR_VERSION_FALLBACK           0x110
 

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -995,6 +995,7 @@ ngx_http_v3_init_pseudo_headers(ngx_http_request_t *r)
 
 failed:
 
+    ngx_quic_reset_stream(r->connection, NGX_HTTP_V3_ERR_MESSAGE_ERROR);
     ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
     return NGX_ERROR;
 }
@@ -1103,6 +1104,7 @@ ngx_http_v3_process_request_header(ngx_http_request_t *r)
 
 failed:
 
+    ngx_quic_reset_stream(r->connection, NGX_HTTP_V3_ERR_MESSAGE_ERROR);
     ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
     return NGX_ERROR;
 }


### PR DESCRIPTION
Fixes #1043

### Proposed changes

RFC 9114, Section 4.1.2, specifies that malformed requests or responses that are detected MUST be treated as a stream error of type H3_MESSAGE_ERROR.

NGINX currently detects malformed HTTP/3 request headers (e.g. invalid, missing, duplicated, or misordered pseudo-header fields) but only finalizes the request with 400 Bad Request, without resetting the QUIC stream with the required HTTP/3 error code.

This change enforces RFC 9114 compliance by explicitly resetting the affected request stream with H3_MESSAGE_ERROR when malformed request headers are detected during:


### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
