### PR TITLE
Fixed the function to parse request cookie lines.

### DIFF
--- a/src/http/modules/ngx_http_userid_filter_module.c
+++ b/src/http/modules/ngx_http_userid_filter_module.c
@@ -338,8 +338,8 @@ ngx_http_userid_get_uid(ngx_http_request_t *r, ngx_http_userid_conf_t *conf)
         ngx_http_set_ctx(r, ctx, ngx_http_userid_filter_module);
     }
 
-    cookie = ngx_http_parse_multi_header_lines(r, r->headers_in.cookie,
-                                               &conf->name, &ctx->cookie);
+    cookie = ngx_http_parse_request_cookie_lines(r, r->headers_in.cookie,
+                                                 &conf->name, &ctx->cookie);
     if (cookie == NULL) {
         return ctx;
     }

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -110,6 +110,8 @@ ngx_int_t ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
     ngx_uint_t allow_underscores);
 ngx_table_elt_t *ngx_http_parse_multi_header_lines(ngx_http_request_t *r,
     ngx_table_elt_t *headers, ngx_str_t *name, ngx_str_t *value);
+ngx_table_elt_t *ngx_http_parse_request_cookie_lines(ngx_http_request_t *r,
+    ngx_table_elt_t *headers, ngx_str_t *name, ngx_str_t *value);
 ngx_table_elt_t *ngx_http_parse_set_cookie_lines(ngx_http_request_t *r,
     ngx_table_elt_t *headers, ngx_str_t *name, ngx_str_t *value);
 ngx_int_t ngx_http_arg(ngx_http_request_t *r, u_char *name, size_t len,

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -1088,7 +1088,8 @@ ngx_http_variable_cookie(ngx_http_request_t *r, ngx_http_variable_value_t *v,
     s.len = name->len - (sizeof("cookie_") - 1);
     s.data = name->data + sizeof("cookie_") - 1;
 
-    if (ngx_http_parse_multi_header_lines(r, r->headers_in.cookie, &s, &cookie)
+    if (ngx_http_parse_request_cookie_lines(r, r->headers_in.cookie,
+                                            &s, &cookie)
         == NULL)
     {
         v->not_found = 1;


### PR DESCRIPTION
### Proposed changes

introduced function ngx_http_parse_request_cookie_lines to properly handle cookie parsing according to RFC 2965 and RFC 6265, where cookies are separated by semicolons or commas. Although support for comma-separated characters was removed in RFC 6265, it is still supported for compatibility and the handling of multiple cookie headers.

ngx_http_parse_multi_header_lines no longer handles scenarios with semicolon delimiters.

Fixes https://github.com/nginx/nginx/issues/1042

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [ ] I have checked that NGINX compiles and runs after adding my changes.
