### PR TITLE
Core: Don't create temp directories when tesing configurations.

### DIFF
--- a/src/core/ngx_cycle.c
+++ b/src/core/ngx_cycle.c
@@ -351,8 +351,10 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
     }
 
 
-    if (ngx_create_paths(cycle, ccf->user) != NGX_OK) {
-        goto failed;
+    if (!ngx_test_config) {
+        if (ngx_create_paths(cycle, ccf->user) != NGX_OK) {
+            goto failed;
+        }
     }
 
 


### PR DESCRIPTION
If no user directive is set in nginx.conf and Nginx is started by a non-root account (e.g., `nginx`), the temporary directories is created with owner `nginx`. Later, when root runs `nginx -t`, it changes the owner of that temp directories to `nobody`, causing the running worker processes to lose permission to read the temp directories.

### Proposed changes
When no user directive is set in nginx.conf, the nginx is started by user `nginx`, such as:
```plain
nginx     273095  0.0  0.0  26788   384 ?        Ss   10:11   0:00 nginx: master process ./sbin/nginx
nginx     273096  0.0  0.0  27156  1948 ?        S    10:11   0:00 nginx: worker process
```

The owner of the temp directories is `nginx`.

```plain
[nginx@dev02 nginx]$ ls -l
total 4
drwx------. 2 nginx nginx    6 Dec 18 10:10 client_body_temp
drwxr-xr-x. 2 nginx root  4096 Dec 18 10:11 conf
drwx------. 2 nginx nginx    6 Dec 18 10:10 fastcgi_temp
drwxr-xr-x. 2 nginx root    40 Oct 24 17:22 html
drwxr-xr-x. 2 nginx root    58 Dec 18 10:11 logs
drwx------. 2 nginx nginx    6 Dec 18 10:10 proxy_temp
drwxr-xr-x. 2 nginx root    48 Dec 18 10:07 sbin
drwx------. 2 nginx nginx    6 Dec 18 10:10 scgi_temp
drwx------. 2 nginx nginx    6 Dec 18 10:10 uwsgi_temp
```

Now run `nginx -t` with `root`,  the onwer of temp directories would be changed to `nobody`:
```plain
[root@dev02 nginx]# ls -l
total 4
drwx------. 2 nobody nginx   24 Dec 18 10:31 client_body_temp
drwxr-xr-x. 2 nginx  root  4096 Dec 18 10:33 conf
drwx------. 2 nobody nginx    6 Dec 18 10:10 fastcgi_temp
drwxr-xr-x. 2 nginx  root    40 Oct 24 17:22 html
drwxr-xr-x. 2 nginx  root    58 Dec 18 10:32 logs
drwx------. 2 nobody nginx    6 Dec 18 10:10 proxy_temp
drwxr-xr-x. 2 nginx  root    48 Dec 18 10:07 sbin
drwx------. 2 nobody nginx    6 Dec 18 10:10 scgi_temp
drwx------. 2 nobody nginx    6 Dec 18 10:10 uwsgi_temp
``` 

This can cause invalid requests, e.g.
```plain
2025/12/18 10:42:40 [crit] 273290#0: *13 open() "/usr/local/nginx/client_body_temp/0000000002" failed (13: Permission denied), client: 127.0.0.1, server: localhost, request: "POST /upload HTTP/1.1", host: "127.0.0.1:8080"
``` 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [*] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [*] I have checked that NGINX compiles and runs after adding my changes.
