### PR TITLE
Fix(html): Ensure error pages are HTML5 compliant (fixes #1046)

### DIFF
--- a/src/http/ngx_http_special_response.c
+++ b/src/http/ngx_http_special_response.c
@@ -19,21 +19,21 @@ static ngx_int_t ngx_http_send_refresh(ngx_http_request_t *r);
 
 
 static u_char ngx_http_error_full_tail[] =
-"<hr><center>" NGINX_VER "</center>" CRLF
+"<hr><div style=\"text-align:center;\">" NGINX_VER "</div>" CRLF
 "</body>" CRLF
 "</html>" CRLF
 ;
 
 
 static u_char ngx_http_error_build_tail[] =
-"<hr><center>" NGINX_VER_BUILD "</center>" CRLF
+"<hr><div style=\"text-align:center;\">" NGINX_VER_BUILD "</div>" CRLF
 "</body>" CRLF
 "</html>" CRLF
 ;
 
 
 static u_char ngx_http_error_tail[] =
-"<hr><center>nginx</center>" CRLF
+"<hr><div style=\"text-align:center;\">nginx</div>" CRLF
 "</body>" CRLF
 "</html>" CRLF
 ;
@@ -50,7 +50,7 @@ static u_char ngx_http_msie_padding[] =
 
 
 static u_char ngx_http_msie_refresh_head[] =
-"<html><head><meta http-equiv=\"Refresh\" content=\"0; URL=";
+"<!DOCTYPE html><html><head><meta http-equiv=\"Refresh\" content=\"0; URL=";
 
 
 static u_char ngx_http_msie_refresh_tail[] =
@@ -58,282 +58,316 @@ static u_char ngx_http_msie_refresh_tail[] =
 
 
 static char ngx_http_error_301_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>301 Moved Permanently</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>301 Moved Permanently</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>301 Moved Permanently</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_302_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>302 Found</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>302 Found</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>302 Found</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_303_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>303 See Other</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>303 See Other</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>303 See Other</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_307_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>307 Temporary Redirect</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>307 Temporary Redirect</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>307 Temporary Redirect</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_308_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>308 Permanent Redirect</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>308 Permanent Redirect</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>308 Permanent Redirect</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_400_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>400 Bad Request</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>400 Bad Request</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>400 Bad Request</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_401_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>401 Authorization Required</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>401 Authorization Required</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>401 Authorization Required</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_402_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>402 Payment Required</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>402 Payment Required</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>402 Payment Required</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_403_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>403 Forbidden</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>403 Forbidden</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>403 Forbidden</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_404_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>404 Not Found</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>404 Not Found</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>404 Not Found</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_405_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>405 Not Allowed</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>405 Not Allowed</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>405 Not Allowed</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_406_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>406 Not Acceptable</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>406 Not Acceptable</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>406 Not Acceptable</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_408_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>408 Request Time-out</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>408 Request Time-out</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>408 Request Time-out</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_409_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>409 Conflict</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>409 Conflict</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>409 Conflict</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_410_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>410 Gone</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>410 Gone</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>410 Gone</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_411_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>411 Length Required</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>411 Length Required</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>411 Length Required</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_412_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>412 Precondition Failed</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>412 Precondition Failed</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>412 Precondition Failed</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_413_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>413 Request Entity Too Large</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>413 Request Entity Too Large</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>413 Request Entity Too Large</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_414_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>414 Request-URI Too Large</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>414 Request-URI Too Large</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>414 Request-URI Too Large</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_415_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>415 Unsupported Media Type</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>415 Unsupported Media Type</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>415 Unsupported Media Type</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_416_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>416 Requested Range Not Satisfiable</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>416 Requested Range Not Satisfiable</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>416 Requested Range Not Satisfiable</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_421_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>421 Misdirected Request</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>421 Misdirected Request</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>421 Misdirected Request</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_429_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>429 Too Many Requests</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>429 Too Many Requests</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>429 Too Many Requests</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_494_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>400 Request Header Or Cookie Too Large</title></head>"
 CRLF
 "<body>" CRLF
-"<center><h1>400 Bad Request</h1></center>" CRLF
-"<center>Request Header Or Cookie Too Large</center>" CRLF
+"<div style=\"text-align:center;\"><h1>400 Bad Request</h1></div>" CRLF
+"<div style=\"text-align:center;\">Request Header Or Cookie Too Large</div>" CRLF
 ;
 
 
 static char ngx_http_error_495_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>400 The SSL certificate error</title></head>"
 CRLF
 "<body>" CRLF
-"<center><h1>400 Bad Request</h1></center>" CRLF
-"<center>The SSL certificate error</center>" CRLF
+"<div style=\"text-align:center;\"><h1>400 Bad Request</h1></div>" CRLF
+"<div style=\"text-align:center;\">The SSL certificate error</div>" CRLF
 ;
 
 
 static char ngx_http_error_496_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>400 No required SSL certificate was sent</title></head>"
 CRLF
 "<body>" CRLF
-"<center><h1>400 Bad Request</h1></center>" CRLF
-"<center>No required SSL certificate was sent</center>" CRLF
+"<div style=\"text-align:center;\"><h1>400 Bad Request</h1></div>" CRLF
+"<div style=\"text-align:center;\">No required SSL certificate was sent</div>" CRLF
 ;
 
 
 static char ngx_http_error_497_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>400 The plain HTTP request was sent to HTTPS port</title></head>"
 CRLF
 "<body>" CRLF
-"<center><h1>400 Bad Request</h1></center>" CRLF
-"<center>The plain HTTP request was sent to HTTPS port</center>" CRLF
+"<div style=\"text-align:center;\"><h1>400 Bad Request</h1></div>" CRLF
+"<div style=\"text-align:center;\">The plain HTTP request was sent to HTTPS port</div>" CRLF
 ;
 
 
 static char ngx_http_error_500_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>500 Internal Server Error</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>500 Internal Server Error</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>500 Internal Server Error</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_501_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>501 Not Implemented</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>501 Not Implemented</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>501 Not Implemented</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_502_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>502 Bad Gateway</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>502 Bad Gateway</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>502 Bad Gateway</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_503_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>503 Service Temporarily Unavailable</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>503 Service Temporarily Unavailable</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>503 Service Temporarily Unavailable</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_504_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>504 Gateway Time-out</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>504 Gateway Time-out</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>504 Gateway Time-out</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_505_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>505 HTTP Version Not Supported</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>505 HTTP Version Not Supported</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>505 HTTP Version Not Supported</h1></div>" CRLF
 ;
 
 
 static char ngx_http_error_507_page[] =
+"<!DOCTYPE html>" CRLF
 "<html>" CRLF
 "<head><title>507 Insufficient Storage</title></head>" CRLF
 "<body>" CRLF
-"<center><h1>507 Insufficient Storage</h1></center>" CRLF
+"<div style=\"text-align:center;\"><h1>507 Insufficient Storage</h1></div>" CRLF
 ;
 
 


### PR DESCRIPTION
### Proposed changes

This commit addresses issue #1046 by:
- Adding the <!DOCTYPE html> declaration to all generated HTML pages.
- Replacing the deprecated <center> tag with a div element using CSS for centering.

The change was validated using a Perl test that checks for the presence of DOCTYPE and absence of <center> tags in 404 error pages.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [X ] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [ X] I have checked that NGINX compiles and runs after adding my changes.
