### PR TITLE
Fix possible null pointer dereference

### DIFF
--- a/src/http/modules/ngx_http_upstream_hash_module.c
+++ b/src/http/modules/ngx_http_upstream_hash_module.c
@@ -533,7 +533,7 @@ ngx_http_upstream_init_chash_peer(ngx_http_request_t *r,
     }
 #endif
 
-    if (hcf->points->number) {
+    if (hcf->points != NULL && hcf->points->number) {
         hp->hash = ngx_http_upstream_find_chash_point(hcf->points, hash);
     }
 


### PR DESCRIPTION
The null check for hcf->points was performed several lines earlier, so it is possible that hcf->points can be NULL
