### PR TITLE
Win32: fixed C4319 warning with MSVC x86.

### DIFF
--- a/src/os/win32/ngx_shmem.c
+++ b/src/os/win32/ngx_shmem.c
@@ -82,7 +82,7 @@ ngx_shm_alloc(ngx_shm_t *shm)
     shm->addr = MapViewOfFileEx(shm->handle, FILE_MAP_WRITE, 0, 0, 0, base);
 
     if (shm->addr != NULL) {
-        base += ngx_align(size, ngx_allocation_granularity);
+        base += ngx_align(shm->size, ngx_allocation_granularity);
         return NGX_OK;
     }
 


### PR DESCRIPTION
The warning appears because we mix uint64_t and ngx_uint_t (32-bit) in the same expression and result of bitwise ~ on ngx_uint_t is zero-extended to a larger type.

We can avoid using uint64_t here, because both the original shm->size value and the result of the expression are 32-bit platform words.
