### PR TITLE
Proxy v2 request body fixes.

### DIFF
--- a/src/core/ngx_output_chain.c
+++ b/src/core/ngx_output_chain.c
@@ -552,6 +552,11 @@ ngx_output_chain_copy_buf(ngx_output_chain_ctx_t *ctx)
             dst->flush = src->flush;
             dst->last_buf = src->last_buf;
             dst->last_in_chain = src->last_in_chain;
+
+        } else {
+            dst->flush = 0;
+            dst->last_buf = 0;
+            dst->last_in_chain = 0;
         }
 
     } else {
@@ -648,6 +653,11 @@ ngx_output_chain_copy_buf(ngx_output_chain_ctx_t *ctx)
             dst->flush = src->flush;
             dst->last_buf = src->last_buf;
             dst->last_in_chain = src->last_in_chain;
+
+        } else {
+            dst->flush = 0;
+            dst->last_buf = 0;
+            dst->last_in_chain = 0;
         }
     }
 

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -944,6 +944,8 @@ ngx_http_proxy_v2_reinit_request(ngx_http_request_t *r)
     ctx->rst = 0;
     ctx->goaway = 0;
     ctx->connection = NULL;
+    ctx->in = NULL;
+    ctx->busy = NULL;
 
     return NGX_OK;
 }


### PR DESCRIPTION
The series fixes various leftovers when proxying request body on next upstream
as caught by tests for HTTP/2 support in the proxy module.
