### PR TITLE
do not add "Connection: keep-alive" when possible

### DIFF
--- a/src/http/ngx_http_header_filter_module.c
+++ b/src/http/ngx_http_header_filter_module.c
@@ -387,7 +387,9 @@ ngx_http_header_filter(ngx_http_request_t *r)
         len += sizeof("Connection: upgrade" CRLF) - 1;
 
     } else if (r->keepalive) {
-        len += sizeof("Connection: keep-alive" CRLF) - 1;
+        if ((r->http_version == NGX_HTTP_VERSION_10) || (clcf->keepalive_header)) {
+            len += sizeof("Connection: keep-alive" CRLF) - 1;
+        }
 
         /*
          * MSIE and Opera ignore the "Keep-Alive: timeout=<N>" header.
@@ -564,8 +566,10 @@ ngx_http_header_filter(ngx_http_request_t *r)
                              sizeof("Connection: upgrade" CRLF) - 1);
 
     } else if (r->keepalive) {
-        b->last = ngx_cpymem(b->last, "Connection: keep-alive" CRLF,
+        if ((r->http_version == NGX_HTTP_VERSION_10) || (clcf->keepalive_header)) {
+            b->last = ngx_cpymem(b->last, "Connection: keep-alive" CRLF,
                              sizeof("Connection: keep-alive" CRLF) - 1);
+        }
 
         if (clcf->keepalive_header) {
             b->last = ngx_sprintf(b->last, "Keep-Alive: timeout=%T" CRLF,


### PR DESCRIPTION
### Proposed changes

According to the HTTP specifications (RFC 9110 and earlier RFCs), a server should emit the Connection: keep-alive header only in HTTP/1.0 responses when it explicitly wants to signal that the connection will remain open for further requests. In HTTP/1.1, persistent connections are the default, so the header is unnecessary. Another corner condition is non standard Keep-Alive header.

This PR is changing default behavior. However, for the sake of simplicity, it is not made by additional config settings. Another very popular web server IIS already behaves in similar way. Which makes me believe it is safe to change default behavior.

Rationale for this change: smaller response due to less response haeders transmitted

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
