### PR TITLE
docs(manpage): update config test example to use `nginx -t -q`

### DIFF
--- a/docs/man/nginx.8
+++ b/docs/man/nginx.8
@@ -188,7 +188,7 @@ Test configuration file
 .Pa ~/mynginx.conf
 with global directives for PID and quantity of worker processes:
 .Bd -literal -offset indent
-nginx -t -c ~/mynginx.conf \e
+nginx -t -q -c ~/mynginx.conf \e
 	-g "pid /var/run/mynginx.pid; worker_processes 2;"
 .Ed
 .Sh SEE ALSO


### PR DESCRIPTION
### Proposed changes

This PR updates the configuration test example in docs/man/nginx.8 from:
nginx -t -c ~/mynginx.conf


to:
nginx -t -q -c ~/mynginx.conf


The -q flag suppresses non-error output, producing cleaner results (in CI). This aligns the manpage with current NGINX usage recommendations and improves clarity for users copying the example.


### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
