### PR TITLE
Updated URL to community page.

### DIFF
--- a/docs/man/nginx.8
+++ b/docs/man/nginx.8
@@ -25,7 +25,7 @@
 .\" SUCH DAMAGE.
 .\"
 .\"
-.Dd November 5, 2020
+.Dd January 15, 2026
 .Dt NGINX 8
 .Os
 .Sh NAME
@@ -198,7 +198,7 @@ Documentation at
 .Pa http://nginx.org/en/docs/ .
 .Pp
 For questions and technical support, please refer to
-.Pa http://nginx.org/en/support.html .
+.Pa http://nginx.org/en/community.html .
 .Sh HISTORY
 Development of
 .Nm


### PR DESCRIPTION
The support page was removed in 2024 by F5 representatives. The community page seems to be the most suitable replacement.
