### PR TITLE
Upstream keepalive: enabled keepalive module by default.

### DIFF
--- a/src/http/modules/ngx_http_upstream_keepalive_module.c
+++ b/src/http/modules/ngx_http_upstream_keepalive_module.c
@@ -22,6 +22,8 @@ typedef struct {
     ngx_http_upstream_init_pt          original_init_upstream;
     ngx_http_upstream_init_peer_pt     original_init_peer;
 
+    ngx_uint_t                         local; /* unsigned  local:1; */
+
 } ngx_http_upstream_keepalive_srv_conf_t;
 
 
@@ -33,6 +35,8 @@ typedef struct {
 
     socklen_t                          socklen;
     ngx_sockaddr_t                     sockaddr;
+
+    ngx_http_upstream_conf_t          *tag;
 
 } ngx_http_upstream_keepalive_cache_t;
 
@@ -81,7 +85,7 @@ static char *ngx_http_upstream_keepalive(ngx_conf_t *cf, ngx_command_t *cmd,
 static ngx_command_t  ngx_http_upstream_keepalive_commands[] = {
 
     { ngx_string("keepalive"),
-      NGX_HTTP_UPS_CONF|NGX_CONF_TAKE1,
+      NGX_HTTP_UPS_CONF|NGX_CONF_TAKE12,
       ngx_http_upstream_keepalive,
       NGX_HTTP_SRV_CONF_OFFSET,
       0,
@@ -264,6 +268,10 @@ ngx_http_upstream_get_keepalive_peer(ngx_peer_connection_t *pc, void *data)
         item = ngx_queue_data(q, ngx_http_upstream_keepalive_cache_t, queue);
         c = item->connection;
 
+        if (kp->conf->local && item->tag != kp->upstream->conf) {
+            continue;
+        }
+
         if (ngx_memn2cmp((u_char *) &item->sockaddr, (u_char *) pc->sockaddr,
                          item->socklen, pc->socklen)
             == 0)
@@ -377,6 +385,7 @@ ngx_http_upstream_free_keepalive_peer(ngx_peer_connection_t *pc, void *data,
     ngx_queue_insert_head(&kp->conf->cache, q);
 
     item->connection = c;
+    item->tag = u->conf;
 
     pc->connection = NULL;
 
@@ -524,6 +533,7 @@ ngx_http_upstream_keepalive_create_conf(ngx_conf_t *cf)
      *     conf->original_init_upstream = NULL;
      *     conf->original_init_peer = NULL;
      *     conf->max_cached = 0;
+     *     conf->local = 0;
      */
 
     conf->time = NGX_CONF_UNSET_MSEC;
@@ -561,6 +571,17 @@ ngx_http_upstream_keepalive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     kcf->max_cached = n;
+
+    if (cf->args->nelts == 3) {
+        if (ngx_strncmp(value[2].data, "local", 5) == 0) {
+            kcf->local = 1;
+
+        } else {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "invalid parameter \"%V\"", &value[2]);
+            return NGX_CONF_ERROR;
+        }
+    }
 
     /* init upstream handler */
 

--- a/src/http/modules/ngx_http_upstream_keepalive_module.c
+++ b/src/http/modules/ngx_http_upstream_keepalive_module.c
@@ -19,7 +19,6 @@ typedef struct {
     ngx_queue_t                        cache;
     ngx_queue_t                        free;
 
-    ngx_http_upstream_init_pt          original_init_upstream;
     ngx_http_upstream_init_peer_pt     original_init_peer;
 
     ngx_uint_t                         local; /* unsigned  local:1; */
@@ -78,6 +77,8 @@ static void ngx_http_upstream_keepalive_save_session(ngx_peer_connection_t *pc,
 #endif
 
 static void *ngx_http_upstream_keepalive_create_conf(ngx_conf_t *cf);
+static char *ngx_http_upstream_keepalive_init_main_conf(ngx_conf_t *cf,
+    void *conf);
 static char *ngx_http_upstream_keepalive(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 
@@ -121,7 +122,7 @@ static ngx_http_module_t  ngx_http_upstream_keepalive_module_ctx = {
     NULL,                                  /* postconfiguration */
 
     NULL,                                  /* create main configuration */
-    NULL,                                  /* init main configuration */
+    ngx_http_upstream_keepalive_init_main_conf, /* init main configuration */
 
     ngx_http_upstream_keepalive_create_conf, /* create server configuration */
     NULL,                                  /* merge server configuration */
@@ -145,52 +146,6 @@ ngx_module_t  ngx_http_upstream_keepalive_module = {
     NULL,                                  /* exit master */
     NGX_MODULE_V1_PADDING
 };
-
-
-static ngx_int_t
-ngx_http_upstream_init_keepalive(ngx_conf_t *cf,
-    ngx_http_upstream_srv_conf_t *us)
-{
-    ngx_uint_t                               i;
-    ngx_http_upstream_keepalive_srv_conf_t  *kcf;
-    ngx_http_upstream_keepalive_cache_t     *cached;
-
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cf->log, 0,
-                   "init keepalive");
-
-    kcf = ngx_http_conf_upstream_srv_conf(us,
-                                          ngx_http_upstream_keepalive_module);
-
-    ngx_conf_init_msec_value(kcf->time, 3600000);
-    ngx_conf_init_msec_value(kcf->timeout, 60000);
-    ngx_conf_init_uint_value(kcf->requests, 1000);
-
-    if (kcf->original_init_upstream(cf, us) != NGX_OK) {
-        return NGX_ERROR;
-    }
-
-    kcf->original_init_peer = us->peer.init;
-
-    us->peer.init = ngx_http_upstream_init_keepalive_peer;
-
-    /* allocate cache items and add to free queue */
-
-    cached = ngx_pcalloc(cf->pool,
-                sizeof(ngx_http_upstream_keepalive_cache_t) * kcf->max_cached);
-    if (cached == NULL) {
-        return NGX_ERROR;
-    }
-
-    ngx_queue_init(&kcf->cache);
-    ngx_queue_init(&kcf->free);
-
-    for (i = 0; i < kcf->max_cached; i++) {
-        ngx_queue_insert_head(&kcf->free, &cached[i].queue);
-        cached[i].conf = kcf;
-    }
-
-    return NGX_OK;
-}
 
 
 static ngx_int_t
@@ -530,30 +485,89 @@ ngx_http_upstream_keepalive_create_conf(ngx_conf_t *cf)
     /*
      * set by ngx_pcalloc():
      *
-     *     conf->original_init_upstream = NULL;
      *     conf->original_init_peer = NULL;
-     *     conf->max_cached = 0;
      *     conf->local = 0;
      */
 
     conf->time = NGX_CONF_UNSET_MSEC;
     conf->timeout = NGX_CONF_UNSET_MSEC;
     conf->requests = NGX_CONF_UNSET_UINT;
+    conf->max_cached = NGX_CONF_UNSET_UINT;
 
     return conf;
 }
 
 
 static char *
+ngx_http_upstream_keepalive_init_main_conf(ngx_conf_t *cf, void *conf)
+{
+    ngx_uint_t                                i, j;
+    ngx_http_upstream_srv_conf_t            **uscfp;
+    ngx_http_upstream_main_conf_t            *umcf;
+    ngx_http_upstream_keepalive_cache_t      *cached;
+    ngx_http_upstream_keepalive_srv_conf_t   *kcf;
+
+    umcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_upstream_module);
+
+    uscfp = umcf->upstreams.elts;
+
+    for (i = 0; i < umcf->upstreams.nelts; i++) {
+
+        /* skip implicit upstreams */
+        if (uscfp[i]->srv_conf == NULL) {
+            continue;
+        }
+
+        kcf = ngx_http_conf_upstream_srv_conf(uscfp[i],
+                                            ngx_http_upstream_keepalive_module);
+
+        if (kcf->max_cached == 0) {
+            continue;
+        }
+
+        ngx_conf_init_msec_value(kcf->time, 3600000);
+        ngx_conf_init_msec_value(kcf->timeout, 60000);
+        ngx_conf_init_uint_value(kcf->requests, 1000);
+
+        if (kcf->max_cached == NGX_CONF_UNSET_UINT) {
+            kcf->local = 1;
+            kcf->max_cached = 32;
+        }
+
+        kcf->original_init_peer = uscfp[i]->peer.init;
+
+        uscfp[i]->peer.init = ngx_http_upstream_init_keepalive_peer;
+
+        /* allocate cache items and add to free queue */
+
+        cached = ngx_pcalloc(cf->pool,
+                 sizeof(ngx_http_upstream_keepalive_cache_t) * kcf->max_cached);
+        if (cached == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        ngx_queue_init(&kcf->cache);
+        ngx_queue_init(&kcf->free);
+
+        for (j = 0; j < kcf->max_cached; j++) {
+            ngx_queue_insert_head(&kcf->free, &cached[j].queue);
+            cached[j].conf = kcf;
+        }
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+static char *
 ngx_http_upstream_keepalive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-    ngx_http_upstream_srv_conf_t            *uscf;
     ngx_http_upstream_keepalive_srv_conf_t  *kcf = conf;
 
     ngx_int_t    n;
     ngx_str_t   *value;
 
-    if (kcf->max_cached) {
+    if (kcf->max_cached != NGX_CONF_UNSET_UINT) {
         return "is duplicate";
     }
 
@@ -563,7 +577,7 @@ ngx_http_upstream_keepalive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     n = ngx_atoi(value[1].data, value[1].len);
 
-    if (n == NGX_ERROR || n == 0) {
+    if (n == NGX_ERROR) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                            "invalid value \"%V\" in \"%V\" directive",
                            &value[1], &cmd->name);
@@ -582,16 +596,6 @@ ngx_http_upstream_keepalive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             return NGX_CONF_ERROR;
         }
     }
-
-    /* init upstream handler */
-
-    uscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module);
-
-    kcf->original_init_upstream = uscf->peer.init_upstream
-                                  ? uscf->peer.init_upstream
-                                  : ngx_http_upstream_init_round_robin;
-
-    uscf->peer.init_upstream = ngx_http_upstream_init_keepalive;
 
     return NGX_CONF_OK;
 }


### PR DESCRIPTION
Explicit upstream blocks now use keepalive connections by default, improving performance and reducing connection churn in common deployments. The behavior remains fully configurable: specifying keepalive 0; disables keepalive.

### Proposed changes

The proposed change enables keepalive connection by default for explicitly defined upstreams.
The maximum cached connections is initialized to 16.
The rest of the settings have the same default values as before the fix.

The 'keepalive' directive now accepts value '0' as an argument to allow disabling keepalive for an upstream.

### Checklist
prove upstream_keepalive.t
upstream_keepalive.t .. ok     [B
All tests successful.
Files=1, Tests=13,  2 wallclock secs ( 0.02 usr  0.00 sys +  0.05 cusr  0.03 csys =  0.10 CPU)
Result: PASS

Closes #1098 
