### PR TITLE
Prevent Undefined Behaviour in memcpy(3) via ngx_init_cycle()

### DIFF
--- a/src/core/ngx_cycle.c
+++ b/src/core/ngx_cycle.c
@@ -114,11 +114,13 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
     ngx_cpystrn(cycle->conf_file.data, old_cycle->conf_file.data,
                 old_cycle->conf_file.len + 1);
 
-    cycle->conf_param.len = old_cycle->conf_param.len;
-    cycle->conf_param.data = ngx_pstrdup(pool, &old_cycle->conf_param);
-    if (cycle->conf_param.data == NULL) {
-        ngx_destroy_pool(pool);
-        return NULL;
+    if (old_cycle->conf_param.len) {
+        cycle->conf_param.len = old_cycle->conf_param.len;
+        cycle->conf_param.data = ngx_pstrdup(pool, &old_cycle->conf_param);
+        if (cycle->conf_param.data == NULL) {
+            ngx_destroy_pool(pool);
+            return NULL;
+        }
     }
 
 


### PR DESCRIPTION
```
Avoid undefined behaviour in ngx_pstrdup()

In the third call to ngx_pstrdup() for setting cycle->conf_param.data in
ngx_init_cycle() we would pass in a nulled ngx_str_t in the case there
was no -g command line option passed to nginx.

This would result in a

  memcpy(dst, NULL, 0)

which up to and including C23 is Undefined Behaviour.

Currently Clang and GCC (in this particular case) just treat this as a
no-op, so things just happen to work.

However some undefined behaviour sanitizers will throw an error when
this is hit, e.g. Clang and the zig compiler and it's probably best not
to rely on this behaviour.

Put a simple check in ngx_pstrdup() for src->len == 0 and just return an
empty string in such cases.

By doing this we avoid two other issues

1) 0-sized allocations which can result in allocated memory address
   re-use due to ->d.last not being increased.

2) Returning uninitialised memory due to the memcpy(3) being a no-op,
   dst is never written to.

It's worth noting that the next C standard will make this (and other
NULL related operations) defined behaviour.

Link: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3322.pdf>
Closes: https://github.com/nginx/nginx/issues/1079
```