### PR TITLE
Adding support for JPEG XL

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -5,6 +5,7 @@ types {
     text/xml                                         xml;
     image/gif                                        gif;
     image/jpeg                                       jpeg jpg;
+    image/jxl                                        jxl;
     application/javascript                           js;
     application/atom+xml                             atom;
     application/rss+xml                              rss;


### PR DESCRIPTION
As Safari, FireFox and now also Google Chrome supports JPEG XL and the compression for photos is more compact and with better quality than jpeg and webp for normal and larger sized photos  This should be supported.

Example usage in html

```html
<picture>
  <source srcset="photo.jxl" type="image/jxl" />
  <source srcset="photo.webp" type="image/webp" />
  <img src="photo.jpg" alt="photo description" />
</picture>
```

Background on JPEG XL (in Dutch): https://tweakers.net/reviews/14116/google-is-om-waarom-jpeg-xl-alsnog-de-standaard-voor-het-web-wordt.html

### Proposed changes

As Safari, FireFox and now also Google Chrome supports JPEG XL and the compression for photos is more compact and with better quality than jpeg and webp for normal and larger sized photos  This should be supported.
https://chromium-review.googlesource.com/c/chromium/src/+/7184969

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x ] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x ] I have checked that NGINX compiles and runs after adding my changes.
