### PR TITLE
Docs: Clarify -t option behavior in nginx man page

### DIFF
--- a/docs/man/nginx.8
+++ b/docs/man/nginx.8
@@ -25,7 +25,7 @@
 .\" SUCH DAMAGE.
 .\"
 .\"
-.Dd November 5, 2020
+.Dd January 21, 2026
 .Dt NGINX 8
 .Os
 .Sh NAME
@@ -98,7 +98,8 @@ but additionally dump configuration files to standard output.
 Do not run, just test the configuration file.
 .Nm
 checks the configuration file syntax and then tries to open files
-referenced in the configuration file.
+referenced in the configuration file, including binding to configured
+listen addresses.
 .It Fl V
 Print the
 .Nm


### PR DESCRIPTION
Update the nginx(8) man page to clarify that the -t option may attempt to open sockets and bind to configured listen addresses, not just open files. This explains why configuration tests can fail due to missing privileges or address conflicts.

### Proposed changes

Clarify the behavior of the -t option in the nginx(8) man page.

When testing a configuration with nginx -t, nginx not only checks the
configuration syntax and opens referenced files, but may also attempt to
open sockets and bind to configured listen addresses. This can result
in errors (for example, due to insufficient privileges or address
conflicts), which is currently not made explicit in the documentation.

Example:
```
# nginx -t
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: [emerg] bind() to 0.0.0.0:80 failed (13: Permission denied)
nginx: configuration file /etc/nginx/nginx.conf test failed
```

This change updates the man page to accurately reflect that behavior and
reduce confusion when nginx -t fails despite valid configuration
syntax.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.