### PR TITLE
Worker threads

### DIFF
--- a/auto/unix
+++ b/auto/unix
@@ -833,6 +833,16 @@ ngx_feature_test="void *p; p = memalign(4096, 4096);
 . auto/feature
 
 
+ngx_feature="malloc_trim()"
+ngx_feature_name="NGX_HAVE_MALLOC_TRIM"
+ngx_feature_run=no
+ngx_feature_incs="#include <malloc.h>"
+ngx_feature_path=
+ngx_feature_libs=
+ngx_feature_test="malloc_trim(0)"
+. auto/feature
+
+
 ngx_feature="mmap(MAP_ANON|MAP_SHARED)"
 ngx_feature_name="NGX_HAVE_MAP_ANON"
 ngx_feature_run=yes

--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -171,7 +171,7 @@ ngx_module_t  ngx_core_module = {
     NGX_CORE_MODULE,                       /* module type */
     NULL,                                  /* init master */
     NULL,                                  /* init module */
-    NULL,                                  /* init process */
+    ngx_init_cyclex,                       /* init process */
     NULL,                                  /* init thread */
     NULL,                                  /* exit thread */
     NULL,                                  /* exit process */

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -72,9 +72,7 @@ ngx_create_listening(ngx_conf_t *cf, struct sockaddr *sockaddr,
 
     ngx_memcpy(ls->addr_text.data, text, len);
 
-#if !(NGX_WIN32)
-    ngx_rbtree_init(&ls->rbtree, &ls->sentinel, ngx_udp_rbtree_insert_value);
-#endif
+    ls->ctx_id = ngx_cycle_ctx_add(cf);
 
     ls->fd = (ngx_socket_t) -1;
     ls->type = SOCK_STREAM;

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -10,7 +10,7 @@
 #include <ngx_event.h>
 
 
-ngx_os_io_t  ngx_io;
+ngx_thread_local ngx_os_io_t  ngx_io;
 
 
 static void ngx_drain_connections(ngx_cycle_t *cycle);

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -225,6 +225,7 @@ ngx_int_t ngx_set_inherited_sockets(ngx_cycle_t *cycle);
 ngx_int_t ngx_open_listening_sockets(ngx_cycle_t *cycle);
 void ngx_configure_listening_sockets(ngx_cycle_t *cycle);
 void ngx_close_listening_sockets(ngx_cycle_t *cycle);
+void ngx_stop_listening(ngx_cycle_t *cycle);
 void ngx_close_connection(ngx_connection_t *c);
 void ngx_close_idle_connections(ngx_cycle_t *cycle);
 ngx_int_t ngx_connection_local_sockaddr(ngx_connection_t *c, ngx_str_t *s,

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -47,7 +47,6 @@ struct ngx_listening_s {
     size_t              post_accept_buffer_size;
 
     ngx_listening_t    *previous;
-    ngx_connection_t   *connection;
 
     ngx_rbtree_t        rbtree;
     ngx_rbtree_node_t   sentinel;

--- a/src/core/ngx_connection.h
+++ b/src/core/ngx_connection.h
@@ -48,8 +48,7 @@ struct ngx_listening_s {
 
     ngx_listening_t    *previous;
 
-    ngx_rbtree_t        rbtree;
-    ngx_rbtree_node_t   sentinel;
+    ngx_uint_t          ctx_id;
 
     ngx_uint_t          worker;
 
@@ -89,6 +88,12 @@ struct ngx_listening_s {
 #endif
 
 };
+
+
+typedef struct {
+    ngx_rbtree_t        rbtree;
+    ngx_rbtree_node_t   sentinel;
+} ngx_listening_ctx_t;
 
 
 typedef enum {

--- a/src/core/ngx_cycle.c
+++ b/src/core/ngx_cycle.c
@@ -65,7 +65,11 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
 
     log = old_cycle->log;
 
+#if (NGX_DEBUG_PLOCK)
+    pool = ngx_create_lockable_pool(log);
+#else
     pool = ngx_create_pool(NGX_CYCLE_POOL_SIZE, log);
+#endif
     if (pool == NULL) {
         return NULL;
     }
@@ -530,12 +534,20 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
     }
 #endif
 
+#if (NGX_DEBUG_PLOCK)
+    cycle->ctx = ngx_pmcalloc(pool, n * sizeof(void *));
+#else
     cycle->ctx = ngx_pcalloc(pool, n * sizeof(void *));
+#endif
     if (cycle->ctx == NULL) {
         goto failed;
     }
 
+#if (NGX_DEBUG_PLOCK)
+    cycle->count = ngx_pmcalloc(pool, sizeof(ngx_atomic_t));
+#else
     cycle->count = ngx_pcalloc(pool, sizeof(ngx_atomic_t));
+#endif
     if (cycle->count == NULL) {
         goto failed;
     }

--- a/src/core/ngx_cycle.h
+++ b/src/core/ngx_cycle.h
@@ -124,6 +124,14 @@ typedef struct {
 
 #define ngx_is_init_cycle(cycle)  (cycle->conf_ctx == NULL)
 
+#define ngx_save_cycle(cycle)                                                 \
+    cycle = (ngx_cycle_t *) ngx_cycle
+
+#define ngx_set_cycle(cycle)                                                  \
+    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, (cycle)->log, 0,                      \
+                   "cycle p:%p", cycle);                                      \
+    ngx_cycle = cycle
+
 
 ngx_cycle_t *ngx_init_cycle(ngx_cycle_t *old_cycle);
 ngx_int_t ngx_create_pidfile(ngx_str_t *name, ngx_log_t *log);

--- a/src/core/ngx_log.c
+++ b/src/core/ngx_log.c
@@ -642,7 +642,11 @@ ngx_log_set_log(ngx_conf_t *cf, ngx_log_t **head)
 #endif
 
     } else if (ngx_strncmp(value[1].data, "syslog:", 7) == 0) {
+#if (NGX_DEBUG_PLOCK)
+        peer = ngx_pmcalloc(cf->pool, sizeof(ngx_syslog_peer_t));
+#else
         peer = ngx_pcalloc(cf->pool, sizeof(ngx_syslog_peer_t));
+#endif
         if (peer == NULL) {
             return NGX_CONF_ERROR;
         }

--- a/src/core/ngx_open_file_cache.c
+++ b/src/core/ngx_open_file_cache.c
@@ -558,7 +558,7 @@ failed:
 static ngx_int_t
 ngx_file_o_path_info(ngx_fd_t fd, ngx_file_info_t *fi, ngx_log_t *log)
 {
-    static ngx_uint_t  use_fstat = 1;
+    static volatile ngx_uint_t  use_fstat = 1;
 
     /*
      * In Linux 2.6.39 the O_PATH flag was introduced that allows to obtain

--- a/src/core/ngx_open_file_cache.h
+++ b/src/core/ngx_open_file_cache.h
@@ -96,11 +96,18 @@ typedef struct {
     ngx_uint_t               current;
     ngx_uint_t               max;
     time_t                   inactive;
+} ngx_open_file_cache_ctx_t;
+
+
+typedef struct {
+    ngx_uint_t               ctx_id;
+    ngx_uint_t               max;
+    time_t                   inactive;
 } ngx_open_file_cache_t;
 
 
 typedef struct {
-    ngx_open_file_cache_t   *cache;
+    ngx_open_file_cache_ctx_t  *cache;
     ngx_cached_open_file_t  *file;
     ngx_uint_t               min_uses;
     ngx_log_t               *log;
@@ -116,11 +123,11 @@ typedef struct {
     ngx_fd_t                 fd;
 
     ngx_cached_open_file_t  *file;
-    ngx_open_file_cache_t   *cache;
+    ngx_open_file_cache_ctx_t  *cache;
 } ngx_open_file_cache_event_t;
 
 
-ngx_open_file_cache_t *ngx_open_file_cache_init(ngx_pool_t *pool,
+ngx_open_file_cache_t *ngx_open_file_cache_init(ngx_conf_t *cf,
     ngx_uint_t max, time_t inactive);
 ngx_int_t ngx_open_cached_file(ngx_open_file_cache_t *cache, ngx_str_t *name,
     ngx_open_file_info_t *of, ngx_pool_t *pool);

--- a/src/core/ngx_palloc.h
+++ b/src/core/ngx_palloc.h
@@ -43,6 +43,9 @@ typedef struct ngx_pool_large_s  ngx_pool_large_t;
 struct ngx_pool_large_s {
     ngx_pool_large_t     *next;
     void                 *alloc;
+#if (NGX_DEBUG_PLOCK)
+    size_t                size;
+#endif
 };
 
 
@@ -62,6 +65,9 @@ struct ngx_pool_s {
     ngx_pool_large_t     *large;
     ngx_pool_cleanup_t   *cleanup;
     ngx_log_t            *log;
+#if (NGX_DEBUG_PLOCK)
+    ngx_uint_t            lockable; /* unsigned  lockable:1; */
+#endif
 };
 
 
@@ -81,6 +87,15 @@ void *ngx_pnalloc(ngx_pool_t *pool, size_t size);
 void *ngx_pcalloc(ngx_pool_t *pool, size_t size);
 void *ngx_pmemalign(ngx_pool_t *pool, size_t size, size_t alignment);
 ngx_int_t ngx_pfree(ngx_pool_t *pool, void *p);
+
+#if (NGX_DEBUG_PLOCK)
+ngx_pool_t *ngx_create_lockable_pool(ngx_log_t *log);
+ngx_int_t ngx_plock(ngx_pool_t *pool);
+ngx_int_t ngx_punlock(ngx_pool_t *pool);
+void *ngx_pmalloc(ngx_pool_t *pool, size_t size);
+void *ngx_pmcalloc(ngx_pool_t *pool, size_t size);
+ngx_pool_t *ngx_create_child_pool(ngx_pool_t *pool);
+#endif
 
 
 ngx_pool_cleanup_t *ngx_pool_cleanup_add(ngx_pool_t *p, size_t size);

--- a/src/core/ngx_regex.c
+++ b/src/core/ngx_regex.c
@@ -408,6 +408,14 @@ ngx_regex_exec(ngx_regex_t *re, ngx_str_t *s, int *captures, ngx_uint_t size)
 
     cln = NULL;
 
+    if (ngx_regex_match_data == NULL) {
+        cln = ngx_pool_cleanup_add(ngx_get_cyclex(ngx_cycle)->pool, 0);
+        if (cln == NULL) {
+            rc = NGX_ERROR;
+            goto failed;
+        }
+    }
+
     if (ngx_regex_match_data == NULL
         || size > ngx_regex_match_data_size)
     {

--- a/src/core/ngx_resolver.h
+++ b/src/core/ngx_resolver.h
@@ -37,7 +37,7 @@
 #define NGX_RESOLVER_MAX_RECURSION    50
 
 
-typedef struct ngx_resolver_s  ngx_resolver_t;
+typedef struct ngx_resolver_c_s  ngx_resolver_c_t;
 
 
 typedef struct {
@@ -49,7 +49,7 @@ typedef struct {
     ngx_log_t                 log;
     ngx_buf_t                *read_buf;
     ngx_buf_t                *write_buf;
-    ngx_resolver_t           *resolver;
+    ngx_resolver_c_t         *resolver;
 } ngx_resolver_connection_t;
 
 
@@ -145,7 +145,20 @@ typedef struct {
 } ngx_resolver_node_t;
 
 
-struct ngx_resolver_s {
+typedef struct {
+    ngx_array_t               connections;
+
+    ngx_uint_t                ctx_id;
+
+    time_t                    valid;
+    unsigned                  ipv4:1;
+#if (NGX_HAVE_INET6)
+    unsigned                  ipv6:1;
+#endif
+} ngx_resolver_t;
+
+
+struct ngx_resolver_c_s {
     /* has to be pointer because of "incomplete type" */
     ngx_event_t              *event;
     void                     *dummy;
@@ -196,7 +209,7 @@ struct ngx_resolver_s {
 
 struct ngx_resolver_ctx_s {
     ngx_resolver_ctx_t       *next;
-    ngx_resolver_t           *resolver;
+    ngx_resolver_c_t         *resolver;
     ngx_resolver_node_t      *node;
 
     /* event ident must be after 3 pointers as in ngx_connection_t */

--- a/src/core/ngx_syslog.c
+++ b/src/core/ngx_syslog.c
@@ -261,11 +261,10 @@ ngx_syslog_writer(ngx_log_t *log, ngx_uint_t level, u_char *buf,
 
     peer = log->wdata;
 
-    if (peer->busy) {
+    if (peer->busy || !ngx_atomic_cmp_set(&peer->busy, 0, 1)) {
         return;
     }
 
-    peer->busy = 1;
     peer->severity = level - 1;
 
     p = ngx_syslog_add_header(peer, msg);

--- a/src/core/ngx_syslog.h
+++ b/src/core/ngx_syslog.h
@@ -21,8 +21,9 @@ typedef struct {
     ngx_log_t          log;
     ngx_log_t         *logp;
 
-    unsigned           busy:1;
-    unsigned           nohostname:1;
+    ngx_atomic_t       busy;
+
+    ngx_uint_t         nohostname; /* unsigned  nohostname:1; */
 } ngx_syslog_peer_t;
 
 

--- a/src/core/ngx_times.c
+++ b/src/core/ngx_times.c
@@ -23,16 +23,16 @@ static ngx_msec_t ngx_monotonic_time(time_t sec, ngx_uint_t msec);
 
 #define NGX_TIME_SLOTS   64
 
-static ngx_uint_t        slot;
-static ngx_atomic_t      ngx_time_lock;
+static ngx_thread_local ngx_uint_t        slot;
+static ngx_thread_local ngx_atomic_t      ngx_time_lock;
 
-volatile ngx_msec_t      ngx_current_msec;
-volatile ngx_time_t     *ngx_cached_time;
-volatile ngx_str_t       ngx_cached_err_log_time;
-volatile ngx_str_t       ngx_cached_http_time;
-volatile ngx_str_t       ngx_cached_http_log_time;
-volatile ngx_str_t       ngx_cached_http_log_iso8601;
-volatile ngx_str_t       ngx_cached_syslog_time;
+ngx_thread_local volatile ngx_msec_t      ngx_current_msec;
+ngx_thread_local volatile ngx_time_t     *ngx_cached_time;
+ngx_thread_local volatile ngx_str_t       ngx_cached_err_log_time;
+ngx_thread_local volatile ngx_str_t       ngx_cached_http_time;
+ngx_thread_local volatile ngx_str_t       ngx_cached_http_log_time;
+ngx_thread_local volatile ngx_str_t       ngx_cached_http_log_iso8601;
+ngx_thread_local volatile ngx_str_t       ngx_cached_syslog_time;
 
 #if !(NGX_WIN32)
 
@@ -42,20 +42,20 @@ volatile ngx_str_t       ngx_cached_syslog_time;
  * GMT offset value. Fortunately the value is changed only two times a year.
  */
 
-static ngx_int_t         cached_gmtoff;
+static ngx_thread_local ngx_int_t         cached_gmtoff;
 #endif
 
-static ngx_time_t        cached_time[NGX_TIME_SLOTS];
-static u_char            cached_err_log_time[NGX_TIME_SLOTS]
-                                    [sizeof("1970/09/28 12:00:00")];
-static u_char            cached_http_time[NGX_TIME_SLOTS]
-                                    [sizeof("Mon, 28 Sep 1970 06:00:00 GMT")];
-static u_char            cached_http_log_time[NGX_TIME_SLOTS]
-                                    [sizeof("28/Sep/1970:12:00:00 +0600")];
-static u_char            cached_http_log_iso8601[NGX_TIME_SLOTS]
-                                    [sizeof("1970-09-28T12:00:00+06:00")];
-static u_char            cached_syslog_time[NGX_TIME_SLOTS]
-                                    [sizeof("Sep 28 12:00:00")];
+static ngx_thread_local ngx_time_t     cached_time[NGX_TIME_SLOTS];
+static ngx_thread_local u_char         cached_err_log_time[NGX_TIME_SLOTS]
+                                              [sizeof("1970/09/28 12:00:00")];
+static ngx_thread_local u_char         cached_http_time[NGX_TIME_SLOTS]
+                                     [sizeof("Mon, 28 Sep 1970 06:00:00 GMT")];
+static ngx_thread_local u_char          cached_http_log_time[NGX_TIME_SLOTS]
+                                        [sizeof("28/Sep/1970:12:00:00 +0600")];
+static ngx_thread_local u_char         cached_http_log_iso8601[NGX_TIME_SLOTS]
+                                         [sizeof("1970-09-28T12:00:00+06:00")];
+static ngx_thread_local u_char         cached_syslog_time[NGX_TIME_SLOTS]
+                                                   [sizeof("Sep 28 12:00:00")];
 
 
 static char  *week[] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };

--- a/src/core/ngx_times.h
+++ b/src/core/ngx_times.h
@@ -31,22 +31,22 @@ time_t ngx_next_time(time_t when);
 #define ngx_next_time_n      "mktime()"
 
 
-extern volatile ngx_time_t  *ngx_cached_time;
+extern ngx_thread_local volatile ngx_time_t  *ngx_cached_time;
 
 #define ngx_time()           ngx_cached_time->sec
 #define ngx_timeofday()      (ngx_time_t *) ngx_cached_time
 
-extern volatile ngx_str_t    ngx_cached_err_log_time;
-extern volatile ngx_str_t    ngx_cached_http_time;
-extern volatile ngx_str_t    ngx_cached_http_log_time;
-extern volatile ngx_str_t    ngx_cached_http_log_iso8601;
-extern volatile ngx_str_t    ngx_cached_syslog_time;
+extern ngx_thread_local volatile ngx_str_t    ngx_cached_err_log_time;
+extern ngx_thread_local volatile ngx_str_t    ngx_cached_http_time;
+extern ngx_thread_local volatile ngx_str_t    ngx_cached_http_log_time;
+extern ngx_thread_local volatile ngx_str_t    ngx_cached_http_log_iso8601;
+extern ngx_thread_local volatile ngx_str_t    ngx_cached_syslog_time;
 
 /*
  * milliseconds elapsed since some unspecified point in the past
  * and truncated to ngx_msec_t, used in event timers
  */
-extern volatile ngx_msec_t  ngx_current_msec;
+extern ngx_thread_local volatile ngx_msec_t  ngx_current_msec;
 
 
 #endif /* _NGX_TIMES_H_INCLUDED_ */

--- a/src/event/modules/ngx_devpoll_module.c
+++ b/src/event/modules/ngx_devpoll_module.c
@@ -49,11 +49,11 @@ static ngx_int_t ngx_devpoll_process_events(ngx_cycle_t *cycle,
 static void *ngx_devpoll_create_conf(ngx_cycle_t *cycle);
 static char *ngx_devpoll_init_conf(ngx_cycle_t *cycle, void *conf);
 
-static int              dp = -1;
-static struct pollfd   *change_list, *event_list;
-static ngx_uint_t       nchanges, max_changes, nevents;
+static ngx_thread_local int              dp = -1;
+static ngx_thread_local struct pollfd   *change_list, *event_list;
+static ngx_thread_local ngx_uint_t       nchanges, max_changes, nevents;
 
-static ngx_event_t    **change_index;
+static ngx_thread_local ngx_event_t    **change_index;
 
 
 static ngx_str_t      devpoll_name = ngx_string("/dev/poll");

--- a/src/event/modules/ngx_epoll_module.c
+++ b/src/event/modules/ngx_epoll_module.c
@@ -130,28 +130,28 @@ static void ngx_epoll_eventfd_handler(ngx_event_t *ev);
 static void *ngx_epoll_create_conf(ngx_cycle_t *cycle);
 static char *ngx_epoll_init_conf(ngx_cycle_t *cycle, void *conf);
 
-static int                  ep = -1;
-static struct epoll_event  *event_list;
-static ngx_uint_t           nevents;
+static ngx_thread_local int                  ep = -1;
+static ngx_thread_local struct epoll_event  *event_list;
+static ngx_thread_local ngx_uint_t           nevents;
 
 #if (NGX_HAVE_EVENTFD)
-static int                  notify_fd = -1;
-static ngx_event_t          notify_event;
-static ngx_connection_t     notify_conn;
+static ngx_thread_local int                  notify_fd = -1;
+static ngx_thread_local ngx_event_t          notify_event;
+static ngx_thread_local ngx_connection_t     notify_conn;
 #endif
 
 #if (NGX_HAVE_FILE_AIO)
 
-int                         ngx_eventfd = -1;
-aio_context_t               ngx_aio_ctx = 0;
+ngx_thread_local int                         ngx_eventfd = -1;
+ngx_thread_local aio_context_t               ngx_aio_ctx = 0;
 
-static ngx_event_t          ngx_eventfd_event;
-static ngx_connection_t     ngx_eventfd_conn;
+static ngx_thread_local ngx_event_t          ngx_eventfd_event;
+static ngx_thread_local ngx_connection_t     ngx_eventfd_conn;
 
 #endif
 
 #if (NGX_HAVE_EPOLLRDHUP)
-ngx_uint_t                  ngx_use_epoll_rdhup;
+ngx_thread_local ngx_uint_t                  ngx_use_epoll_rdhup;
 #endif
 
 static ngx_str_t      epoll_name = ngx_string("epoll");

--- a/src/event/modules/ngx_eventport_module.c
+++ b/src/event/modules/ngx_eventport_module.c
@@ -149,11 +149,11 @@ static ngx_int_t ngx_eventport_process_events(ngx_cycle_t *cycle,
 static void *ngx_eventport_create_conf(ngx_cycle_t *cycle);
 static char *ngx_eventport_init_conf(ngx_cycle_t *cycle, void *conf);
 
-static int            ep = -1;
-static port_event_t  *event_list;
-static ngx_uint_t     nevents;
-static timer_t        event_timer = (timer_t) -1;
-static ngx_event_t    notify_event;
+static ngx_thread_local int            ep = -1;
+static ngx_thread_local port_event_t  *event_list;
+static ngx_thread_local ngx_uint_t     nevents;
+static ngx_thread_local timer_t        event_timer = (timer_t) -1;
+static ngx_thread_local ngx_event_t    notify_event;
 
 static ngx_str_t      eventport_name = ngx_string("eventport");
 

--- a/src/event/modules/ngx_kqueue_module.c
+++ b/src/event/modules/ngx_kqueue_module.c
@@ -261,6 +261,8 @@ ngx_kqueue_notify_init(ngx_log_t *log)
     notify_kev.fflags = NOTE_TRIGGER;
     notify_kev.udata = NGX_KQUEUE_UDATA_T ((uintptr_t) &notify_event);
 
+    ngx_save_cycle(notify_event.cycle);
+
     return NGX_OK;
 }
 
@@ -300,6 +302,8 @@ ngx_kqueue_add_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags)
     ev->active = 1;
     ev->disabled = 0;
     ev->oneshot = (flags & NGX_ONESHOT_EVENT) ? 1 : 0;
+
+    ngx_save_cycle(ev->cycle);
 
 #if 0
 
@@ -665,6 +669,8 @@ ngx_kqueue_process_events(ngx_cycle_t *cycle, ngx_msec_t timer,
                           event_list[i].filter);
             continue;
         }
+
+        ngx_set_cycle(ev->cycle);
 
         if (flags & NGX_POST_EVENTS) {
             queue = ev->accept ? &ngx_posted_accept_events

--- a/src/event/modules/ngx_kqueue_module.c
+++ b/src/event/modules/ngx_kqueue_module.c
@@ -48,15 +48,15 @@ static void *ngx_kqueue_create_conf(ngx_cycle_t *cycle);
 static char *ngx_kqueue_init_conf(ngx_cycle_t *cycle, void *conf);
 
 
-int                    ngx_kqueue = -1;
+ngx_thread_local int                    ngx_kqueue = -1;
 
-static struct kevent  *change_list;
-static struct kevent  *event_list;
-static ngx_uint_t      max_changes, nchanges, nevents;
+static ngx_thread_local struct kevent  *change_list;
+static ngx_thread_local struct kevent  *event_list;
+static ngx_thread_local ngx_uint_t      max_changes, nchanges, nevents;
 
 #ifdef EVFILT_USER
-static ngx_event_t     notify_event;
-static struct kevent   notify_kev;
+static ngx_thread_local ngx_event_t     notify_event;
+static ngx_thread_local struct kevent   notify_kev;
 #endif
 
 

--- a/src/event/modules/ngx_poll_module.c
+++ b/src/event/modules/ngx_poll_module.c
@@ -120,6 +120,8 @@ ngx_poll_add_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags)
 
     ev->active = 1;
 
+    ngx_save_cycle(ev->cycle);
+
     if (ev->index != NGX_INVALID_INDEX) {
         ngx_log_error(NGX_LOG_ALERT, ev->log, 0,
                       "poll event fd:%d ev:%i is already set", c->fd, event);
@@ -375,6 +377,8 @@ ngx_poll_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
             queue = ev->accept ? &ngx_posted_accept_events
                                : &ngx_posted_events;
 
+            ngx_set_cycle(ev->cycle);
+
             ngx_post_event(ev, queue);
         }
 
@@ -383,6 +387,8 @@ ngx_poll_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
 
             ev = c->write;
             ev->ready = 1;
+
+            ngx_set_cycle(ev->cycle);
 
             ngx_post_event(ev, &ngx_posted_events);
         }

--- a/src/event/modules/ngx_poll_module.c
+++ b/src/event/modules/ngx_poll_module.c
@@ -21,8 +21,8 @@ static ngx_int_t ngx_poll_process_events(ngx_cycle_t *cycle, ngx_msec_t timer,
 static char *ngx_poll_init_conf(ngx_cycle_t *cycle, void *conf);
 
 
-static struct pollfd  *event_list;
-static ngx_uint_t      nevents;
+static ngx_thread_local struct pollfd  *event_list;
+static ngx_thread_local ngx_uint_t      nevents;
 
 
 static ngx_str_t           poll_name = ngx_string("poll");

--- a/src/event/modules/ngx_poll_module.c
+++ b/src/event/modules/ngx_poll_module.c
@@ -207,7 +207,7 @@ ngx_poll_del_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags)
 
             event_list[ev->index] = event_list[nevents];
 
-            c = ngx_cycle->files[event_list[nevents].fd];
+            c = ngx_get_cyclex(ev->cycle)->files[event_list[nevents].fd];
 
             if (c->fd == -1) {
                 ngx_log_error(NGX_LOG_ALERT, ev->log, 0,
@@ -336,7 +336,7 @@ ngx_poll_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
             continue;
         }
 
-        c = ngx_cycle->files[event_list[i].fd];
+        c = ngx_get_cyclex(cycle)->files[event_list[i].fd];
 
         if (c->fd == -1) {
             ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "unexpected event");

--- a/src/event/modules/ngx_select_module.c
+++ b/src/event/modules/ngx_select_module.c
@@ -159,6 +159,8 @@ ngx_select_add_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags)
 
     ev->active = 1;
 
+    ngx_save_cycle(ev->cycle);
+
     event_index[nevents] = ev;
     ev->index = nevents;
     nevents++;
@@ -331,6 +333,8 @@ ngx_select_process_events(ngx_cycle_t *cycle, ngx_msec_t timer,
         if (found) {
             ev->ready = 1;
             ev->available = -1;
+
+            ngx_set_cycle(ev->cycle);
 
             queue = ev->accept ? &ngx_posted_accept_events
                                : &ngx_posted_events;

--- a/src/event/modules/ngx_select_module.c
+++ b/src/event/modules/ngx_select_module.c
@@ -22,15 +22,15 @@ static void ngx_select_repair_fd_sets(ngx_cycle_t *cycle);
 static char *ngx_select_init_conf(ngx_cycle_t *cycle, void *conf);
 
 
-static fd_set         master_read_fd_set;
-static fd_set         master_write_fd_set;
-static fd_set         work_read_fd_set;
-static fd_set         work_write_fd_set;
+static ngx_thread_local fd_set         master_read_fd_set;
+static ngx_thread_local fd_set         master_write_fd_set;
+static ngx_thread_local fd_set         work_read_fd_set;
+static ngx_thread_local fd_set         work_write_fd_set;
 
-static ngx_int_t      max_fd;
-static ngx_uint_t     nevents;
+static ngx_thread_local ngx_int_t      max_fd;
+static ngx_thread_local ngx_uint_t     nevents;
 
-static ngx_event_t  **event_index;
+static ngx_thread_local ngx_event_t  **event_index;
 
 
 static ngx_str_t           select_name = ngx_string("select");

--- a/src/event/ngx_event.c
+++ b/src/event/ngx_event.c
@@ -36,12 +36,13 @@ static char *ngx_event_core_init_conf(ngx_cycle_t *cycle, void *conf);
 
 
 static ngx_uint_t     ngx_timer_resolution;
+
 sig_atomic_t          ngx_event_timer_alarm;
 
 static ngx_uint_t     ngx_event_max_module;
 
-ngx_uint_t            ngx_event_flags;
-ngx_event_actions_t   ngx_event_actions;
+ngx_thread_local ngx_uint_t            ngx_event_flags;
+ngx_thread_local ngx_event_actions_t   ngx_event_actions;
 
 
 static ngx_atomic_t   connection_counter = 1;
@@ -50,12 +51,12 @@ ngx_atomic_t         *ngx_connection_counter = &connection_counter;
 
 ngx_atomic_t         *ngx_accept_mutex_ptr;
 ngx_shmtx_t           ngx_accept_mutex;
-ngx_uint_t            ngx_use_accept_mutex;
-ngx_uint_t            ngx_accept_events;
-ngx_uint_t            ngx_accept_mutex_held;
-ngx_msec_t            ngx_accept_mutex_delay;
-ngx_int_t             ngx_accept_disabled;
-ngx_uint_t            ngx_use_exclusive_accept;
+ngx_thread_local ngx_uint_t            ngx_use_accept_mutex;
+ngx_thread_local ngx_uint_t            ngx_accept_events;
+ngx_thread_local ngx_uint_t            ngx_accept_mutex_held;
+ngx_thread_local ngx_msec_t            ngx_accept_mutex_delay;
+ngx_thread_local ngx_int_t             ngx_accept_disabled;
+ngx_thread_local ngx_uint_t            ngx_use_exclusive_accept;
 
 
 #if (NGX_STAT_STUB)

--- a/src/event/ngx_event.h
+++ b/src/event/ngx_event.h
@@ -185,9 +185,9 @@ typedef struct {
 } ngx_event_actions_t;
 
 
-extern ngx_event_actions_t   ngx_event_actions;
+extern ngx_thread_local ngx_event_actions_t   ngx_event_actions;
 #if (NGX_HAVE_EPOLLRDHUP)
-extern ngx_uint_t            ngx_use_epoll_rdhup;
+extern ngx_thread_local ngx_uint_t            ngx_use_epoll_rdhup;
 #endif
 
 
@@ -413,7 +413,7 @@ extern ngx_uint_t            ngx_use_epoll_rdhup;
 #define ngx_del_timer        ngx_event_del_timer
 
 
-extern ngx_os_io_t  ngx_io;
+extern ngx_thread_local ngx_os_io_t  ngx_io;
 
 #define ngx_recv             ngx_io.recv
 #define ngx_recv_chain       ngx_io.recv_chain
@@ -459,12 +459,12 @@ extern ngx_atomic_t          *ngx_connection_counter;
 
 extern ngx_atomic_t          *ngx_accept_mutex_ptr;
 extern ngx_shmtx_t            ngx_accept_mutex;
-extern ngx_uint_t             ngx_use_accept_mutex;
-extern ngx_uint_t             ngx_accept_events;
-extern ngx_uint_t             ngx_accept_mutex_held;
-extern ngx_msec_t             ngx_accept_mutex_delay;
-extern ngx_int_t              ngx_accept_disabled;
-extern ngx_uint_t             ngx_use_exclusive_accept;
+extern ngx_thread_local ngx_uint_t             ngx_use_accept_mutex;
+extern ngx_thread_local ngx_uint_t             ngx_accept_events;
+extern ngx_thread_local ngx_uint_t             ngx_accept_mutex_held;
+extern ngx_thread_local ngx_msec_t             ngx_accept_mutex_delay;
+extern ngx_thread_local ngx_int_t              ngx_accept_disabled;
+extern ngx_thread_local ngx_uint_t             ngx_use_exclusive_accept;
 
 
 #if (NGX_STAT_STUB)
@@ -485,7 +485,7 @@ extern ngx_atomic_t  *ngx_stat_waiting;
 
 
 extern sig_atomic_t           ngx_event_timer_alarm;
-extern ngx_uint_t             ngx_event_flags;
+extern ngx_thread_local ngx_uint_t             ngx_event_flags;
 extern ngx_module_t           ngx_events_module;
 extern ngx_module_t           ngx_event_core_module;
 

--- a/src/event/ngx_event.h
+++ b/src/event/ngx_event.h
@@ -116,6 +116,8 @@ struct ngx_event_s {
     /* the posted queue */
     ngx_queue_t      queue;
 
+    ngx_cycle_t     *cycle;
+
 #if 0
 
     /* the threads support */

--- a/src/event/ngx_event_accept.c
+++ b/src/event/ngx_event_accept.c
@@ -31,7 +31,7 @@ ngx_event_accept(ngx_event_t *ev)
     ngx_connection_t  *c, *lc;
     ngx_event_conf_t  *ecf;
 #if (NGX_HAVE_ACCEPT4)
-    static ngx_uint_t  use_accept4 = 1;
+    static volatile ngx_uint_t  use_accept4 = 1;
 #endif
 
     if (ev->timedout) {

--- a/src/event/ngx_event_connect.c
+++ b/src/event/ngx_event_connect.c
@@ -109,7 +109,7 @@ ngx_event_connect_peer(ngx_peer_connection_t *pc)
 #if (NGX_HAVE_IP_BIND_ADDRESS_NO_PORT)
 
         if (pc->sockaddr->sa_family != AF_UNIX && port == 0) {
-            static int  bind_address_no_port = 1;
+            static volatile int  bind_address_no_port = 1;
 
             if (bind_address_no_port) {
                 if (setsockopt(s, IPPROTO_IP, IP_BIND_ADDRESS_NO_PORT,

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -143,7 +143,7 @@ int  ngx_ssl_certificate_comp_index;
 int  ngx_ssl_client_hello_arg_index;
 
 
-u_char  ngx_ssl_session_buffer[NGX_SSL_MAX_SESSION_SIZE];
+ngx_thread_local u_char  ngx_ssl_session_buffer[NGX_SSL_MAX_SESSION_SIZE];
 
 
 ngx_int_t

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -4805,7 +4805,11 @@ ngx_ssl_session_ticket_keys(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *paths)
         return NGX_OK;
     }
 
+#if (NGX_DEBUG_PLOCK)
+    keys = ngx_pmcalloc(cf->pool, sizeof(ngx_ssl_ticket_keys_t));
+#else
     keys = ngx_pcalloc(cf->pool, sizeof(ngx_ssl_ticket_keys_t));
+#endif
     if (keys == NULL) {
         return NGX_ERROR;
     }
@@ -4816,6 +4820,12 @@ ngx_ssl_session_ticket_keys(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *paths)
     {
         return NGX_ERROR;
     }
+#if (NGX_DEBUG_PLOCK)
+    keys->keys.elts = ngx_alloc(keys->keys.nalloc * keys->keys.size, cf->log);
+    if (keys->keys.elts == NULL) {
+        return NGX_ERROR;
+    }
+#endif
 
     cln = ngx_pool_cleanup_add(cf->pool, 0);
     if (cln == NULL) {

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -182,6 +182,12 @@ typedef struct {
 
 
 typedef struct {
+    ngx_array_t                 keys;
+    ngx_atomic_t                lock;
+} ngx_ssl_ticket_keys_t;
+
+
+typedef struct {
     ngx_rbtree_t                session_rbtree;
     ngx_rbtree_node_t           sentinel;
     ngx_queue_t                 expire_queue;

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -405,7 +405,7 @@ extern int  ngx_ssl_certificate_comp_index;
 extern int  ngx_ssl_client_hello_arg_index;
 
 
-extern u_char  ngx_ssl_session_buffer[NGX_SSL_MAX_SESSION_SIZE];
+extern ngx_thread_local u_char ngx_ssl_session_buffer[NGX_SSL_MAX_SESSION_SIZE];
 
 
 #endif /* _NGX_EVENT_OPENSSL_H_INCLUDED_ */

--- a/src/event/ngx_event_openssl_cache.c
+++ b/src/event/ngx_event_openssl_cache.c
@@ -1136,6 +1136,13 @@ ngx_ssl_cache_init(ngx_pool_t *pool, ngx_uint_t max, time_t valid,
     ngx_ssl_cache_t     *cache;
     ngx_pool_cleanup_t  *cln;
 
+#if (NGX_DEBUG_PLOCK)
+    pool = ngx_create_child_pool(pool);
+    if (pool == NULL) {
+        return NULL;
+    }
+#endif
+
     cache = ngx_pcalloc(pool, sizeof(ngx_ssl_cache_t));
     if (cache == NULL) {
         return NULL;

--- a/src/event/ngx_event_openssl_stapling.c
+++ b/src/event/ngx_event_openssl_stapling.c
@@ -226,7 +226,11 @@ ngx_ssl_stapling_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl, X509 *cert,
     ngx_pool_cleanup_t  *cln;
     ngx_ssl_stapling_t  *staple;
 
+#if (NGX_DEBUG_PLOCK)
+    staple = ngx_pmcalloc(cf->pool, sizeof(ngx_ssl_stapling_t));
+#else
     staple = ngx_pcalloc(cf->pool, sizeof(ngx_ssl_stapling_t));
+#endif
     if (staple == NULL) {
         return NGX_ERROR;
     }

--- a/src/event/ngx_event_posted.c
+++ b/src/event/ngx_event_posted.c
@@ -10,9 +10,9 @@
 #include <ngx_event.h>
 
 
-ngx_queue_t  ngx_posted_accept_events;
-ngx_queue_t  ngx_posted_next_events;
-ngx_queue_t  ngx_posted_events;
+ngx_thread_local ngx_queue_t  ngx_posted_accept_events;
+ngx_thread_local ngx_queue_t  ngx_posted_next_events;
+ngx_thread_local ngx_queue_t  ngx_posted_events;
 
 
 void

--- a/src/event/ngx_event_posted.c
+++ b/src/event/ngx_event_posted.c
@@ -31,6 +31,8 @@ ngx_event_process_posted(ngx_cycle_t *cycle, ngx_queue_t *posted)
 
         ngx_delete_posted_event(ev);
 
+        ngx_set_cycle(ev->cycle);
+
         ev->handler(ev);
     }
 }

--- a/src/event/ngx_event_posted.h
+++ b/src/event/ngx_event_posted.h
@@ -43,9 +43,9 @@ void ngx_event_process_posted(ngx_cycle_t *cycle, ngx_queue_t *posted);
 void ngx_event_move_posted_next(ngx_cycle_t *cycle);
 
 
-extern ngx_queue_t  ngx_posted_accept_events;
-extern ngx_queue_t  ngx_posted_next_events;
-extern ngx_queue_t  ngx_posted_events;
+extern ngx_thread_local ngx_queue_t  ngx_posted_accept_events;
+extern ngx_thread_local ngx_queue_t  ngx_posted_next_events;
+extern ngx_thread_local ngx_queue_t  ngx_posted_events;
 
 
 #endif /* _NGX_EVENT_POSTED_H_INCLUDED_ */

--- a/src/event/ngx_event_posted.h
+++ b/src/event/ngx_event_posted.h
@@ -18,6 +18,7 @@
                                                                               \
     if (!(ev)->posted) {                                                      \
         (ev)->posted = 1;                                                     \
+        ngx_save_cycle((ev)->cycle);                                          \
         ngx_queue_insert_tail(q, &(ev)->queue);                               \
                                                                               \
         ngx_log_debug1(NGX_LOG_DEBUG_CORE, (ev)->log, 0, "post event %p", ev);\

--- a/src/event/ngx_event_timer.c
+++ b/src/event/ngx_event_timer.c
@@ -93,36 +93,17 @@ ngx_event_expire_timers(void)
 
         ngx_set_cycle(ev->cycle);
 
+        if (!ev->cancelable) {
+            ngx_get_cyclex(ev->cycle)->timers_n--;
+        }
+
         ev->handler(ev);
     }
 }
 
 
 ngx_int_t
-ngx_event_no_timers_left(void)
+ngx_event_no_timers_left(ngx_cycle_t *cycle)
 {
-    ngx_event_t        *ev;
-    ngx_rbtree_node_t  *node, *root, *sentinel;
-
-    sentinel = ngx_event_timer_rbtree.sentinel;
-    root = ngx_event_timer_rbtree.root;
-
-    if (root == sentinel) {
-        return NGX_OK;
-    }
-
-    for (node = ngx_rbtree_min(root, sentinel);
-         node;
-         node = ngx_rbtree_next(&ngx_event_timer_rbtree, node))
-    {
-        ev = ngx_rbtree_data(node, ngx_event_t, timer);
-
-        if (!ev->cancelable) {
-            return NGX_AGAIN;
-        }
-    }
-
-    /* only cancelable timers left */
-
-    return NGX_OK;
+    return ngx_get_cyclex(cycle)->timers_n ? NGX_DECLINED : NGX_OK;
 }

--- a/src/event/ngx_event_timer.c
+++ b/src/event/ngx_event_timer.c
@@ -91,6 +91,8 @@ ngx_event_expire_timers(void)
 
         ev->timedout = 1;
 
+        ngx_set_cycle(ev->cycle);
+
         ev->handler(ev);
     }
 }

--- a/src/event/ngx_event_timer.c
+++ b/src/event/ngx_event_timer.c
@@ -10,8 +10,8 @@
 #include <ngx_event.h>
 
 
-ngx_rbtree_t              ngx_event_timer_rbtree;
-static ngx_rbtree_node_t  ngx_event_timer_sentinel;
+ngx_thread_local ngx_rbtree_t              ngx_event_timer_rbtree;
+static ngx_thread_local ngx_rbtree_node_t  ngx_event_timer_sentinel;
 
 /*
  * the event timer rbtree may contain the duplicate keys, however,

--- a/src/event/ngx_event_timer.h
+++ b/src/event/ngx_event_timer.h
@@ -25,7 +25,7 @@ void ngx_event_expire_timers(void);
 ngx_int_t ngx_event_no_timers_left(void);
 
 
-extern ngx_rbtree_t  ngx_event_timer_rbtree;
+extern ngx_thread_local ngx_rbtree_t  ngx_event_timer_rbtree;
 
 
 static ngx_inline void

--- a/src/event/ngx_event_timer.h
+++ b/src/event/ngx_event_timer.h
@@ -83,6 +83,8 @@ ngx_event_add_timer(ngx_event_t *ev, ngx_msec_t timer)
 
     ngx_rbtree_insert(&ngx_event_timer_rbtree, &ev->timer);
 
+    ngx_save_cycle(ev->cycle);
+
     ev->timer_set = 1;
 }
 

--- a/src/event/ngx_event_udp.c
+++ b/src/event/ngx_event_udp.c
@@ -37,7 +37,7 @@ ngx_event_recvmsg(ngx_event_t *ev)
     ngx_listening_t   *ls;
     ngx_event_conf_t  *ecf;
     ngx_connection_t  *c, *lc;
-    static u_char      buffer[65535];
+    static ngx_thread_local u_char      buffer[65535];
 
 #if (NGX_HAVE_ADDRINFO_CMSG)
     u_char             msg_control[CMSG_SPACE(sizeof(ngx_addrinfo_t))];

--- a/src/event/ngx_event_udp.c
+++ b/src/event/ngx_event_udp.c
@@ -30,6 +30,7 @@ ngx_event_recvmsg(ngx_event_t *ev)
     ngx_err_t          err;
     socklen_t          socklen, local_socklen;
     ngx_event_t       *rev, *wev;
+    ngx_cyclex_t      *cyclex;
     struct iovec       iov[1];
     struct msghdr      msg;
     ngx_sockaddr_t     sa, lsa;
@@ -197,8 +198,10 @@ ngx_event_recvmsg(ngx_event_t *ev)
         (void) ngx_atomic_fetch_add(ngx_stat_accepted, 1);
 #endif
 
-        ngx_accept_disabled = ngx_cycle->connection_n / 8
-                              - ngx_cycle->free_connection_n;
+        cyclex = ngx_get_cyclex(ngx_cycle);
+
+        ngx_accept_disabled = cyclex->connection_n / 8
+                              - cyclex->free_connection_n;
 
         c = ngx_get_connection(lc->fd, ev->log);
         if (c == NULL) {

--- a/src/event/quic/ngx_event_quic.c
+++ b/src/event/quic/ngx_event_quic.c
@@ -959,7 +959,7 @@ ngx_quic_handle_payload(ngx_connection_t *c, ngx_quic_header_t *pkt)
     ngx_int_t               rc;
     ngx_quic_send_ctx_t    *ctx;
     ngx_quic_connection_t  *qc;
-    static u_char           buf[NGX_QUIC_MAX_UDP_PAYLOAD_SIZE];
+    static ngx_thread_local u_char           buf[NGX_QUIC_MAX_UDP_PAYLOAD_SIZE];
 
     qc = ngx_quic_get_connection(c);
 

--- a/src/event/quic/ngx_event_quic_ssl.c
+++ b/src/event/quic/ngx_event_quic_ssl.c
@@ -883,7 +883,7 @@ ngx_quic_init_connection(ngx_connection_t *c)
         { 0, NULL }
     };
 #else /* NGX_QUIC_BORINGSSL_API || NGX_QUIC_QUICTLS_API */
-    static SSL_QUIC_METHOD  quic_method;
+    static ngx_thread_local SSL_QUIC_METHOD  quic_method;
 #endif
 
     qc = ngx_quic_get_connection(c);

--- a/src/event/quic/ngx_event_quic_udp.c
+++ b/src/event/quic/ngx_event_quic_udp.c
@@ -26,6 +26,7 @@ ngx_quic_recvmsg(ngx_event_t *ev)
     ngx_err_t           err;
     socklen_t           socklen, local_socklen;
     ngx_event_t        *rev, *wev;
+    ngx_cyclex_t       *cyclex;
     struct iovec        iov[1];
     struct msghdr       msg;
     ngx_sockaddr_t      sa, lsa;
@@ -208,8 +209,10 @@ ngx_quic_recvmsg(ngx_event_t *ev)
         (void) ngx_atomic_fetch_add(ngx_stat_accepted, 1);
 #endif
 
-        ngx_accept_disabled = ngx_cycle->connection_n / 8
-                              - ngx_cycle->free_connection_n;
+        cyclex = ngx_get_cyclex(ngx_cycle);
+
+        ngx_accept_disabled = cyclex->connection_n / 8
+                              - cyclex->free_connection_n;
 
         c = ngx_get_connection(lc->fd, ev->log);
         if (c == NULL) {

--- a/src/http/modules/ngx_http_degradation_module.c
+++ b/src/http/modules/ngx_http_degradation_module.c
@@ -107,8 +107,8 @@ ngx_http_degraded(ngx_http_request_t *r)
 {
     time_t                             now;
     ngx_uint_t                         log;
-    static size_t                      sbrk_size;
-    static time_t                      sbrk_time;
+    static ngx_thread_local size_t     sbrk_size;
+    static ngx_thread_local time_t     sbrk_time;
     ngx_http_degradation_main_conf_t  *dmcf;
 
     dmcf = ngx_http_get_module_main_conf(r, ngx_http_degradation_module);

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -591,6 +591,8 @@ ngx_http_grpc_handler(ngx_http_request_t *r)
         }
     }
 
+    u->preserve_output = 1;
+
     u->output.tag = (ngx_buf_tag_t) &ngx_http_grpc_module;
 
     u->conf = &glcf->upstream;
@@ -4430,7 +4432,6 @@ ngx_http_grpc_create_loc_conf(ngx_conf_t *cf)
     conf->upstream.force_ranges = 0;
     conf->upstream.pass_trailers = 1;
     conf->upstream.pass_early_hints = 1;
-    conf->upstream.preserve_output = 1;
 
     conf->headers_source = NGX_CONF_UNSET_PTR;
 

--- a/src/http/modules/ngx_http_gzip_filter_module.c
+++ b/src/http/modules/ngx_http_gzip_filter_module.c
@@ -214,7 +214,7 @@ static ngx_str_t  ngx_http_gzip_ratio = ngx_string("gzip_ratio");
 static ngx_http_output_header_filter_pt  ngx_http_next_header_filter;
 static ngx_http_output_body_filter_pt    ngx_http_next_body_filter;
 
-static ngx_uint_t  ngx_http_gzip_assume_zlib_ng;
+static volatile ngx_uint_t  ngx_http_gzip_assume_zlib_ng;
 
 
 static ngx_int_t

--- a/src/http/modules/ngx_http_log_module.c
+++ b/src/http/modules/ngx_http_log_module.c
@@ -1350,7 +1350,11 @@ ngx_http_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (ngx_strncmp(value[1].data, "syslog:", 7) == 0) {
 
+#if (NGX_DEBUG_PLOCK)
+        peer = ngx_pmcalloc(cf->pool, sizeof(ngx_syslog_peer_t));
+#else
         peer = ngx_pcalloc(cf->pool, sizeof(ngx_syslog_peer_t));
+#endif
         if (peer == NULL) {
             return NGX_CONF_ERROR;
         }

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -236,8 +236,6 @@ ngx_http_proxy_v2_handler(ngx_http_request_t *r)
 
     plcf = ngx_http_get_module_loc_conf(r, ngx_http_proxy_module);
 
-    plcf->upstream.preserve_output = 1;
-
     u = r->upstream;
 
     if (plcf->proxy_lengths == NULL) {
@@ -256,6 +254,8 @@ ngx_http_proxy_v2_handler(ngx_http_request_t *r)
 #if (NGX_HTTP_SSL)
     ngx_str_set(&u->ssl_alpn_protocol, NGX_HTTP_V2_ALPN_PROTO);
 #endif
+
+    u->preserve_output = 1;
 
     u->output.tag = (ngx_buf_tag_t) &ngx_http_proxy_v2_module;
 

--- a/src/http/modules/ngx_http_sub_filter_module.c
+++ b/src/http/modules/ngx_http_sub_filter_module.c
@@ -77,7 +77,7 @@ typedef struct {
 } ngx_http_sub_ctx_t;
 
 
-static ngx_uint_t ngx_http_sub_cmp_index;
+static ngx_thread_local ngx_uint_t ngx_http_sub_cmp_index;
 
 
 static ngx_int_t ngx_http_sub_output(ngx_http_request_t *r,

--- a/src/http/modules/ngx_http_upstream_zone_module.c
+++ b/src/http/modules/ngx_http_upstream_zone_module.c
@@ -29,6 +29,7 @@ static void ngx_http_upstream_zone_set_single(
 static void ngx_http_upstream_zone_remove_peer_locked(
     ngx_http_upstream_rr_peers_t *peers, ngx_http_upstream_rr_peer_t *peer);
 static ngx_int_t ngx_http_upstream_zone_init_worker(ngx_cycle_t *cycle);
+static void ngx_http_upstream_zone_exit_worker(ngx_cycle_t *cycle);
 static void ngx_http_upstream_zone_resolve_timer(ngx_event_t *event);
 static void ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx);
 
@@ -71,7 +72,7 @@ ngx_module_t  ngx_http_upstream_zone_module = {
     ngx_http_upstream_zone_init_worker,    /* init process */
     NULL,                                  /* init thread */
     NULL,                                  /* exit thread */
-    NULL,                                  /* exit process */
+    ngx_http_upstream_zone_exit_worker,    /* exit process */
     NULL,                                  /* exit master */
     NGX_MODULE_V1_PADDING
 };
@@ -693,6 +694,65 @@ ngx_http_upstream_zone_init_worker(ngx_cycle_t *cycle)
     }
 
     return NGX_OK;
+}
+
+
+static void
+ngx_http_upstream_zone_exit_worker(ngx_cycle_t *cycle)
+{
+    ngx_uint_t                      i;
+    ngx_event_t                    *event;
+    ngx_http_upstream_rr_peer_t    *peer;
+    ngx_http_upstream_rr_peers_t   *peers;
+    ngx_http_upstream_srv_conf_t   *uscf, **uscfp;
+    ngx_http_upstream_main_conf_t  *umcf;
+
+    if (ngx_process != NGX_PROCESS_WORKER
+        && ngx_process != NGX_PROCESS_SINGLE)
+    {
+        return;
+    }
+
+    umcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_upstream_module);
+
+    if (umcf == NULL) {
+        return;
+    }
+
+    uscfp = umcf->upstreams.elts;
+
+    for (i = 0; i < umcf->upstreams.nelts; i++) {
+
+        uscf = uscfp[i];
+
+        if (uscf->shm_zone == NULL) {
+            continue;
+        }
+
+        peers = uscf->peer.data;
+
+        do {
+            ngx_http_upstream_rr_peers_wlock(peers);
+
+            for (peer = peers->resolve; peer; peer = peer->next) {
+
+                if (peer->host->worker != ngx_worker) {
+                    continue;
+                }
+
+                event = &peer->host->event;
+
+                if (event->timer_set) {
+                    ngx_del_timer(event);
+                }
+            }
+
+            ngx_http_upstream_rr_peers_unlock(peers);
+
+            peers = peers->next;
+
+        } while (peers);
+    }
 }
 
 

--- a/src/http/modules/ngx_http_upstream_zone_module.c
+++ b/src/http/modules/ngx_http_upstream_zone_module.c
@@ -639,7 +639,8 @@ ngx_http_upstream_zone_init_worker(ngx_cycle_t *cycle)
     ngx_http_upstream_main_conf_t  *umcf;
 
     if (ngx_process != NGX_PROCESS_WORKER
-        && ngx_process != NGX_PROCESS_SINGLE)
+        && ngx_process != NGX_PROCESS_SINGLE
+        && ngx_process != NGX_PROCESS_THREAD)
     {
         return NGX_OK;
     }
@@ -708,7 +709,8 @@ ngx_http_upstream_zone_exit_worker(ngx_cycle_t *cycle)
     ngx_http_upstream_main_conf_t  *umcf;
 
     if (ngx_process != NGX_PROCESS_WORKER
-        && ngx_process != NGX_PROCESS_SINGLE)
+        && ngx_process != NGX_PROCESS_SINGLE
+        && ngx_process != NGX_PROCESS_THREAD)
     {
         return;
     }

--- a/src/http/ngx_http.c
+++ b/src/http/ngx_http.c
@@ -76,6 +76,11 @@ ngx_http_output_header_filter_pt  ngx_http_top_early_hints_filter;
 ngx_http_output_body_filter_pt    ngx_http_top_body_filter;
 ngx_http_request_body_filter_pt   ngx_http_top_request_body_filter;
 
+ngx_http_output_header_filter_pt  ngx_http_safe_top_header_filter;
+ngx_http_output_header_filter_pt  ngx_http_safe_top_early_hints_filter;
+ngx_http_output_body_filter_pt    ngx_http_safe_top_body_filter;
+ngx_http_request_body_filter_pt   ngx_http_safe_top_request_body_filter;
+
 
 ngx_str_t  ngx_http_html_default_types[] = {
     ngx_string("text/html"),
@@ -312,6 +317,10 @@ ngx_http_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 return NGX_CONF_ERROR;
             }
         }
+    }
+
+    if (ngx_http_init_filters(cf) != NGX_OK) {
+        return NGX_CONF_ERROR;
     }
 
     if (ngx_http_variables_init_vars(cf) != NGX_OK) {

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -172,6 +172,8 @@ char *ngx_http_merge_types(ngx_conf_t *cf, ngx_array_t **keys,
 ngx_int_t ngx_http_set_default_types(ngx_conf_t *cf, ngx_array_t **types,
     ngx_str_t *default_type);
 
+char *ngx_http_init_filters(ngx_conf_t *cf);
+
 #if (NGX_HTTP_DEGRADATION)
 ngx_uint_t  ngx_http_degraded(ngx_http_request_t *);
 #endif
@@ -194,6 +196,11 @@ extern ngx_http_output_header_filter_pt  ngx_http_top_header_filter;
 extern ngx_http_output_header_filter_pt  ngx_http_top_early_hints_filter;
 extern ngx_http_output_body_filter_pt    ngx_http_top_body_filter;
 extern ngx_http_request_body_filter_pt   ngx_http_top_request_body_filter;
+
+extern ngx_http_output_header_filter_pt  ngx_http_safe_top_header_filter;
+extern ngx_http_output_header_filter_pt  ngx_http_safe_top_early_hints_filter;
+extern ngx_http_output_body_filter_pt    ngx_http_safe_top_body_filter;
+extern ngx_http_request_body_filter_pt   ngx_http_safe_top_request_body_filter;
 
 
 #endif /* _NGX_HTTP_H_INCLUDED_ */

--- a/src/http/ngx_http_cache.h
+++ b/src/http/ngx_http_cache.h
@@ -170,9 +170,9 @@ struct ngx_http_file_cache_s {
 
     time_t                           fail_time;
 
-    ngx_uint_t                       files;
+    ngx_uint_t                       ctx_id;
+
     ngx_uint_t                       loader_files;
-    ngx_msec_t                       last;
     ngx_msec_t                       loader_sleep;
     ngx_msec_t                       loader_threshold;
 
@@ -185,6 +185,12 @@ struct ngx_http_file_cache_s {
     ngx_uint_t                       use_temp_path;
                                      /* unsigned use_temp_path:1 */
 };
+
+
+typedef struct {
+    ngx_msec_t                       last;
+    ngx_uint_t                       files;
+} ngx_http_file_cachex_t;
 
 
 ngx_int_t ngx_http_file_cache_new(ngx_http_request_t *r);

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -5072,7 +5072,7 @@ ngx_http_core_open_file_cache(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return NGX_CONF_ERROR;
     }
 
-    clcf->open_file_cache = ngx_open_file_cache_init(cf->pool, max, inactive);
+    clcf->open_file_cache = ngx_open_file_cache_init(cf, max, inactive);
     if (clcf->open_file_cache) {
         return NGX_CONF_OK;
     }

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1860,7 +1860,7 @@ ngx_http_send_header(ngx_http_request_t *r)
         r->headers_out.status_line.len = 0;
     }
 
-    return ngx_http_top_header_filter(r);
+    return ngx_http_safe_top_header_filter(r);
 }
 
 
@@ -1891,7 +1891,7 @@ ngx_http_send_early_hints(ngx_http_request_t *r)
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http send early hints \"%V?%V\"", &r->uri, &r->args);
 
-    return ngx_http_top_early_hints_filter(r);
+    return ngx_http_safe_top_early_hints_filter(r);
 }
 
 
@@ -1906,7 +1906,7 @@ ngx_http_output_filter(ngx_http_request_t *r, ngx_chain_t *in)
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
                    "http output filter \"%V?%V\"", &r->uri, &r->args);
 
-    rc = ngx_http_top_body_filter(r, in);
+    rc = ngx_http_safe_top_body_filter(r, in);
 
     if (rc == NGX_ERROR) {
         /* NGX_ERROR may be returned by any filter */
@@ -5403,6 +5403,18 @@ ngx_http_core_pool_size(ngx_conf_t *cf, void *post, void *data)
                            NGX_POOL_ALIGNMENT);
         return NGX_CONF_ERROR;
     }
+
+    return NGX_CONF_OK;
+}
+
+
+char *
+ngx_http_init_filters(ngx_conf_t *cf)
+{
+    ngx_http_safe_top_header_filter = ngx_http_top_header_filter;
+    ngx_http_safe_top_early_hints_filter = ngx_http_top_early_hints_filter;
+    ngx_http_safe_top_body_filter = ngx_http_top_body_filter;
+    ngx_http_safe_top_request_body_filter = ngx_http_top_request_body_filter;
 
     return NGX_CONF_OK;
 }

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -1075,7 +1075,7 @@ ngx_http_request_body_length_filter(ngx_http_request_t *r, ngx_chain_t *in)
         ll = &tl->next;
     }
 
-    rc = ngx_http_top_request_body_filter(r, out);
+    rc = ngx_http_safe_top_request_body_filter(r, out);
 
     ngx_chain_update_chains(r->pool, &rb->free, &rb->busy, &out,
                             (ngx_buf_tag_t) &ngx_http_read_client_request_body);
@@ -1259,7 +1259,7 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
         }
     }
 
-    rc = ngx_http_top_request_body_filter(r, out);
+    rc = ngx_http_safe_top_request_body_filter(r, out);
 
     ngx_chain_update_chains(r->pool, &rb->free, &rb->busy, &out,
                             (ngx_buf_tag_t) &ngx_http_read_client_request_body);

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -2228,7 +2228,7 @@ ngx_http_upstream_send_request(ngx_http_request_t *r, ngx_http_upstream_t *u,
         c->tcp_nopush = NGX_TCP_NOPUSH_UNSET;
     }
 
-    if (!u->conf->preserve_output) {
+    if (!u->preserve_output) {
         u->write_event_handler = ngx_http_upstream_dummy_handler;
     }
 
@@ -2400,7 +2400,7 @@ ngx_http_upstream_send_request_handler(ngx_http_request_t *r,
 
 #endif
 
-    if (u->header_sent && !u->conf->preserve_output) {
+    if (u->header_sent && !u->preserve_output) {
         u->write_event_handler = ngx_http_upstream_dummy_handler;
 
         (void) ngx_handle_write_event(c->write, 0);
@@ -3282,7 +3282,7 @@ ngx_http_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
     if (r->request_body && r->request_body->temp_file
         && r == r->main && !r->preserve_body
-        && !u->conf->preserve_output)
+        && !u->preserve_output)
     {
         ngx_pool_run_cleanup_file(r->pool, r->request_body->temp_file->file.fd);
         r->request_body->temp_file->file.fd = NGX_INVALID_FILE;

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -235,7 +235,6 @@ typedef struct {
     signed                           store:2;
     unsigned                         intercept_404:1;
     unsigned                         change_buffering:1;
-    unsigned                         preserve_output:1;
 
 #if (NGX_HTTP_SSL || NGX_COMPAT)
     ngx_ssl_t                       *ssl;
@@ -412,6 +411,7 @@ struct ngx_http_upstream_s {
     unsigned                         request_body_sent:1;
     unsigned                         request_body_blocked:1;
     unsigned                         header_sent:1;
+    unsigned                         preserve_output:1;
 };
 
 

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -33,6 +33,7 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
 {
     ngx_url_t                      u;
     ngx_uint_t                     i, j, n, r, w, t;
+    ngx_pool_t                    *pool;
     ngx_http_upstream_server_t    *server;
     ngx_http_upstream_rr_peer_t   *peer, **peerp;
     ngx_http_upstream_rr_peers_t  *peers, *backup;
@@ -40,6 +41,15 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
     ngx_uint_t                     resolve;
     ngx_http_core_loc_conf_t      *clcf;
     ngx_http_upstream_rr_peer_t  **rpeerp;
+#endif
+
+#if (NGX_DEBUG_PLOCK)
+    pool = ngx_create_child_pool(cf->pool);
+    if (pool == NULL) {
+        return NGX_ERROR;
+    }
+#else
+    pool = cf->pool;
 #endif
 
     us->peer.init = ngx_http_upstream_init_round_robin_peer;
@@ -136,12 +146,12 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
             return NGX_ERROR;
         }
 
-        peers = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_rr_peers_t));
+        peers = ngx_pcalloc(pool, sizeof(ngx_http_upstream_rr_peers_t));
         if (peers == NULL) {
             return NGX_ERROR;
         }
 
-        peer = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_rr_peer_t)
+        peer = ngx_pcalloc(pool, sizeof(ngx_http_upstream_rr_peer_t)
                                      * (n + r));
         if (peer == NULL) {
             return NGX_ERROR;
@@ -169,7 +179,7 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
 #if (NGX_HTTP_UPSTREAM_ZONE)
             if (server[i].host.len) {
 
-                peer[n].host = ngx_pcalloc(cf->pool,
+                peer[n].host = ngx_pcalloc(pool,
                                            sizeof(ngx_http_upstream_host_t));
                 if (peer[n].host == NULL) {
                     return NGX_ERROR;
@@ -258,12 +268,12 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
             return NGX_OK;
         }
 
-        backup = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_rr_peers_t));
+        backup = ngx_pcalloc(pool, sizeof(ngx_http_upstream_rr_peers_t));
         if (backup == NULL) {
             return NGX_ERROR;
         }
 
-        peer = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_rr_peer_t)
+        peer = ngx_pcalloc(pool, sizeof(ngx_http_upstream_rr_peer_t)
                                      * (n + r));
         if (peer == NULL) {
             return NGX_ERROR;
@@ -295,7 +305,7 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
 #if (NGX_HTTP_UPSTREAM_ZONE)
             if (server[i].host.len) {
 
-                peer[n].host = ngx_pcalloc(cf->pool,
+                peer[n].host = ngx_pcalloc(pool,
                                            sizeof(ngx_http_upstream_host_t));
                 if (peer[n].host == NULL) {
                     return NGX_ERROR;
@@ -363,7 +373,7 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
     u.host = us->host;
     u.port = us->port;
 
-    if (ngx_inet_resolve_host(cf->pool, &u) != NGX_OK) {
+    if (ngx_inet_resolve_host(pool, &u) != NGX_OK) {
         if (u.err) {
             ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                           "%s in upstream \"%V\" in %s:%ui",
@@ -375,12 +385,12 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
 
     n = u.naddrs;
 
-    peers = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_rr_peers_t));
+    peers = ngx_pcalloc(pool, sizeof(ngx_http_upstream_rr_peers_t));
     if (peers == NULL) {
         return NGX_ERROR;
     }
 
-    peer = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_rr_peer_t) * n);
+    peer = ngx_pcalloc(pool, sizeof(ngx_http_upstream_rr_peer_t) * n);
     if (peer == NULL) {
         return NGX_ERROR;
     }

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3921,7 +3921,7 @@ ngx_http_v2_read_request_body(ngx_http_request_t *r)
 
     /* set rb->filter_need_buffering */
 
-    rc = ngx_http_top_request_body_filter(r, NULL);
+    rc = ngx_http_safe_top_request_body_filter(r, NULL);
 
     if (rc != NGX_OK) {
         stream->skip_data = 1;
@@ -4255,7 +4255,7 @@ ngx_http_v2_filter_request_body(ngx_http_request_t *r)
 
 update:
 
-    rc = ngx_http_top_request_body_filter(r, cl);
+    rc = ngx_http_safe_top_request_body_filter(r, cl);
 
     ngx_chain_update_chains(r->pool, &rb->free, &rb->busy, &cl,
                             (ngx_buf_tag_t) &ngx_http_v2_filter_request_body);

--- a/src/http/v2/ngx_http_v2_module.c
+++ b/src/http/v2/ngx_http_v2_module.c
@@ -294,6 +294,8 @@ ngx_http_v2_create_main_conf(ngx_conf_t *cf)
 
     h2mcf->recv_buffer_size = NGX_CONF_UNSET_SIZE;
 
+    h2mcf->recv_buffer_id = ngx_cycle_ctx_add(cf);
+
     return h2mcf;
 }
 

--- a/src/http/v2/ngx_http_v2_module.h
+++ b/src/http/v2/ngx_http_v2_module.h
@@ -16,7 +16,7 @@
 
 typedef struct {
     size_t                          recv_buffer_size;
-    u_char                         *recv_buffer;
+    ngx_uint_t                      recv_buffer_id;
 } ngx_http_v2_main_conf_t;
 
 

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -1723,7 +1723,7 @@ done:
         rb->rest = (off_t) cscf->large_client_header_buffers.size;
     }
 
-    rc = ngx_http_top_request_body_filter(r, out);
+    rc = ngx_http_safe_top_request_body_filter(r, out);
 
     ngx_chain_update_chains(r->pool, &rb->free, &rb->busy, &out,
                             (ngx_buf_tag_t) &ngx_http_read_client_request_body);

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -70,7 +70,6 @@ ngx_http_v3_init_stream(ngx_connection_t *c)
 
     if (c->quic == NULL) {
         h3scf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_v3_module);
-        h3scf->quic.idle_timeout = clcf->keepalive_timeout;
 
         ngx_quic_run(c, &h3scf->quic);
         return;

--- a/src/os/unix/ngx_alloc.h
+++ b/src/os/unix/ngx_alloc.h
@@ -16,6 +16,11 @@
 void *ngx_alloc(size_t size, ngx_log_t *log);
 void *ngx_calloc(size_t size, ngx_log_t *log);
 
+void *ngx_kalloc(ngx_uint_t npages, ngx_log_t *log);
+ngx_int_t ngx_kfree(void *p, ngx_uint_t npages, ngx_log_t *log);
+ngx_int_t ngx_kmemlock(void *p, ngx_uint_t npages, ngx_log_t *log);
+ngx_int_t ngx_kmemunlock(void *p, ngx_uint_t npages, ngx_log_t *log);
+
 #define ngx_free          free
 
 

--- a/src/os/unix/ngx_channel.c
+++ b/src/os/unix/ngx_channel.c
@@ -195,7 +195,7 @@ ngx_read_channel(ngx_socket_t s, ngx_channel_t *ch, size_t size, ngx_log_t *log)
 }
 
 
-ngx_int_t
+ngx_connection_t *
 ngx_add_channel_event(ngx_cycle_t *cycle, ngx_fd_t fd, ngx_int_t event,
     ngx_event_handler_pt handler)
 {
@@ -205,7 +205,7 @@ ngx_add_channel_event(ngx_cycle_t *cycle, ngx_fd_t fd, ngx_int_t event,
     c = ngx_get_connection(fd, cycle->log);
 
     if (c == NULL) {
-        return NGX_ERROR;
+        return NULL;
     }
 
     c->pool = cycle->pool;
@@ -226,17 +226,17 @@ ngx_add_channel_event(ngx_cycle_t *cycle, ngx_fd_t fd, ngx_int_t event,
     if (ngx_add_conn && (ngx_event_flags & NGX_USE_EPOLL_EVENT) == 0) {
         if (ngx_add_conn(c) == NGX_ERROR) {
             ngx_free_connection(c);
-            return NGX_ERROR;
+            return NULL;
         }
 
     } else {
         if (ngx_add_event(ev, event, 0) == NGX_ERROR) {
             ngx_free_connection(c);
-            return NGX_ERROR;
+            return NULL;
         }
     }
 
-    return NGX_OK;
+    return c;
 }
 
 

--- a/src/os/unix/ngx_channel.h
+++ b/src/os/unix/ngx_channel.h
@@ -26,7 +26,7 @@ ngx_int_t ngx_write_channel(ngx_socket_t s, ngx_channel_t *ch, size_t size,
     ngx_log_t *log);
 ngx_int_t ngx_read_channel(ngx_socket_t s, ngx_channel_t *ch, size_t size,
     ngx_log_t *log);
-ngx_int_t ngx_add_channel_event(ngx_cycle_t *cycle, ngx_fd_t fd,
+ngx_connection_t *ngx_add_channel_event(ngx_cycle_t *cycle, ngx_fd_t fd,
     ngx_int_t event, ngx_event_handler_pt handler);
 void ngx_close_channel(ngx_fd_t *fd, ngx_log_t *log);
 

--- a/src/os/unix/ngx_file_aio_read.c
+++ b/src/os/unix/ngx_file_aio_read.c
@@ -141,6 +141,8 @@ ngx_file_aio_read(ngx_file_t *file, u_char *buf, size_t size, off_t offset,
     ev->ready = 0;
     ev->complete = 0;
 
+    ngx_save_cycle(ev->cycle);
+
     return ngx_file_aio_result(aio->file, aio, ev);
 }
 

--- a/src/os/unix/ngx_file_aio_read.c
+++ b/src/os/unix/ngx_file_aio_read.c
@@ -28,7 +28,7 @@
  */
 
 
-extern int  ngx_kqueue;
+extern ngx_thread_local int  ngx_kqueue;
 
 
 static ssize_t ngx_file_aio_result(ngx_file_t *file, ngx_event_aio_t *aio,

--- a/src/os/unix/ngx_files.c
+++ b/src/os/unix/ngx_files.c
@@ -22,7 +22,7 @@ static ssize_t ngx_writev_file(ngx_file_t *file, ngx_iovec_t *vec,
 
 #if (NGX_HAVE_FILE_AIO)
 
-ngx_uint_t  ngx_file_aio = 1;
+volatile ngx_uint_t  ngx_file_aio = 1;
 
 #endif
 

--- a/src/os/unix/ngx_files.h
+++ b/src/os/unix/ngx_files.h
@@ -381,7 +381,7 @@ ngx_int_t ngx_file_aio_init(ngx_file_t *file, ngx_pool_t *pool);
 ssize_t ngx_file_aio_read(ngx_file_t *file, u_char *buf, size_t size,
     off_t offset, ngx_pool_t *pool);
 
-extern ngx_uint_t  ngx_file_aio;
+extern volatile ngx_uint_t  ngx_file_aio;
 
 #endif
 

--- a/src/os/unix/ngx_linux_aio_read.c
+++ b/src/os/unix/ngx_linux_aio_read.c
@@ -106,6 +106,8 @@ ngx_file_aio_read(ngx_file_t *file, u_char *buf, size_t size, off_t offset,
 
     ev->handler = ngx_file_aio_event_handler;
 
+    ngx_save_cycle(ev->cycle);
+
     piocb[0] = &aio->aiocb;
 
     if (io_submit(ngx_aio_ctx, 1, piocb) == 1) {

--- a/src/os/unix/ngx_linux_aio_read.c
+++ b/src/os/unix/ngx_linux_aio_read.c
@@ -10,8 +10,8 @@
 #include <ngx_event.h>
 
 
-extern int            ngx_eventfd;
-extern aio_context_t  ngx_aio_ctx;
+extern ngx_thread_local int            ngx_eventfd;
+extern ngx_thread_local aio_context_t  ngx_aio_ctx;
 
 
 static void ngx_file_aio_event_handler(ngx_event_t *ev);

--- a/src/os/unix/ngx_process.h
+++ b/src/os/unix/ngx_process.h
@@ -36,6 +36,16 @@ typedef struct {
 } ngx_process_t;
 
 
+#if (NGX_THREADS)
+
+typedef struct {
+    ngx_socket_t        channel[2];
+    ngx_uint_t          active;  /* unsigned  active:1; */
+} ngx_thread_t;
+
+#endif
+
+
 typedef struct {
     char         *path;
     char         *name;
@@ -63,6 +73,10 @@ typedef struct {
 
 ngx_pid_t ngx_spawn_process(ngx_cycle_t *cycle,
     ngx_spawn_proc_pt proc, void *data, char *name, ngx_int_t respawn);
+#if (NGX_THREADS)
+ngx_int_t ngx_spawn_thread(ngx_cycle_t *cycle,
+    ngx_spawn_proc_pt proc, void *data, char *name);
+#endif
 ngx_pid_t ngx_execute(ngx_cycle_t *cycle, ngx_exec_ctx_t *ctx);
 ngx_int_t ngx_init_signals(ngx_log_t *log);
 void ngx_debug_point(void);
@@ -85,6 +99,13 @@ extern ngx_socket_t   ngx_channel;
 extern ngx_int_t      ngx_process_slot;
 extern ngx_int_t      ngx_last_process;
 extern ngx_process_t  ngx_processes[NGX_MAX_PROCESSES];
+#if (NGX_THREADS)
+extern ngx_int_t      ngx_last_thread;
+extern ngx_thread_t   ngx_threads[NGX_MAX_PROCESSES];
+
+extern ngx_thread_local ngx_int_t     ngx_thread_slot;
+extern ngx_thread_local ngx_socket_t  ngx_thread_channel;
+#endif
 
 
 #endif /* _NGX_PROCESS_H_INCLUDED_ */

--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -1325,6 +1325,10 @@ ngx_master_thread_cycle(ngx_cycle_t *cycle)
             ngx_destroy_pool(first_cycle->pool);
 
             first_cycle = next_cycle;
+
+#if (NGX_HAVE_MALLOC_TRIM)
+            malloc_trim(0);
+#endif
         }
 
         if (first_cycle == cycle) {

--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -685,8 +685,10 @@ ngx_master_process_exit(ngx_cycle_t *cycle)
     ngx_exit_log.writer = NULL;
 
     ngx_exit_cycle.log = &ngx_exit_log;
+    /* XXX
     ngx_exit_cycle.files = ngx_cycle->files;
     ngx_exit_cycle.files_n = ngx_cycle->files_n;
+    */
     ngx_cycle = &ngx_exit_cycle;
 
     ngx_destroy_pool(cycle->pool);
@@ -940,6 +942,7 @@ static void
 ngx_worker_process_exit(ngx_cycle_t *cycle)
 {
     ngx_uint_t         i;
+    ngx_cyclex_t      *cyclex;
     ngx_connection_t  *c;
 
     for (i = 0; cycle->modules[i]; i++) {
@@ -949,8 +952,10 @@ ngx_worker_process_exit(ngx_cycle_t *cycle)
     }
 
     if (ngx_exiting && !ngx_terminate) {
-        c = cycle->connections;
-        for (i = 0; i < cycle->connection_n; i++) {
+        cyclex = ngx_get_cyclex(cycle);
+
+        c = cyclex->connections;
+        for (i = 0; i < cyclex->connection_n; i++) {
             if (c[i].fd != -1
                 && c[i].read
                 && !c[i].read->accept
@@ -985,8 +990,10 @@ ngx_worker_process_exit(ngx_cycle_t *cycle)
     ngx_exit_log.writer = NULL;
 
     ngx_exit_cycle.log = &ngx_exit_log;
+    /* XXX
     ngx_exit_cycle.files = ngx_cycle->files;
     ngx_exit_cycle.files_n = ngx_cycle->files_n;
+    */
     ngx_cycle = &ngx_exit_cycle;
 
     ngx_destroy_pool(cycle->pool);

--- a/src/os/unix/ngx_process_cycle.h
+++ b/src/os/unix/ngx_process_cycle.h
@@ -18,13 +18,15 @@
 #define NGX_CMD_QUIT           3
 #define NGX_CMD_TERMINATE      4
 #define NGX_CMD_REOPEN         5
+#define NGX_CMD_RECONFIGURE    6
 
 
 #define NGX_PROCESS_SINGLE     0
-#define NGX_PROCESS_MASTER     1
-#define NGX_PROCESS_SIGNALLER  2
-#define NGX_PROCESS_WORKER     3
-#define NGX_PROCESS_HELPER     4
+#define NGX_PROCESS_THREAD     1
+#define NGX_PROCESS_MASTER     2
+#define NGX_PROCESS_SIGNALLER  3
+#define NGX_PROCESS_WORKER     4
+#define NGX_PROCESS_HELPER     5
 
 
 typedef struct {
@@ -35,16 +37,24 @@ typedef struct {
 
 
 void ngx_master_process_cycle(ngx_cycle_t *cycle);
+#if (NGX_THREADS)
+void ngx_master_thread_cycle(ngx_cycle_t *cycle);
+#endif
 void ngx_single_process_cycle(ngx_cycle_t *cycle);
 
 
 extern ngx_uint_t      ngx_process;
-extern ngx_uint_t      ngx_worker;
 extern ngx_pid_t       ngx_pid;
 extern ngx_pid_t       ngx_new_binary;
 extern ngx_uint_t      ngx_inherited;
 extern ngx_uint_t      ngx_daemonized;
-extern ngx_uint_t      ngx_exiting;
+
+extern ngx_thread_local ngx_uint_t  ngx_worker;
+extern ngx_thread_local ngx_uint_t  ngx_exiting;
+extern ngx_thread_local ngx_uint_t  ngx_thread;
+#if (NGX_THREADS)
+extern ngx_thread_local ngx_tid_t   ngx_tid;
+#endif
 
 extern sig_atomic_t    ngx_reap;
 extern sig_atomic_t    ngx_sigio;

--- a/src/os/unix/ngx_thread.h
+++ b/src/os/unix/ngx_thread.h
@@ -34,7 +34,9 @@ ngx_int_t ngx_thread_cond_wait(ngx_thread_cond_t *cond, ngx_thread_mutex_t *mtx,
     ngx_log_t *log);
 
 
-#define ngx_thread_local
+#define ngx_thread_local  __thread
+
+#define NGX_INVALID_TID       -1
 
 
 #if (NGX_LINUX)

--- a/src/os/unix/ngx_thread.h
+++ b/src/os/unix/ngx_thread.h
@@ -34,6 +34,9 @@ ngx_int_t ngx_thread_cond_wait(ngx_thread_cond_t *cond, ngx_thread_mutex_t *mtx,
     ngx_log_t *log);
 
 
+#define ngx_thread_local
+
+
 #if (NGX_LINUX)
 
 typedef pid_t      ngx_tid_t;
@@ -61,6 +64,8 @@ ngx_tid_t ngx_thread_tid(void);
 #define ngx_log_tid           ngx_thread_tid()
 
 #else
+
+#define ngx_thread_local
 
 #define ngx_log_tid           0
 #define NGX_TID_T_FMT         "%d"

--- a/src/stream/ngx_stream.c
+++ b/src/stream/ngx_stream.c
@@ -50,6 +50,7 @@ ngx_uint_t  ngx_stream_max_module;
 
 
 ngx_stream_filter_pt  ngx_stream_top_filter;
+ngx_stream_filter_pt  ngx_stream_safe_top_filter;
 
 
 static ngx_command_t  ngx_stream_commands[] = {
@@ -255,6 +256,10 @@ ngx_stream_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 return NGX_CONF_ERROR;
             }
         }
+    }
+
+    if (ngx_stream_init_filters(cf) != NGX_OK) {
+        return NGX_CONF_ERROR;
     }
 
     if (ngx_stream_variables_init_vars(cf) != NGX_OK) {

--- a/src/stream/ngx_stream.h
+++ b/src/stream/ngx_stream.h
@@ -363,6 +363,8 @@ ngx_int_t ngx_stream_validate_host(ngx_str_t *host, ngx_pool_t *pool,
 ngx_int_t ngx_stream_find_virtual_server(ngx_stream_session_t *s,
     ngx_str_t *host, ngx_stream_core_srv_conf_t **cscfp);
 
+char *ngx_stream_init_filters(ngx_conf_t *cf);
+
 void ngx_stream_init_connection(ngx_connection_t *c);
 void ngx_stream_session_handler(ngx_event_t *rev);
 void ngx_stream_finalize_session(ngx_stream_session_t *s, ngx_uint_t rc);
@@ -378,6 +380,7 @@ typedef ngx_int_t (*ngx_stream_filter_pt)(ngx_stream_session_t *s,
 
 
 extern ngx_stream_filter_pt  ngx_stream_top_filter;
+extern ngx_stream_filter_pt  ngx_stream_safe_top_filter;
 
 
 #endif /* _NGX_STREAM_H_INCLUDED_ */

--- a/src/stream/ngx_stream_core_module.c
+++ b/src/stream/ngx_stream_core_module.c
@@ -1502,3 +1502,12 @@ ngx_stream_core_resolver(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     return NGX_CONF_OK;
 }
+
+
+char *
+ngx_stream_init_filters(ngx_conf_t *cf)
+{
+    ngx_stream_safe_top_filter = ngx_stream_top_filter;
+
+    return NGX_CONF_OK;
+}

--- a/src/stream/ngx_stream_log_module.c
+++ b/src/stream/ngx_stream_log_module.c
@@ -1083,7 +1083,11 @@ ngx_stream_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (ngx_strncmp(value[1].data, "syslog:", 7) == 0) {
 
+#if (NGX_DEBUG_PLOCK)
+        peer = ngx_pmcalloc(cf->pool, sizeof(ngx_syslog_peer_t));
+#else
         peer = ngx_pcalloc(cf->pool, sizeof(ngx_syslog_peer_t));
+#endif
         if (peer == NULL) {
             return NGX_CONF_ERROR;
         }

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -1784,7 +1784,7 @@ ngx_stream_proxy_process(ngx_stream_session_t *s, ngx_uint_t from_upstream,
             if (*out || *busy || dst->buffered) {
                 c->log->action = send_action;
 
-                rc = ngx_stream_top_filter(s, *out, from_upstream);
+                rc = ngx_stream_safe_top_filter(s, *out, from_upstream);
 
                 if (rc == NGX_ERROR) {
                     ngx_stream_proxy_finalize(s, NGX_STREAM_OK);

--- a/src/stream/ngx_stream_return_module.c
+++ b/src/stream/ngx_stream_return_module.c
@@ -148,7 +148,7 @@ ngx_stream_return_write_handler(ngx_event_t *ev)
 
     ctx = ngx_stream_get_module_ctx(s, ngx_stream_return_module);
 
-    if (ngx_stream_top_filter(s, ctx->out, 1) == NGX_ERROR) {
+    if (ngx_stream_safe_top_filter(s, ctx->out, 1) == NGX_ERROR) {
         ngx_stream_finalize_session(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
         return;
     }

--- a/src/stream/ngx_stream_upstream_random_module.c
+++ b/src/stream/ngx_stream_upstream_random_module.c
@@ -17,11 +17,16 @@ typedef struct {
 
 typedef struct {
     ngx_uint_t                              two;
-#if (NGX_STREAM_UPSTREAM_ZONE)
+    ngx_uint_t                              ctx_id;
+} ngx_stream_upstream_random_srv_conf_t;
+
+
+typedef struct {
+#if (NGX_HTTP_UPSTREAM_ZONE)
     ngx_uint_t                              config;
 #endif
     ngx_stream_upstream_random_range_t     *ranges;
-} ngx_stream_upstream_random_srv_conf_t;
+} ngx_stream_upstream_random_ctx_t;
 
 
 typedef struct {
@@ -35,8 +40,8 @@ typedef struct {
 
 static ngx_int_t ngx_stream_upstream_init_random(ngx_conf_t *cf,
     ngx_stream_upstream_srv_conf_t *us);
-static ngx_int_t ngx_stream_upstream_update_random(ngx_pool_t *pool,
-    ngx_stream_upstream_srv_conf_t *us);
+static ngx_int_t ngx_stream_upstream_update_random(
+    ngx_stream_upstream_srv_conf_t *us, ngx_uint_t config);
 
 static ngx_int_t ngx_stream_upstream_init_random_peer(ngx_stream_session_t *s,
     ngx_stream_upstream_srv_conf_t *us);
@@ -105,39 +110,56 @@ ngx_stream_upstream_init_random(ngx_conf_t *cf,
 
     us->peer.init = ngx_stream_upstream_init_random_peer;
 
-#if (NGX_STREAM_UPSTREAM_ZONE)
-    if (us->shm_zone) {
-        return NGX_OK;
-    }
-#endif
-
-    return ngx_stream_upstream_update_random(cf->pool, us);
+    return NGX_OK;
 }
 
 
 static ngx_int_t
-ngx_stream_upstream_update_random(ngx_pool_t *pool,
-    ngx_stream_upstream_srv_conf_t *us)
+ngx_stream_upstream_update_random(ngx_stream_upstream_srv_conf_t *us,
+    ngx_uint_t config)
 {
     size_t                                  size;
     ngx_uint_t                              i, total_weight;
     ngx_stream_upstream_rr_peer_t          *peer;
     ngx_stream_upstream_rr_peers_t         *peers;
+    ngx_stream_upstream_random_ctx_t       *ctx;
     ngx_stream_upstream_random_range_t     *ranges;
     ngx_stream_upstream_random_srv_conf_t  *rcf;
 
     rcf = ngx_stream_conf_upstream_srv_conf(us,
                                             ngx_stream_upstream_random_module);
-    if (rcf->ranges) {
-        ngx_free(rcf->ranges);
-        rcf->ranges = NULL;
+
+    ctx = ngx_get_cycle_ctx(ngx_cycle, rcf->ctx_id);
+
+    if (ctx == NULL) {
+        ctx = ngx_pcalloc(ngx_get_cyclex(ngx_cycle)->pool,
+                          sizeof(ngx_stream_upstream_random_ctx_t));
+        if (ctx == NULL) {
+            return NGX_ERROR;
+        }
+
+        ngx_set_cycle_ctx(ngx_cycle, rcf->ctx_id, ctx);
+    }
+
+    if (ctx->ranges
+#if (NGX_HTTP_UPSTREAM_ZONE)
+        && ctx->config == config
+#endif
+       )
+    {
+        return NGX_OK;
+    }
+
+    if (ctx->ranges) {
+        ngx_free(ctx->ranges);
+        ctx->ranges = NULL;
     }
 
     peers = us->peer.data;
 
     size = peers->number * sizeof(ngx_stream_upstream_random_range_t);
 
-    ranges = pool ? ngx_palloc(pool, size) : ngx_alloc(size, ngx_cycle->log);
+    ranges = ngx_alloc(size, ngx_cycle->log);
     if (ranges == NULL) {
         return NGX_ERROR;
     }
@@ -150,7 +172,10 @@ ngx_stream_upstream_update_random(ngx_pool_t *pool,
         total_weight += peer->weight;
     }
 
-    rcf->ranges = ranges;
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    ctx->config = config;
+#endif
+    ctx->ranges = ranges;
 
     return NGX_OK;
 }
@@ -160,6 +185,7 @@ static ngx_int_t
 ngx_stream_upstream_init_random_peer(ngx_stream_session_t *s,
     ngx_stream_upstream_srv_conf_t *us)
 {
+    ngx_uint_t                               config;
     ngx_stream_upstream_random_srv_conf_t   *rcf;
     ngx_stream_upstream_random_peer_data_t  *rp;
 
@@ -191,20 +217,20 @@ ngx_stream_upstream_init_random_peer(ngx_stream_session_t *s,
     rp->conf = rcf;
     rp->tries = 0;
 
-    ngx_stream_upstream_rr_peers_rlock(rp->rrp.peers);
+    config = 0;
 
-#if (NGX_STREAM_UPSTREAM_ZONE)
-    if (rp->rrp.peers->config
-        && (rcf->ranges == NULL || rcf->config != *rp->rrp.peers->config))
-    {
-        if (ngx_stream_upstream_update_random(NULL, us) != NGX_OK) {
-            ngx_stream_upstream_rr_peers_unlock(rp->rrp.peers);
-            return NGX_ERROR;
-        }
-
-        rcf->config = *rp->rrp.peers->config;
+#if (NGX_HTTP_UPSTREAM_ZONE)
+    if (rp->rrp.peers->config) {
+        config = *rp->rrp.peers->config;
     }
 #endif
+
+    ngx_stream_upstream_rr_peers_rlock(rp->rrp.peers);
+
+    if (ngx_stream_upstream_update_random(us, config) != NGX_OK) {
+        ngx_stream_upstream_rr_peers_unlock(rp->rrp.peers);
+        return NGX_ERROR;
+    }
 
     ngx_stream_upstream_rr_peers_unlock(rp->rrp.peers);
 
@@ -222,6 +248,7 @@ ngx_stream_upstream_get_random_peer(ngx_peer_connection_t *pc, void *data)
     ngx_uint_t                           i, n;
     ngx_stream_upstream_rr_peer_t       *peer;
     ngx_stream_upstream_rr_peers_t      *peers;
+    ngx_stream_upstream_random_ctx_t    *ctx;
     ngx_stream_upstream_rr_peer_data_t  *rrp;
 
     ngx_log_debug1(NGX_LOG_DEBUG_STREAM, pc->log, 0,
@@ -249,11 +276,13 @@ ngx_stream_upstream_get_random_peer(ngx_peer_connection_t *pc, void *data)
 
     now = ngx_time();
 
+    ctx = ngx_get_cycle_ctx(ngx_cycle, rp->conf->ctx_id);
+
     for ( ;; ) {
 
         i = ngx_stream_upstream_peek_random_peer(peers, rp);
 
-        peer = rp->conf->ranges[i].peer;
+        peer = ctx->ranges[i].peer;
 
         n = i / (8 * sizeof(uintptr_t));
         m = (uintptr_t) 1 << i % (8 * sizeof(uintptr_t));
@@ -324,6 +353,7 @@ ngx_stream_upstream_get_random2_peer(ngx_peer_connection_t *pc, void *data)
     ngx_uint_t                           i, n, p;
     ngx_stream_upstream_rr_peer_t       *peer, *prev;
     ngx_stream_upstream_rr_peers_t      *peers;
+    ngx_stream_upstream_random_ctx_t    *ctx;
     ngx_stream_upstream_rr_peer_data_t  *rrp;
 
     ngx_log_debug1(NGX_LOG_DEBUG_STREAM, pc->log, 0,
@@ -357,11 +387,13 @@ ngx_stream_upstream_get_random2_peer(ngx_peer_connection_t *pc, void *data)
     p = 0;
 #endif
 
+    ctx = ngx_get_cycle_ctx(ngx_cycle, rp->conf->ctx_id);
+
     for ( ;; ) {
 
         i = ngx_stream_upstream_peek_random_peer(peers, rp);
 
-        peer = rp->conf->ranges[i].peer;
+        peer = ctx->ranges[i].peer;
 
         if (peer == prev) {
             goto next;
@@ -435,7 +467,10 @@ static ngx_uint_t
 ngx_stream_upstream_peek_random_peer(ngx_stream_upstream_rr_peers_t *peers,
     ngx_stream_upstream_random_peer_data_t *rp)
 {
-    ngx_uint_t  i, j, k, x;
+    ngx_uint_t                         i, j, k, x;
+    ngx_stream_upstream_random_ctx_t  *ctx;
+
+    ctx = ngx_get_cycle_ctx(ngx_cycle, rp->conf->ctx_id);
 
     x = ngx_random() % peers->total_weight;
 
@@ -445,7 +480,7 @@ ngx_stream_upstream_peek_random_peer(ngx_stream_upstream_rr_peers_t *peers,
     while (j - i > 1) {
         k = (i + j) / 2;
 
-        if (x < rp->conf->ranges[k].range) {
+        if (x < ctx->ranges[k].range) {
             j = k;
 
         } else {
@@ -472,6 +507,8 @@ ngx_stream_upstream_random_create_conf(ngx_conf_t *cf)
      *
      *     conf->two = 0;
      */
+
+    conf->ctx_id = ngx_cycle_ctx_add(cf);
 
     return conf;
 }

--- a/src/stream/ngx_stream_upstream_round_robin.c
+++ b/src/stream/ngx_stream_upstream_round_robin.c
@@ -39,6 +39,7 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
 {
     ngx_url_t                        u;
     ngx_uint_t                       i, j, n, r, w, t;
+    ngx_pool_t                      *pool;
     ngx_stream_upstream_server_t    *server;
     ngx_stream_upstream_rr_peer_t   *peer, **peerp;
     ngx_stream_upstream_rr_peers_t  *peers, *backup;
@@ -46,6 +47,15 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
     ngx_uint_t                       resolve;
     ngx_stream_core_srv_conf_t      *cscf;
     ngx_stream_upstream_rr_peer_t  **rpeerp;
+#endif
+
+#if (NGX_DEBUG_PLOCK)
+    pool = ngx_create_child_pool(cf->pool);
+    if (pool == NULL) {
+        return NGX_ERROR;
+    }
+#else
+    pool = cf->pool;
 #endif
 
     us->peer.init = ngx_stream_upstream_init_round_robin_peer;
@@ -143,12 +153,12 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
             return NGX_ERROR;
         }
 
-        peers = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_rr_peers_t));
+        peers = ngx_pcalloc(pool, sizeof(ngx_stream_upstream_rr_peers_t));
         if (peers == NULL) {
             return NGX_ERROR;
         }
 
-        peer = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_rr_peer_t)
+        peer = ngx_pcalloc(pool, sizeof(ngx_stream_upstream_rr_peer_t)
                                      * (n + r));
         if (peer == NULL) {
             return NGX_ERROR;
@@ -176,7 +186,7 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
 #if (NGX_STREAM_UPSTREAM_ZONE)
             if (server[i].host.len) {
 
-                peer[n].host = ngx_pcalloc(cf->pool,
+                peer[n].host = ngx_pcalloc(pool,
                                            sizeof(ngx_stream_upstream_host_t));
                 if (peer[n].host == NULL) {
                     return NGX_ERROR;
@@ -264,12 +274,12 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
             return NGX_OK;
         }
 
-        backup = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_rr_peers_t));
+        backup = ngx_pcalloc(pool, sizeof(ngx_stream_upstream_rr_peers_t));
         if (backup == NULL) {
             return NGX_ERROR;
         }
 
-        peer = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_rr_peer_t)
+        peer = ngx_pcalloc(pool, sizeof(ngx_stream_upstream_rr_peer_t)
                                      * (n + r));
         if (peer == NULL) {
             return NGX_ERROR;
@@ -301,7 +311,7 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
 #if (NGX_STREAM_UPSTREAM_ZONE)
             if (server[i].host.len) {
 
-                peer[n].host = ngx_pcalloc(cf->pool,
+                peer[n].host = ngx_pcalloc(pool,
                                            sizeof(ngx_stream_upstream_host_t));
                 if (peer[n].host == NULL) {
                     return NGX_ERROR;
@@ -368,7 +378,7 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
     u.host = us->host;
     u.port = us->port;
 
-    if (ngx_inet_resolve_host(cf->pool, &u) != NGX_OK) {
+    if (ngx_inet_resolve_host(pool, &u) != NGX_OK) {
         if (u.err) {
             ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                           "%s in upstream \"%V\" in %s:%ui",
@@ -380,12 +390,12 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
 
     n = u.naddrs;
 
-    peers = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_rr_peers_t));
+    peers = ngx_pcalloc(pool, sizeof(ngx_stream_upstream_rr_peers_t));
     if (peers == NULL) {
         return NGX_ERROR;
     }
 
-    peer = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_rr_peer_t) * n);
+    peer = ngx_pcalloc(pool, sizeof(ngx_stream_upstream_rr_peer_t) * n);
     if (peer == NULL) {
         return NGX_ERROR;
     }

--- a/src/stream/ngx_stream_upstream_zone_module.c
+++ b/src/stream/ngx_stream_upstream_zone_module.c
@@ -636,7 +636,8 @@ ngx_stream_upstream_zone_init_worker(ngx_cycle_t *cycle)
     ngx_stream_upstream_main_conf_t  *umcf;
 
     if (ngx_process != NGX_PROCESS_WORKER
-        && ngx_process != NGX_PROCESS_SINGLE)
+        && ngx_process != NGX_PROCESS_SINGLE
+        && ngx_process != NGX_PROCESS_THREAD)
     {
         return NGX_OK;
     }
@@ -706,7 +707,8 @@ ngx_stream_upstream_zone_exit_worker(ngx_cycle_t *cycle)
     ngx_stream_upstream_main_conf_t  *umcf;
 
     if (ngx_process != NGX_PROCESS_WORKER
-        && ngx_process != NGX_PROCESS_SINGLE)
+        && ngx_process != NGX_PROCESS_SINGLE
+        && ngx_process != NGX_PROCESS_THREAD)
     {
         return;
     }

--- a/src/stream/ngx_stream_variables.c
+++ b/src/stream/ngx_stream_variables.c
@@ -142,7 +142,7 @@ ngx_stream_variable_value_t  ngx_stream_variable_true_value =
     ngx_stream_variable("1");
 
 
-static ngx_uint_t  ngx_stream_variable_depth = 100;
+static ngx_thread_local ngx_uint_t  ngx_stream_variable_depth = 100;
 
 
 ngx_stream_variable_t *

--- a/src/stream/ngx_stream_variables.c
+++ b/src/stream/ngx_stream_variables.c
@@ -46,6 +46,10 @@ static ngx_int_t ngx_stream_variable_hostname(ngx_stream_session_t *s,
     ngx_stream_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_stream_variable_pid(ngx_stream_session_t *s,
     ngx_stream_variable_value_t *v, uintptr_t data);
+#if (NGX_THREADS)
+static ngx_int_t ngx_stream_variable_tid(ngx_stream_session_t *s,
+    ngx_stream_variable_value_t *v, uintptr_t data);
+#endif
 static ngx_int_t ngx_stream_variable_msec(ngx_stream_session_t *s,
     ngx_stream_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_stream_variable_time_iso8601(ngx_stream_session_t *s,
@@ -119,6 +123,11 @@ static ngx_stream_variable_t  ngx_stream_core_variables[] = {
 
     { ngx_string("pid"), NULL, ngx_stream_variable_pid,
       0, 0, 0 },
+
+#if (NGX_THREADS)
+    { ngx_string("tid"), NULL, ngx_stream_variable_tid,
+      0, 0, 0 },
+#endif
 
     { ngx_string("msec"), NULL, ngx_stream_variable_msec,
       0, NGX_STREAM_VAR_NOCACHEABLE, 0 },
@@ -886,6 +895,31 @@ ngx_stream_variable_pid(ngx_stream_session_t *s,
 
     return NGX_OK;
 }
+
+
+#if (NGX_THREADS)
+
+static ngx_int_t
+ngx_stream_variable_tid(ngx_stream_session_t *s,
+    ngx_stream_variable_value_t *v, uintptr_t data)
+{
+    u_char  *p;
+
+    p = ngx_pnalloc(s->connection->pool, NGX_INT64_LEN);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    v->len = ngx_sprintf(p, NGX_TID_T_FMT, ngx_tid) - p;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+    v->data = p;
+
+    return NGX_OK;
+}
+
+#endif
 
 
 static ngx_int_t


### PR DESCRIPTION
This PR adds support for worker threads in NGINX. Previously NGINX only supported worker processes.

### Pros
- configuration reload with minimum memory use in existing threads (see also #1037)
- shared SSL data
- shared SSL certificate cache
- shared OCSP stapling responses
- upstreams do not need zones for shared state

### Cons
- cannot set a separate user for workers
- cannot restart workers on crash

### Syntax

`threads on;`

The existing `worker_processes` directive sets worker threads number if threads are enabled.

### Build
```
~/nginx $ auto/configure --with-threads
~/nginx $ make
```

### Configuration
```
threads on;
worker_processes 10;                                                                      
                                                                                 
error_log logs/error.log debug;                                                  
                                                                                 
events {                                                                         
}                                                                                
                                                                                 
http {                                                                           
    server {                                                                     
        listen 8000;                                                             
                                                                                 
        location / {                                                             
            return 200 $pid-$tid;                                                           
        }                                                                        
    }                                                                            
}
```
A new variable `$tid` returns thread id similar to the existing `$pid` variable for process id.

### Threads
```
$ pstree -pa|grep nginx
  |-nginx,2124719 -c conf/nginx.conf
  |   |-{nginx},2124720
  |   |-{nginx},2124721
  |   |-{nginx},2124722
  |   |-{nginx},2124723
  |   |-{nginx},2124724
  |   |-{nginx},2124725
  |   |-{nginx},2124726
  |   |-{nginx},2124727
  |   |-{nginx},2124728
  |   `-{nginx},2124729
```

### Testing

Testing threads:
```
~/nginx-tests $ TEST_NGINX_GLOBALS="threads on;" prove .
```

In the multi-thread environment NGINX configuration needs to be read-only or require locks for access.
If the `NGX_DEBUG_PLOCK` macro is set, cycle memory pages are marked as read-only to make sure they are not written to. You can run the tests even in the regular worker process mode to find memory write issues.
```
~/nginx $ auto/configure --with-cc-opt=-DNGX_DEBUG_PLOCK ...
~/nginx $ make
~/nginx $ cd ~/nginx-tests
~/nginx-tests $ prove .
```

### Unsupported
- cannot change modules
- cannot set timer_resolution
- cannot change event method
- cannot change worker threads number
- cannot do binary reload
- cannot reopen files
- win32 unsupported

### TODO
- fix thread pools
- fix cache loader/manager
- support more event methods