### PR TITLE
Proxy: move preserve_output flag to ngx_http_upstream_t.

### DIFF
--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -591,6 +591,8 @@ ngx_http_grpc_handler(ngx_http_request_t *r)
         }
     }
 
+    u->preserve_output = 1;
+
     u->output.tag = (ngx_buf_tag_t) &ngx_http_grpc_module;
 
     u->conf = &glcf->upstream;
@@ -4430,7 +4432,6 @@ ngx_http_grpc_create_loc_conf(ngx_conf_t *cf)
     conf->upstream.force_ranges = 0;
     conf->upstream.pass_trailers = 1;
     conf->upstream.pass_early_hints = 1;
-    conf->upstream.preserve_output = 1;
 
     conf->headers_source = NGX_CONF_UNSET_PTR;
 

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -236,8 +236,6 @@ ngx_http_proxy_v2_handler(ngx_http_request_t *r)
 
     plcf = ngx_http_get_module_loc_conf(r, ngx_http_proxy_module);
 
-    plcf->upstream.preserve_output = 1;
-
     u = r->upstream;
 
     if (plcf->proxy_lengths == NULL) {
@@ -256,6 +254,8 @@ ngx_http_proxy_v2_handler(ngx_http_request_t *r)
 #if (NGX_HTTP_SSL)
     ngx_str_set(&u->ssl_alpn_protocol, NGX_HTTP_V2_ALPN_PROTO);
 #endif
+
+    u->preserve_output = 1;
 
     u->output.tag = (ngx_buf_tag_t) &ngx_http_proxy_v2_module;
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -2228,7 +2228,7 @@ ngx_http_upstream_send_request(ngx_http_request_t *r, ngx_http_upstream_t *u,
         c->tcp_nopush = NGX_TCP_NOPUSH_UNSET;
     }
 
-    if (!u->conf->preserve_output) {
+    if (!u->preserve_output) {
         u->write_event_handler = ngx_http_upstream_dummy_handler;
     }
 
@@ -2400,7 +2400,7 @@ ngx_http_upstream_send_request_handler(ngx_http_request_t *r,
 
 #endif
 
-    if (u->header_sent && !u->conf->preserve_output) {
+    if (u->header_sent && !u->preserve_output) {
         u->write_event_handler = ngx_http_upstream_dummy_handler;
 
         (void) ngx_handle_write_event(c->write, 0);
@@ -3282,7 +3282,7 @@ ngx_http_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
     if (r->request_body && r->request_body->temp_file
         && r == r->main && !r->preserve_body
-        && !u->conf->preserve_output)
+        && !u->preserve_output)
     {
         ngx_pool_run_cleanup_file(r->pool, r->request_body->temp_file->file.fd);
         r->request_body->temp_file->file.fd = NGX_INVALID_FILE;

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -235,7 +235,6 @@ typedef struct {
     signed                           store:2;
     unsigned                         intercept_404:1;
     unsigned                         change_buffering:1;
-    unsigned                         preserve_output:1;
 
 #if (NGX_HTTP_SSL || NGX_COMPAT)
     ngx_ssl_t                       *ssl;
@@ -412,6 +411,7 @@ struct ngx_http_upstream_s {
     unsigned                         request_body_sent:1;
     unsigned                         request_body_blocked:1;
     unsigned                         header_sent:1;
+    unsigned                         preserve_output:1;
 };
 
 


### PR DESCRIPTION
Previously the flag was in `ngx_http_upstream_conf_t` and was changed in runtime by the HTTP/2 proxy handler.  While currently this has no visible side-effects since proxy HTTP version is static, writing to configuration memory triggers unnecessary copy-on-writes.

This was found while testing nginx-threads with write-protected configuration.