### PR TITLE
HTTP: add `$uargs` and $uarg_*` variable family that decodes UTF-8 string in advance

### DIFF
--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -42,6 +42,8 @@ static ngx_int_t ngx_http_variable_cookie(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_variable_argument(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_variable_argument_unescape(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
 #if (NGX_HAVE_TCP_INFO)
 static ngx_int_t ngx_http_variable_tcpinfo(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
@@ -406,6 +408,9 @@ static ngx_http_variable_t  ngx_http_core_variables[] = {
       0, NGX_HTTP_VAR_PREFIX, 0 },
 
     { ngx_string("arg_"), NULL, ngx_http_variable_argument,
+      0, NGX_HTTP_VAR_NOCACHEABLE|NGX_HTTP_VAR_PREFIX, 0 },
+
+    { ngx_string("uarg_"), NULL, ngx_http_variable_argument_unescape,
       0, NGX_HTTP_VAR_NOCACHEABLE|NGX_HTTP_VAR_PREFIX, 0 },
 
       ngx_http_null_variable
@@ -1125,6 +1130,44 @@ ngx_http_variable_argument(ngx_http_request_t *r, ngx_http_variable_value_t *v,
 
     v->data = value.data;
     v->len = value.len;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_variable_argument_unescape(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    ngx_str_t *name = (ngx_str_t *) data;
+
+    u_char     *arg, *dst, *src;
+    size_t      len;
+    ngx_str_t   value;
+
+    len = name->len - (sizeof("uarg_") - 1);
+    arg = name->data + sizeof("uarg_") - 1;
+
+    if (len == 0 || ngx_http_arg(r, arg, len, &value) != NGX_OK) {
+        v->not_found = 1;
+        return NGX_OK;
+    }
+
+    /* allocate buffer for unescaped value (can only shrink or stay same) */
+    dst = ngx_pnalloc(r->pool, value.len);
+    if (dst == NULL) {
+        return NGX_ERROR;
+    }
+
+    v->data = dst;
+    src = value.data;
+
+    ngx_unescape_uri(&dst, &src, value.len, 0);
+
+    v->len = dst - v->data;
     v->valid = 1;
     v->no_cacheable = 0;
     v->not_found = 0;


### PR DESCRIPTION
### Proposed changes
- Close #1096 
- Add `$uargs` and `$uarg_*` variable families for URL-decoded query string access
- Added new variables instead of modifying current one to minimize regressions and side effects

### Description
Nginx's existing `$args` and `$arg_*` variables return raw, URL-encoded query strings as received from the client. No automatic URL decoding is performed before variable comparison or regex matching. This behavior can lead to security filter bypasses when applications downstream decode UTF-8/URL-encoded strings.

Example bypass scenario:
```nginx
location = /index.php {
    if ($arg_r = "slash/included") {
        return 403;
    }
    fastcgi_pass php:9000;
}
```
- ?r=slash/included → Blocked (403) ✓
- ?r=slash%2Fincluded → Bypasses (200) ✗
- ?r=%73lash/included → Bypasses (200) ✗

The URL-encoded variants bypass the filter because %2F (encoded /) and %73 (encoded s) are not decoded before comparison.

### Solution
The new $uarg_* and $uargs variables decode URL-encoded characters using ngx_unescape_uri() before returning values, enabling proper filtering:

```nginx
location = /index.php {
    if ($uarg_r = "slash/included") {
        return 403;
    }
    fastcgi_pass php:9000;
}
```
Now all encoded variants are properly matched:

- ?r=slash/included → Blocked (403) ✓
- ?r=slash%2Fincluded → Blocked (403) ✓
- ?r=%73lash/included → Blocked (403) ✓


### Testing
- Test Script
```shell
curl "http://localhost:8080/index.html?r=slash/included"
curl "http://localhost:8080/index.html?r=slash%2Fincluded"
curl "http://localhost:8080/index.html?r=%73lash/included"
```

### Screenshots
- As-is
  <img width="662" height="299" alt="asis" src="https://github.com/user-attachments/assets/7e165b4a-8225-4df8-b5da-e8d002ad91fd" />
- To-be
  <img width="698" height="558" alt="tobe" src="https://github.com/user-attachments/assets/9f7b95c9-ee1e-4a27-a456-a93323c2d018" />

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
