### PR TITLE
Add request_body_length variable

### DIFF
--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -1541,6 +1541,7 @@ ngx_http_process_request_headers(ngx_event_t *rev)
                            "http header done");
 
             r->request_length += r->header_in->pos - r->header_name_start;
+            r->request_header_length = r->request_length;
 
             r->http_state = NGX_HTTP_PROCESS_REQUEST_STATE;
 

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -450,6 +450,7 @@ struct ngx_http_request_s {
     size_t                            header_size;
 
     off_t                             request_length;
+    off_t                             request_header_length;
 
     ngx_uint_t                        err_status;
 

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -105,6 +105,8 @@ static ngx_int_t ngx_http_variable_request_body_file(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_variable_request_length(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_variable_request_body_length(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_variable_request_time(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_variable_request_id(ngx_http_request_t *r,
@@ -307,6 +309,9 @@ static ngx_http_variable_t  ngx_http_core_variables[] = {
       0, 0, 0 },
 
     { ngx_string("request_length"), NULL, ngx_http_variable_request_length,
+      0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+
+    { ngx_string("request_body_length"), NULL, ngx_http_variable_request_body_length,
       0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
 
     { ngx_string("request_time"), NULL, ngx_http_variable_request_time,
@@ -2256,6 +2261,28 @@ ngx_http_variable_request_length(ngx_http_request_t *r,
     }
 
     v->len = ngx_sprintf(p, "%O", r->request_length) - p;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+    v->data = p;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_variable_request_body_length(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    u_char  *p;
+
+    p = ngx_pnalloc(r->pool, NGX_OFF_T_LEN);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    v->len = ngx_sprintf(p, "%O",
+                         r->request_length - r->request_header_length) - p;
     v->valid = 1;
     v->no_cacheable = 0;
     v->not_found = 0;

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3886,6 +3886,7 @@ ngx_http_v2_run_request(ngx_http_request_t *r)
     h2c = r->stream->connection;
 
     h2c->payload_bytes += r->request_length;
+    r->request_header_length = r->request_length;
 
     ngx_http_process_request(r);
 

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -551,6 +551,7 @@ ngx_http_v3_process_request(ngx_event_t *rev)
 
         r->request_length += b->pos - p;
         h3c->total_bytes += b->pos - p;
+        r->request_header_length = r->request_length;
 
         if (ngx_http_v3_check_flood(c) != NGX_OK) {
             ngx_http_close_request(r, NGX_HTTP_CLOSE);


### PR DESCRIPTION
### Proposed changes

Add `request_body_length` variable whose value is number of bytes received from a client, not counting the request line and the request headers.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
