### PR TITLE
Use Debian PCRE2 dev package name in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ sudo apt install gcc make
 ### Installing dependency libraries
 
 ```bash
-sudo apt install libpcre3-dev zlib1g-dev
+sudo apt install libpcre2-dev zlib1g-dev
 ```
 
 > [!WARNING]


### PR DESCRIPTION
### Proposed changes

The libpcre3-dev package is [no longer in Debian](https://tracker.debian.org/pkg/pcre3). Replace it with libpcre2-dev in the README build instructions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
