### PR TITLE
Dynamic locations

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -710,6 +710,19 @@ if [ $HTTP = YES ]; then
         . auto/module
     fi
 
+    if [ $HTTP_EVAL = YES ]; then
+        have=NGX_HTTP_EVAL . auto/have
+
+        ngx_module_name=ngx_http_eval_module
+        ngx_module_incs=
+        ngx_module_deps=
+        ngx_module_srcs=src/http/modules/ngx_http_eval_module.c
+        ngx_module_libs=
+        ngx_module_link=$HTTP_EVAL
+
+        . auto/module
+    fi
+
     if [ $HTTP_SSL = YES ]; then
         USE_OPENSSL=YES
         have=NGX_HTTP_SSL . auto/have

--- a/auto/options
+++ b/auto/options
@@ -84,6 +84,7 @@ HTTP_MAP=YES
 HTTP_SPLIT_CLIENTS=YES
 HTTP_REFERER=YES
 HTTP_REWRITE=YES
+HTTP_EVAL=YES
 HTTP_PROXY=YES
 HTTP_FASTCGI=YES
 HTTP_UWSGI=YES
@@ -274,6 +275,7 @@ $0: warning: the \"--with-ipv6\" option is deprecated"
         --without-http_split_clients_module) HTTP_SPLIT_CLIENTS=NO  ;;
         --without-http_referer_module)   HTTP_REFERER=NO            ;;
         --without-http_rewrite_module)   HTTP_REWRITE=NO            ;;
+        --without-http_eval_module)      HTTP_EVAL=NO               ;;
         --without-http_proxy_module)     HTTP_PROXY=NO              ;;
         --without-http_fastcgi_module)   HTTP_FASTCGI=NO            ;;
         --without-http_uwsgi_module)     HTTP_UWSGI=NO              ;;
@@ -494,6 +496,7 @@ cat << END
   --without-http_split_clients_module disable ngx_http_split_clients_module
   --without-http_referer_module      disable ngx_http_referer_module
   --without-http_rewrite_module      disable ngx_http_rewrite_module
+  --without-http_eval_module         disable ngx_http_eval_module
   --without-http_proxy_module        disable ngx_http_proxy_module
   --without-http_fastcgi_module      disable ngx_http_fastcgi_module
   --without-http_uwsgi_module        disable ngx_http_uwsgi_module

--- a/src/core/ngx_conf_file.h
+++ b/src/core/ngx_conf_file.h
@@ -124,6 +124,8 @@ struct ngx_conf_s {
     ngx_log_t            *log;
 
     void                 *ctx;
+
+    ngx_uint_t            dynamic; /* unsigned  dynamic:1; */
     ngx_uint_t            module_type;
     ngx_uint_t            cmd_type;
 
@@ -268,7 +270,7 @@ char *ngx_conf_check_num_bounds(ngx_conf_t *cf, void *post, void *data);
 char *ngx_conf_param(ngx_conf_t *cf);
 char *ngx_conf_parse(ngx_conf_t *cf, ngx_str_t *filename);
 char *ngx_conf_include(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
-
+ngx_int_t ngx_conf_read_token(ngx_conf_t *cf);
 
 ngx_int_t ngx_conf_full_name(ngx_cycle_t *cycle, ngx_str_t *name,
     ngx_uint_t conf_prefix);
@@ -290,6 +292,8 @@ char *ngx_conf_set_sec_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 char *ngx_conf_set_bufs_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 char *ngx_conf_set_enum_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 char *ngx_conf_set_bitmask_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+
+extern ngx_uint_t  argument_number[];
 
 
 #endif /* _NGX_CONF_FILE_H_INCLUDED_ */

--- a/src/core/ngx_module.h
+++ b/src/core/ngx_module.h
@@ -217,9 +217,15 @@
     NGX_MODULE_SIGNATURE_33 NGX_MODULE_SIGNATURE_34
 
 
-#define NGX_MODULE_V1                                                         \
+#define NGX_DYNAMIC_MODULE     0x01
+
+#define NGX_MODULE_V1_EX(flags)                                               \
     NGX_MODULE_UNSET_INDEX, NGX_MODULE_UNSET_INDEX,                           \
-    NULL, 0, 0, nginx_version, NGX_MODULE_SIGNATURE
+    NULL, flags, 0, nginx_version, NGX_MODULE_SIGNATURE
+
+#define NGX_MODULE_V1          NGX_MODULE_V1_EX(0)
+
+#define NGX_DYNAMIC_MODULE_V1  NGX_MODULE_V1_EX(NGX_DYNAMIC_MODULE)
 
 #define NGX_MODULE_V1_PADDING  0, 0, 0, 0, 0, 0, 0, 0
 
@@ -230,7 +236,7 @@ struct ngx_module_s {
 
     char                 *name;
 
-    ngx_uint_t            spare0;
+    ngx_uint_t            flags;
     ngx_uint_t            spare1;
 
     ngx_uint_t            version;

--- a/src/event/ngx_event_openssl_cache.c
+++ b/src/event/ngx_event_openssl_cache.c
@@ -245,6 +245,10 @@ ngx_ssl_cache_fetch(ngx_conf_t *cf, ngx_uint_t index, char **err,
         uniq = 0;
     }
 
+    if (cf->dynamic) {
+        return type->create(&id, err, &data);
+    }
+
     /* try to use a reference from the old cycle */
 
     old_cache = ngx_ssl_cache_get_old_conf(cf->cycle);

--- a/src/http/modules/ngx_http_access_module.c
+++ b/src/http/modules/ngx_http_access_module.c
@@ -104,7 +104,7 @@ static ngx_http_module_t  ngx_http_access_module_ctx = {
 
 
 ngx_module_t  ngx_http_access_module = {
-    NGX_MODULE_V1,
+    NGX_DYNAMIC_MODULE_V1,
     &ngx_http_access_module_ctx,           /* module context */
     ngx_http_access_commands,              /* module directives */
     NGX_HTTP_MODULE,                       /* module type */

--- a/src/http/modules/ngx_http_auth_basic_module.c
+++ b/src/http/modules/ngx_http_auth_basic_module.c
@@ -71,7 +71,7 @@ static ngx_http_module_t  ngx_http_auth_basic_module_ctx = {
 
 
 ngx_module_t  ngx_http_auth_basic_module = {
-    NGX_MODULE_V1,
+    NGX_DYNAMIC_MODULE_V1,
     &ngx_http_auth_basic_module_ctx,       /* module context */
     ngx_http_auth_basic_commands,          /* module directives */
     NGX_HTTP_MODULE,                       /* module type */

--- a/src/http/modules/ngx_http_eval_module.c
+++ b/src/http/modules/ngx_http_eval_module.c
@@ -1,0 +1,798 @@
+
+/*
+ * Copyright (C) Roman Arutyunyan
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+
+typedef struct ngx_http_eval_loc_conf_s ngx_http_eval_loc_conf_t;
+
+
+struct ngx_http_eval_loc_conf_s {
+    ngx_str_node_t              node;
+    ngx_queue_t                 queue;
+
+    ngx_http_eval_loc_conf_t   *parent;
+
+    ngx_http_complex_value_t   *value;
+
+    ngx_rbtree_t                rbtree;
+    ngx_rbtree_node_t           sentinel;
+    ngx_queue_t                 evict;
+
+    ngx_uint_t                  max_cached;
+    ngx_uint_t                  cached;
+    ngx_msec_t                  valid;
+
+    ngx_pool_t                 *pool;
+
+    void                      **main_conf;
+    void                      **srv_conf;
+    void                      **loc_conf;
+
+    ngx_msec_t                  expire;
+    ngx_file_uniq_t             uniq;
+    time_t                      mtime;
+
+    ngx_uint_t                  count;
+
+    ngx_uint_t                  orphan;  /* unsigned  orphan:1; */
+};
+
+
+static ngx_int_t ngx_http_eval_handler(ngx_http_request_t *r);
+static ngx_http_eval_loc_conf_t *ngx_http_eval_lookup(ngx_http_request_t *r,
+    ngx_str_t *name);
+static void ngx_http_eval_evict(ngx_http_eval_loc_conf_t *elcf,
+    ngx_http_eval_loc_conf_t *node);
+static void ngx_http_eval_node_cleanup(void *data);
+static ngx_int_t ngx_http_eval_store(ngx_http_request_t *r,
+    ngx_http_eval_loc_conf_t *node);
+static ngx_http_eval_loc_conf_t *ngx_http_eval_create_location(
+    ngx_http_request_t *r, ngx_str_t *name);
+static ngx_int_t ngx_http_eval_read(ngx_http_request_t *r, ngx_pool_t *pool,
+    ngx_str_t *name, ngx_buf_t *buf, ngx_file_info_t *fi);
+static ngx_int_t ngx_http_eval_set(ngx_http_request_t *r,
+    ngx_http_eval_loc_conf_t *node);
+static char *ngx_http_eval(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static void ngx_http_eval_cleanup(void *data);
+static void *ngx_http_eval_create_loc_conf(ngx_conf_t *cf);
+static char *ngx_http_eval_merge_loc_conf(ngx_conf_t *cf, void *parent,
+    void *child);
+
+
+static ngx_command_t  ngx_http_eval_commands[] = {
+
+    { ngx_string("eval"),
+      NGX_HTTP_SRV_CONF|NGX_HTTP_SIF_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                       |NGX_CONF_TAKE1,
+      ngx_http_eval,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("eval_cache"),
+      NGX_HTTP_SRV_CONF|NGX_HTTP_SIF_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                       |NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_eval_loc_conf_t, max_cached),
+      NULL },
+
+    { ngx_string("eval_cache_valid"),
+      NGX_HTTP_SRV_CONF|NGX_HTTP_SIF_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                       |NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_eval_loc_conf_t, valid),
+      NULL },
+
+      ngx_null_command
+};
+
+
+static ngx_http_module_t  ngx_http_eval_module_ctx = {
+    NULL,                                  /* preconfiguration */
+    NULL,                                  /* postconfiguration */
+
+    NULL,                                  /* create main configuration */
+    NULL,                                  /* init main configuration */
+
+    NULL,                                  /* create server configuration */
+    NULL,                                  /* merge server configuration */
+
+    ngx_http_eval_create_loc_conf,         /* create location configuration */
+    ngx_http_eval_merge_loc_conf           /* merge location configuration */
+};
+
+
+ngx_module_t  ngx_http_eval_module = {
+    NGX_DYNAMIC_MODULE_V1,
+    &ngx_http_eval_module_ctx,             /* module context */
+    ngx_http_eval_commands,                /* module directives */
+    NGX_HTTP_MODULE,                       /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    NULL,                                  /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    NULL,                                  /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+static ngx_int_t
+ngx_http_eval_handler(ngx_http_request_t *r)
+{
+    ngx_str_t                    name;
+    ngx_http_eval_loc_conf_t    *elcf, *node;
+    ngx_http_core_main_conf_t   *cmcf;
+
+    elcf = ngx_http_get_module_loc_conf(r, ngx_http_eval_module);
+
+    if (elcf->value == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    if (ngx_http_complex_value(r, elcf->value, &name) != NGX_OK) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    if (name.len == 0) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    node = ngx_http_eval_lookup(r, &name);
+
+    if (node == NULL) {
+
+        node = ngx_http_eval_create_location(r, &name);
+        if (node == NULL) {
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+        if (ngx_http_eval_store(r, node) != NGX_OK) {
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+    }
+
+    if (ngx_http_eval_set(r, node) != NGX_OK) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    r->main->count++;
+
+    cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+    r->phase_handler = cmcf->phase_engine.server_rewrite_index;
+
+    r->write_event_handler = ngx_http_core_run_phases;
+    ngx_http_core_run_phases(r);
+
+    return NGX_DONE;
+}
+
+
+static ngx_http_eval_loc_conf_t *
+ngx_http_eval_lookup(ngx_http_request_t *r, ngx_str_t *name)
+{
+    uint32_t                   hash;
+    ngx_str_t                  filename;
+    ngx_msec_t                 now;
+    ngx_file_info_t            fi;
+    ngx_pool_cleanup_t        *cln;
+    ngx_http_eval_loc_conf_t  *elcf, *node;
+
+    elcf = ngx_http_get_module_loc_conf(r, ngx_http_eval_module);
+
+    hash = ngx_crc32_long(name->data, name->len);
+
+    node = (ngx_http_eval_loc_conf_t *) ngx_str_rbtree_lookup(&elcf->rbtree,
+                                                              name, hash);
+    if (node == NULL) {
+        return NULL;
+    }
+
+    if (name->len >= 5 && ngx_strncmp(name->data, "data:", 5) == 0) {
+        goto found;
+    }
+
+    now = ngx_current_msec;
+
+    if ((ngx_msec_int_t) (now - node->expire) < 0) {
+        goto found;
+    }
+
+    filename = *name;
+
+    if (ngx_get_full_name(r->pool, (ngx_str_t *) &ngx_cycle->conf_prefix,
+                          &filename)
+        != NGX_OK)
+    {
+        return NULL;
+    }
+
+    if (ngx_file_info(filename.data, &fi) != NGX_FILE_ERROR
+        && ngx_file_uniq(&fi) == node->uniq
+        && ngx_file_mtime(&fi) == node->mtime)
+    {
+        node->expire = now + elcf->valid;
+        goto found;
+    }
+
+    ngx_http_eval_evict(elcf, node);
+
+    return NULL;
+
+found:
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http eval found %p", node);
+
+    cln = ngx_pool_cleanup_add(r->connection->pool, 0);
+    if (cln == NULL) {
+        return NULL;
+    }
+
+    ngx_queue_remove(&node->queue);
+    ngx_queue_insert_tail(&elcf->evict, &node->queue);
+
+    cln->handler = ngx_http_eval_node_cleanup;
+    cln->data = node;
+
+    node->count++;
+
+    return node;
+}
+
+
+static void
+ngx_http_eval_evict(ngx_http_eval_loc_conf_t *elcf,
+    ngx_http_eval_loc_conf_t *node)
+{
+    ngx_rbtree_delete(&elcf->rbtree, &node->node.node);
+    ngx_queue_remove(&node->queue);
+
+    elcf->cached--;
+
+    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, node->pool->log, 0,
+                   "http eval evict %p n:%ui c:%ui",
+                   node, node->count, elcf->cached);
+
+    if (node->count) {
+        node->orphan = 1;
+        return;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, node->pool->log, 0,
+                   "http eval free %p", node);
+
+    ngx_destroy_pool(node->pool);
+}
+
+
+static void
+ngx_http_eval_node_cleanup(void *data)
+{
+    ngx_http_eval_loc_conf_t  *node = data;
+
+    node->count--;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, node->pool->log, 0,
+                   "http eval cleanup %p n:%ui", node, node->count);
+
+    if (node->count || !node->orphan) {
+        return;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, node->pool->log, 0,
+                   "http eval free %p", node);
+
+    ngx_destroy_pool(node->pool);
+}
+
+
+static ngx_int_t
+ngx_http_eval_store(ngx_http_request_t *r, ngx_http_eval_loc_conf_t *node)
+{
+    ngx_msec_t                 now;
+    ngx_queue_t               *q;
+    ngx_pool_cleanup_t        *cln;
+    ngx_http_eval_loc_conf_t  *elcf, *nd;
+
+    elcf = ngx_http_get_module_loc_conf(r, ngx_http_eval_module);
+
+    q = ngx_queue_head(&elcf->evict);
+
+    while (elcf->cached + 1 > elcf->max_cached
+           && q != ngx_queue_sentinel(&elcf->evict))
+    {
+        nd = ngx_queue_data(q, ngx_http_eval_loc_conf_t, queue);
+        q = ngx_queue_next(q);
+        ngx_http_eval_evict(elcf, nd);
+    }
+
+    cln = ngx_pool_cleanup_add(r->connection->pool, 0);
+    if (cln == NULL) {
+        ngx_destroy_pool(node->pool);
+        return NGX_ERROR;
+    }
+
+    cln->handler = ngx_http_eval_node_cleanup;
+    cln->data = node;
+
+    now = ngx_current_msec;
+
+    node->count = 1;
+    node->expire = now + elcf->valid;
+
+    if (elcf->max_cached == 0) {
+        node->orphan = 1;
+        return NGX_OK;
+    }
+
+    elcf->cached++;
+
+    ngx_rbtree_insert(&elcf->rbtree, &node->node.node);
+    ngx_queue_insert_tail(&elcf->evict, &node->queue);
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http eval store %p c:%ui", node, elcf->cached);
+
+    return NGX_OK;
+}
+
+
+static ngx_http_eval_loc_conf_t *
+ngx_http_eval_create_location(ngx_http_request_t *r, ngx_str_t *name)
+{
+    void                       **main_conf, **srv_conf, **loc_conf;
+    char                        *rv;
+    uint32_t                     hash;
+    ngx_buf_t                    buf;
+    ngx_log_t                   *log;
+    ngx_pool_t                  *pool;
+    ngx_uint_t                   i, mi;
+    ngx_conf_t                   conf;
+    ngx_array_t                  args;
+    ngx_module_t               **modules;
+    ngx_file_info_t              fi;
+    ngx_conf_file_t              conf_file;
+    ngx_http_module_t           *module;
+    ngx_http_conf_ctx_t          ctx;
+    ngx_http_eval_loc_conf_t    *elcf, *node;
+    ngx_http_core_loc_conf_t    *clcf, *pclcf;
+    ngx_http_core_main_conf_t   *cmcf;
+
+    log = ngx_cycle->log;
+
+    pool = ngx_create_pool(NGX_DEFAULT_POOL_SIZE, log);
+    if (pool == NULL) {
+        return NULL;
+    }
+
+    if (ngx_http_eval_read(r, pool, name, &buf, &fi) != NGX_OK) {
+        goto failed;
+    }
+
+    if (ngx_array_init(&args, pool, 10, sizeof(ngx_str_t)) != NGX_OK) {
+        goto failed;
+    }
+
+    ngx_memzero(&ctx, sizeof(ngx_http_conf_ctx_t));
+
+    ngx_memzero(&conf_file, sizeof(ngx_conf_file_t));
+    conf_file.file.log = log;
+    conf_file.line = 1;
+    conf_file.file.fd = NGX_INVALID_FILE;
+    conf_file.buffer = &buf;
+
+    ngx_memzero(&conf, sizeof(ngx_conf_t));
+    conf.ctx = &ctx;
+    conf.temp_pool = r->pool;
+    conf.cycle = (ngx_cycle_t *) ngx_cycle;
+    conf.pool = pool;
+    conf.log = log;
+    conf.module_type = NGX_HTTP_MODULE;
+    conf.cmd_type = NGX_HTTP_LOC_CONF;
+    conf.conf_file = &conf_file;
+    conf.args = &args;
+    conf.dynamic = 1;
+
+    modules = ngx_cycle->modules;
+
+    main_conf = ngx_pcalloc(pool, sizeof(void *) * ngx_http_max_module);
+    if (main_conf == NULL) {
+        goto failed;
+    }
+
+    ngx_memcpy(main_conf, r->main_conf, sizeof(void *) * ngx_http_max_module);
+
+    srv_conf = ngx_pcalloc(pool, sizeof(void *) * ngx_http_max_module);
+    if (srv_conf == NULL) {
+        goto failed;
+    }
+
+    ngx_memcpy(srv_conf, r->srv_conf, sizeof(void *) * ngx_http_max_module);
+
+    loc_conf = ngx_pcalloc(pool, sizeof(void *) * ngx_http_max_module);
+    if (loc_conf == NULL) {
+        goto failed;
+    }
+
+    ngx_memcpy(loc_conf, r->loc_conf, sizeof(void *) * ngx_http_max_module);
+
+    ctx.main_conf = main_conf;
+    ctx.srv_conf = srv_conf;
+    ctx.loc_conf = loc_conf;
+
+    cmcf = ngx_http_core_recreate_main_conf(&conf);
+    if (cmcf == NULL) {
+        goto failed;
+    }
+
+    main_conf[ngx_http_core_module.ctx_index] = cmcf;
+
+    for (i = 0; modules[i]; i++) {
+        if (modules[i]->type != NGX_HTTP_MODULE) {
+            continue;
+        }
+
+        if (!(modules[i]->flags & NGX_DYNAMIC_MODULE)) {
+            continue;
+        }
+
+        mi = modules[i]->ctx_index;
+        module = modules[i]->ctx;
+
+        if (module->create_loc_conf) {
+            loc_conf[mi] = module->create_loc_conf(&conf);
+            if (loc_conf[mi] == NULL) {
+                goto failed;
+            }
+        }
+    }
+
+    pclcf = r->loc_conf[ngx_http_core_module.ctx_index];
+    clcf = loc_conf[ngx_http_core_module.ctx_index];
+
+    clcf->name = pclcf->name;
+    clcf->exact_match = pclcf->exact_match;
+    clcf->noregex = pclcf->noregex;
+    clcf->named = pclcf->named;
+    clcf->dynamic = 1;
+
+    rv = ngx_conf_parse(&conf, &conf_file.file.name);
+    if (rv == NGX_CONF_ERROR) {
+        goto failed;
+    }
+
+    module = ngx_http_core_module.ctx;
+    if (module->init_main_conf(&conf, cmcf) != NGX_CONF_OK) {
+        goto failed;
+    }
+
+    for (i = 0; modules[i]; i++) {
+        if (modules[i]->type != NGX_HTTP_MODULE) {
+            continue;
+        }
+
+        if (!(modules[i]->flags & NGX_DYNAMIC_MODULE)) {
+            continue;
+        }
+
+        mi = modules[i]->ctx_index;
+        module = modules[i]->ctx;
+
+        if (module->merge_loc_conf) {
+            rv = module->merge_loc_conf(&conf, r->loc_conf[mi], loc_conf[mi]);
+            if (rv != NGX_CONF_OK) {
+                goto failed;
+            }
+
+            rv = ngx_http_merge_locations(&conf, clcf->locations, loc_conf,
+                                          module, mi);
+            if (rv != NGX_CONF_OK) {
+                goto failed;
+            }
+        }
+    }
+
+    if (ngx_http_variables_init_vars(&conf) != NGX_OK) {
+        goto failed;
+    }
+
+    if (ngx_http_init_locations(&conf, NULL, clcf) != NGX_OK) {
+        goto failed;
+    }
+
+    if (ngx_http_init_static_location_trees(&conf, clcf) != NGX_OK) {
+        goto failed;
+    }
+
+    node = loc_conf[ngx_http_eval_module.ctx_index];
+
+    elcf = ngx_http_get_module_loc_conf(r, ngx_http_eval_module);
+
+    hash = ngx_crc32_long(name->data, name->len);
+
+    node->node.str.data = ngx_pnalloc(pool, name->len);
+    if (node->node.str.data == NULL) {
+        goto failed;
+    }
+
+    ngx_memcpy(node->node.str.data, name->data, name->len);
+    node->node.str.len = name->len;
+    node->node.node.key = hash;
+    node->pool = pool;
+    node->uniq = ngx_file_uniq(&fi);
+    node->mtime = ngx_file_mtime(&fi);
+    node->parent = elcf;
+
+    node->main_conf = main_conf;
+    node->srv_conf = srv_conf;
+    node->loc_conf = loc_conf;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http eval create %p", node);
+
+    return node;
+
+failed:
+
+    ngx_destroy_pool(pool);
+
+    return NULL;
+}
+
+
+static ngx_int_t
+ngx_http_eval_read(ngx_http_request_t *r, ngx_pool_t *pool, ngx_str_t *name,
+    ngx_buf_t *buf, ngx_file_info_t *fi)
+{
+    u_char      *p;
+    size_t       size;
+    ssize_t      n;
+    ngx_fd_t     fd;
+    ngx_file_t   file;
+
+    ngx_memzero(buf, sizeof(ngx_buf_t));
+
+    if (name->len >= 5 && ngx_strncmp(name->data, "data:", 5) == 0) {
+
+        buf->pos = name->data + 5;
+        buf->last = name->data + name->len;
+        buf->start = buf->pos;
+        buf->end = buf->last;
+        buf->memory = 1;
+
+        ngx_memzero(fi, sizeof(ngx_file_info_t));
+
+        return NGX_OK;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http eval read \"%V\"", name);
+
+    ngx_memzero(&file, sizeof(ngx_file_t));
+
+    file.log = r->connection->log;
+    file.name = *name;
+
+    if (ngx_get_full_name(pool, (ngx_str_t *) &ngx_cycle->conf_prefix,
+                          &file.name)
+        != NGX_OK)
+    {
+        return NGX_ERROR;
+    }
+
+    fd = ngx_open_file(file.name.data, NGX_FILE_RDONLY, NGX_FILE_OPEN, 0);
+
+    if (fd == NGX_INVALID_FILE) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, ngx_errno,
+                      ngx_open_file_n " \"%s\" failed", name->data);
+        return NGX_ERROR;
+    }
+
+    if (ngx_fd_info(fd, fi) == NGX_FILE_ERROR) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, ngx_errno,
+                      ngx_fd_info_n " \"%s\" failed", name->data);
+
+        (void) ngx_close_file(fd);
+        return NGX_ERROR;
+    }
+
+    size = (size_t) ngx_file_size(fi);
+
+    p = ngx_pnalloc(pool, size);
+    if (p == NULL) {
+        (void) ngx_close_file(fd);
+        return NGX_ERROR;
+    }
+
+    file.fd = fd;
+
+    n = ngx_read_file(&file, p, size, 0);
+
+    if (n == NGX_ERROR) {
+        (void) ngx_close_file(fd);
+        return NGX_ERROR;
+    }
+
+    if (n != (ssize_t) size) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                           ngx_read_file_n " returned "
+                           "only %z bytes instead of %z", n, size);
+        (void) ngx_close_file(fd);
+        return NGX_ERROR;
+    }
+
+    if (ngx_close_file(fd) == NGX_FILE_ERROR) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, ngx_errno,
+                      ngx_close_file_n " %s failed", name->data);
+        return NGX_ERROR;
+    }
+
+    buf->pos = p;
+    buf->last = p + size;
+    buf->start = buf->pos;
+    buf->end = buf->last;
+    buf->temporary = 1;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_eval_set(ngx_http_request_t *r, ngx_http_eval_loc_conf_t *node)
+{
+    ngx_http_variable_value_t  *v;
+    ngx_http_core_main_conf_t  *ocmcf, *cmcf;
+
+    ocmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+    r->main_conf = node->main_conf;
+    r->srv_conf = node->srv_conf;
+    r->loc_conf = node->loc_conf;
+
+    cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+    if (cmcf->variables.nelts > ocmcf->variables.nelts) {
+        v = ngx_pcalloc(r->pool, cmcf->variables.nelts
+                                 * sizeof(ngx_http_variable_value_t));
+        if (v == NULL) {
+            return NGX_ERROR;
+        }
+
+        ngx_memcpy(v, r->variables, ocmcf->variables.nelts
+                                    * sizeof(ngx_http_variable_value_t));
+
+        r->variables = v;
+    }
+
+    r->realloc_captures = 1;
+
+    /* clear the modules contexts */
+    ngx_memzero(r->ctx, sizeof(void *) * ngx_http_max_module);
+
+    ngx_http_update_location_config(r);
+
+    return NGX_OK;
+}
+
+
+static char *
+ngx_http_eval(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_eval_loc_conf_t *elcf = conf;
+
+    ngx_str_t                         *value;
+    ngx_pool_cleanup_t                *cln;
+    ngx_http_core_loc_conf_t          *clcf;
+    ngx_http_compile_complex_value_t   ccv;
+
+    if (elcf->value != NGX_CONF_UNSET_PTR) {
+        return "is duplicate";
+    }
+
+    elcf->value = ngx_palloc(cf->pool, sizeof(ngx_http_complex_value_t));
+    if (elcf->value == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    value = cf->args->elts;
+
+    ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
+
+    ccv.cf = cf;
+    ccv.value = &value[1];
+    ccv.complex_value = elcf->value;
+    ccv.zero = 1;
+
+    if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
+
+    clcf->handler = ngx_http_eval_handler;
+
+    cln = ngx_pool_cleanup_add(cf->pool, 0);
+    if (cln == NULL) {
+        return NULL;
+    }
+
+    cln->handler = ngx_http_eval_cleanup;
+    cln->data = elcf;
+
+    return NGX_CONF_OK;
+}
+
+
+static void
+ngx_http_eval_cleanup(void *data)
+{
+    ngx_http_eval_loc_conf_t  *elcf = data;
+
+    ngx_queue_t               *q;
+    ngx_http_eval_loc_conf_t  *node;
+
+    q = ngx_queue_head(&elcf->evict);
+
+    while (q != ngx_queue_sentinel(&elcf->evict)) {
+        node = ngx_queue_data(q, ngx_http_eval_loc_conf_t, queue);
+        q = ngx_queue_next(q);
+
+        if (node->count) {
+            ngx_log_error(NGX_LOG_ALERT, node->pool->log, 0,
+                          "eval node count is non-zero on cleanup");
+        }
+
+        ngx_http_eval_evict(elcf, node);
+    }
+}
+
+
+static void *
+ngx_http_eval_create_loc_conf(ngx_conf_t *cf)
+{
+    ngx_http_eval_loc_conf_t  *elcf;
+
+    elcf = ngx_pcalloc(cf->pool, sizeof(ngx_http_eval_loc_conf_t));
+    if (elcf == NULL) {
+        return NULL;
+    }
+
+    elcf->value = NGX_CONF_UNSET_PTR;
+    elcf->max_cached = NGX_CONF_UNSET_UINT;
+    elcf->valid = NGX_CONF_UNSET_MSEC;
+
+    ngx_rbtree_init(&elcf->rbtree, &elcf->sentinel,
+                    ngx_str_rbtree_insert_value);
+
+    ngx_queue_init(&elcf->evict);
+
+    return elcf;
+}
+
+
+static char *
+ngx_http_eval_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+    ngx_http_eval_loc_conf_t *prev = parent;
+    ngx_http_eval_loc_conf_t *conf = child;
+
+    ngx_conf_init_ptr_value(conf->value, NULL);
+
+    ngx_conf_merge_uint_value(conf->max_cached, prev->max_cached, 16);
+
+    ngx_conf_merge_msec_value(conf->valid, prev->valid, 100);
+
+    return NGX_CONF_OK;
+}

--- a/src/http/modules/ngx_http_eval_module.c
+++ b/src/http/modules/ngx_http_eval_module.c
@@ -1,0 +1,802 @@
+
+/*
+ * Copyright (C) Roman Arutyunyan
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+
+typedef struct ngx_http_eval_loc_conf_s ngx_http_eval_loc_conf_t;
+
+
+struct ngx_http_eval_loc_conf_s {
+    ngx_str_node_t              node;
+    ngx_queue_t                 queue;
+
+    ngx_http_eval_loc_conf_t   *parent;
+
+    ngx_http_complex_value_t   *value;
+
+    ngx_rbtree_t                rbtree;
+    ngx_rbtree_node_t           sentinel;
+    ngx_queue_t                 evict;
+
+    ngx_uint_t                  max_cached;
+    ngx_uint_t                  cached;
+    ngx_msec_t                  valid;
+
+    ngx_pool_t                 *pool;
+
+    void                      **main_conf;
+    void                      **srv_conf;
+    void                      **loc_conf;
+
+    ngx_msec_t                  expire;
+    ngx_file_uniq_t             uniq;
+    time_t                      mtime;
+
+    ngx_uint_t                  count;
+
+    ngx_uint_t                  orphan;  /* unsigned  orphan:1; */
+};
+
+
+static ngx_int_t ngx_http_eval_handler(ngx_http_request_t *r);
+static ngx_http_eval_loc_conf_t *ngx_http_eval_lookup(ngx_http_request_t *r,
+    ngx_str_t *name);
+static void ngx_http_eval_evict(ngx_http_eval_loc_conf_t *elcf,
+    ngx_http_eval_loc_conf_t *node);
+static void ngx_http_eval_node_cleanup(void *data);
+static ngx_int_t ngx_http_eval_store(ngx_http_request_t *r,
+    ngx_http_eval_loc_conf_t *node);
+static ngx_http_eval_loc_conf_t *ngx_http_eval_create_location(
+    ngx_http_request_t *r, ngx_str_t *name);
+static ngx_int_t ngx_http_eval_read(ngx_http_request_t *r, ngx_pool_t *pool,
+    ngx_str_t *name, ngx_buf_t *buf, ngx_file_info_t *fi);
+static ngx_int_t ngx_http_eval_set(ngx_http_request_t *r,
+    ngx_http_eval_loc_conf_t *node);
+static char *ngx_http_eval(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static void ngx_http_eval_cleanup(void *data);
+static void *ngx_http_eval_create_loc_conf(ngx_conf_t *cf);
+static char *ngx_http_eval_merge_loc_conf(ngx_conf_t *cf, void *parent,
+    void *child);
+
+
+static ngx_command_t  ngx_http_eval_commands[] = {
+
+    { ngx_string("eval"),
+      NGX_HTTP_SRV_CONF|NGX_HTTP_SIF_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                       |NGX_CONF_TAKE1,
+      ngx_http_eval,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("eval_cache"),
+      NGX_HTTP_SRV_CONF|NGX_HTTP_SIF_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                       |NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_eval_loc_conf_t, max_cached),
+      NULL },
+
+    { ngx_string("eval_cache_valid"),
+      NGX_HTTP_SRV_CONF|NGX_HTTP_SIF_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                       |NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_eval_loc_conf_t, valid),
+      NULL },
+
+      ngx_null_command
+};
+
+
+static ngx_http_module_t  ngx_http_eval_module_ctx = {
+    NULL,                                  /* preconfiguration */
+    NULL,                                  /* postconfiguration */
+
+    NULL,                                  /* create main configuration */
+    NULL,                                  /* init main configuration */
+
+    NULL,                                  /* create server configuration */
+    NULL,                                  /* merge server configuration */
+
+    ngx_http_eval_create_loc_conf,         /* create location configuration */
+    ngx_http_eval_merge_loc_conf           /* merge location configuration */
+};
+
+
+ngx_module_t  ngx_http_eval_module = {
+    NGX_DYNAMIC_MODULE_V1,
+    &ngx_http_eval_module_ctx,             /* module context */
+    ngx_http_eval_commands,                /* module directives */
+    NGX_HTTP_MODULE,                       /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    NULL,                                  /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    NULL,                                  /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+static ngx_int_t
+ngx_http_eval_handler(ngx_http_request_t *r)
+{
+    ngx_str_t                    name;
+    ngx_http_eval_loc_conf_t    *elcf, *node;
+    ngx_http_core_main_conf_t   *cmcf;
+
+    elcf = ngx_http_get_module_loc_conf(r, ngx_http_eval_module);
+
+    if (elcf->value == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    if (ngx_http_complex_value(r, elcf->value, &name) != NGX_OK) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    if (name.len == 0) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    node = ngx_http_eval_lookup(r, &name);
+
+    if (node == NULL) {
+
+        node = ngx_http_eval_create_location(r, &name);
+        if (node == NULL) {
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+        if (ngx_http_eval_store(r, node) != NGX_OK) {
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+    }
+
+    if (ngx_http_eval_set(r, node) != NGX_OK) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    r->main->count++;
+
+    cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+    r->phase_handler = cmcf->phase_engine.server_rewrite_index;
+
+    r->write_event_handler = ngx_http_core_run_phases;
+    ngx_http_core_run_phases(r);
+
+    return NGX_DONE;
+}
+
+
+static ngx_http_eval_loc_conf_t *
+ngx_http_eval_lookup(ngx_http_request_t *r, ngx_str_t *name)
+{
+    uint32_t                   hash;
+    ngx_str_t                  filename;
+    ngx_msec_t                 now;
+    ngx_file_info_t            fi;
+    ngx_pool_cleanup_t        *cln;
+    ngx_http_eval_loc_conf_t  *elcf, *node;
+
+    elcf = ngx_http_get_module_loc_conf(r, ngx_http_eval_module);
+
+    hash = ngx_crc32_long(name->data, name->len);
+
+    node = (ngx_http_eval_loc_conf_t *) ngx_str_rbtree_lookup(&elcf->rbtree,
+                                                              name, hash);
+    if (node == NULL) {
+        return NULL;
+    }
+
+    if (name->len >= 5 && ngx_strncmp(name->data, "data:", 5) == 0) {
+        goto found;
+    }
+
+    now = ngx_current_msec;
+
+    if ((ngx_msec_int_t) (now - node->expire) < 0) {
+        goto found;
+    }
+
+    filename = *name;
+
+    if (ngx_get_full_name(r->pool, (ngx_str_t *) &ngx_cycle->conf_prefix,
+                          &filename)
+        != NGX_OK)
+    {
+        return NULL;
+    }
+
+    if (ngx_file_info(filename.data, &fi) != NGX_FILE_ERROR
+        && ngx_file_uniq(&fi) == node->uniq
+        && ngx_file_mtime(&fi) == node->mtime)
+    {
+        node->expire = now + elcf->valid;
+        goto found;
+    }
+
+    ngx_http_eval_evict(elcf, node);
+
+    return NULL;
+
+found:
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http eval found %p", node);
+
+    cln = ngx_pool_cleanup_add(r->connection->pool, 0);
+    if (cln == NULL) {
+        return NULL;
+    }
+
+    ngx_queue_remove(&node->queue);
+    ngx_queue_insert_tail(&elcf->evict, &node->queue);
+
+    cln->handler = ngx_http_eval_node_cleanup;
+    cln->data = node;
+
+    node->count++;
+
+    return node;
+}
+
+
+static void
+ngx_http_eval_evict(ngx_http_eval_loc_conf_t *elcf,
+    ngx_http_eval_loc_conf_t *node)
+{
+    ngx_rbtree_delete(&elcf->rbtree, &node->node.node);
+    ngx_queue_remove(&node->queue);
+
+    elcf->cached--;
+
+    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, node->pool->log, 0,
+                   "http eval evict %p n:%ui c:%ui",
+                   node, node->count, elcf->cached);
+
+    if (node->count) {
+        node->orphan = 1;
+        return;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, node->pool->log, 0,
+                   "http eval free %p", node);
+
+    ngx_destroy_pool(node->pool);
+}
+
+
+static void
+ngx_http_eval_node_cleanup(void *data)
+{
+    ngx_http_eval_loc_conf_t  *node = data;
+
+    node->count--;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, node->pool->log, 0,
+                   "http eval cleanup %p n:%ui", node, node->count);
+
+    if (node->count || !node->orphan) {
+        return;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, node->pool->log, 0,
+                   "http eval free %p", node);
+
+    ngx_destroy_pool(node->pool);
+}
+
+
+static ngx_int_t
+ngx_http_eval_store(ngx_http_request_t *r, ngx_http_eval_loc_conf_t *node)
+{
+    ngx_msec_t                 now;
+    ngx_queue_t               *q;
+    ngx_pool_cleanup_t        *cln;
+    ngx_http_eval_loc_conf_t  *elcf, *nd;
+
+    elcf = ngx_http_get_module_loc_conf(r, ngx_http_eval_module);
+
+    q = ngx_queue_head(&elcf->evict);
+
+    while (elcf->cached + 1 > elcf->max_cached
+           && q != ngx_queue_sentinel(&elcf->evict))
+    {
+        nd = ngx_queue_data(q, ngx_http_eval_loc_conf_t, queue);
+        q = ngx_queue_next(q);
+        ngx_http_eval_evict(elcf, nd);
+    }
+
+    cln = ngx_pool_cleanup_add(r->connection->pool, 0);
+    if (cln == NULL) {
+        ngx_destroy_pool(node->pool);
+        return NGX_ERROR;
+    }
+
+    cln->handler = ngx_http_eval_node_cleanup;
+    cln->data = node;
+
+    now = ngx_current_msec;
+
+    node->count = 1;
+    node->expire = now + elcf->valid;
+
+    if (elcf->max_cached == 0) {
+        node->orphan = 1;
+        return NGX_OK;
+    }
+
+    elcf->cached++;
+
+    ngx_rbtree_insert(&elcf->rbtree, &node->node.node);
+    ngx_queue_insert_tail(&elcf->evict, &node->queue);
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http eval store %p c:%ui", node, elcf->cached);
+
+    return NGX_OK;
+}
+
+
+static ngx_http_eval_loc_conf_t *
+ngx_http_eval_create_location(ngx_http_request_t *r, ngx_str_t *name)
+{
+    void                       **main_conf, **srv_conf, **loc_conf;
+    char                        *rv;
+    uint32_t                     hash;
+    ngx_buf_t                    buf;
+    ngx_log_t                   *log;
+    ngx_pool_t                  *pool;
+    ngx_uint_t                   i, mi;
+    ngx_conf_t                   conf;
+    ngx_array_t                  args;
+    ngx_module_t               **modules;
+    ngx_file_info_t              fi;
+    ngx_conf_file_t              conf_file;
+    ngx_http_module_t           *module;
+    ngx_http_conf_ctx_t          ctx;
+    ngx_http_eval_loc_conf_t    *elcf, *node;
+    ngx_http_core_loc_conf_t    *clcf, *pclcf;
+    ngx_http_core_main_conf_t   *cmcf;
+
+    log = ngx_cycle->log;
+
+    pool = ngx_create_pool(NGX_DEFAULT_POOL_SIZE, log);
+    if (pool == NULL) {
+        return NULL;
+    }
+
+    if (ngx_http_eval_read(r, pool, name, &buf, &fi) != NGX_OK) {
+        goto failed;
+    }
+
+    if (ngx_array_init(&args, pool, 10, sizeof(ngx_str_t)) != NGX_OK) {
+        goto failed;
+    }
+
+    ngx_memzero(&ctx, sizeof(ngx_http_conf_ctx_t));
+
+    ngx_memzero(&conf_file, sizeof(ngx_conf_file_t));
+    conf_file.file.log = log;
+    conf_file.line = 1;
+    conf_file.file.fd = NGX_INVALID_FILE;
+    conf_file.buffer = &buf;
+
+    ngx_memzero(&conf, sizeof(ngx_conf_t));
+    conf.ctx = &ctx;
+    conf.temp_pool = r->pool;
+    conf.cycle = (ngx_cycle_t *) ngx_cycle;
+    conf.pool = pool;
+    conf.log = log;
+    conf.module_type = NGX_HTTP_MODULE;
+    conf.cmd_type = NGX_HTTP_LOC_CONF;
+    conf.conf_file = &conf_file;
+    conf.args = &args;
+    conf.dynamic = 1;
+
+    modules = ngx_cycle->modules;
+
+    main_conf = ngx_pcalloc(pool, sizeof(void *) * ngx_http_max_module);
+    if (main_conf == NULL) {
+        goto failed;
+    }
+
+    ngx_memcpy(main_conf, r->main_conf, sizeof(void *) * ngx_http_max_module);
+
+    srv_conf = ngx_pcalloc(pool, sizeof(void *) * ngx_http_max_module);
+    if (srv_conf == NULL) {
+        goto failed;
+    }
+
+    ngx_memcpy(srv_conf, r->srv_conf, sizeof(void *) * ngx_http_max_module);
+
+    loc_conf = ngx_pcalloc(pool, sizeof(void *) * ngx_http_max_module);
+    if (loc_conf == NULL) {
+        goto failed;
+    }
+
+    ngx_memcpy(loc_conf, r->loc_conf, sizeof(void *) * ngx_http_max_module);
+
+    ctx.main_conf = main_conf;
+    ctx.srv_conf = srv_conf;
+    ctx.loc_conf = loc_conf;
+
+    cmcf = ngx_http_core_recreate_main_conf(&conf);
+    if (cmcf == NULL) {
+        goto failed;
+    }
+
+    main_conf[ngx_http_core_module.ctx_index] = cmcf;
+
+    for (i = 0; modules[i]; i++) {
+        if (modules[i]->type != NGX_HTTP_MODULE) {
+            continue;
+        }
+
+        if (!(modules[i]->flags & NGX_DYNAMIC_MODULE)) {
+            continue;
+        }
+
+        mi = modules[i]->ctx_index;
+        module = modules[i]->ctx;
+
+        if (module->create_loc_conf) {
+            loc_conf[mi] = module->create_loc_conf(&conf);
+            if (loc_conf[mi] == NULL) {
+                goto failed;
+            }
+        }
+    }
+
+    pclcf = r->loc_conf[ngx_http_core_module.ctx_index];
+    clcf = loc_conf[ngx_http_core_module.ctx_index];
+
+    clcf->name = pclcf->name;
+    clcf->exact_match = pclcf->exact_match;
+    clcf->noregex = pclcf->noregex;
+    clcf->named = pclcf->named;
+    clcf->dynamic = 1;
+
+    rv = ngx_conf_parse(&conf, &conf_file.file.name);
+    if (rv == NGX_CONF_ERROR) {
+        goto failed;
+    }
+
+    module = ngx_http_core_module.ctx;
+    if (module->init_main_conf(&conf, cmcf) != NGX_CONF_OK) {
+        goto failed;
+    }
+
+    for (i = 0; modules[i]; i++) {
+        if (modules[i]->type != NGX_HTTP_MODULE) {
+            continue;
+        }
+
+        if (!(modules[i]->flags & NGX_DYNAMIC_MODULE)) {
+            continue;
+        }
+
+        mi = modules[i]->ctx_index;
+        module = modules[i]->ctx;
+
+        if (module->merge_loc_conf) {
+            rv = module->merge_loc_conf(&conf, r->loc_conf[mi], loc_conf[mi]);
+            if (rv != NGX_CONF_OK) {
+                goto failed;
+            }
+
+            rv = ngx_http_merge_locations(&conf, clcf->locations, loc_conf,
+                                          module, mi);
+            if (rv != NGX_CONF_OK) {
+                goto failed;
+            }
+        }
+    }
+
+    if (ngx_http_variables_init_vars(&conf) != NGX_OK) {
+        goto failed;
+    }
+
+    if (ngx_http_init_locations(&conf, NULL, clcf) != NGX_OK) {
+        goto failed;
+    }
+
+    if (ngx_http_init_static_location_trees(&conf, clcf) != NGX_OK) {
+        goto failed;
+    }
+
+    node = loc_conf[ngx_http_eval_module.ctx_index];
+
+    elcf = ngx_http_get_module_loc_conf(r, ngx_http_eval_module);
+
+    hash = ngx_crc32_long(name->data, name->len);
+
+    node->node.str.data = ngx_pnalloc(pool, name->len);
+    if (node->node.str.data == NULL) {
+        goto failed;
+    }
+
+    ngx_memcpy(node->node.str.data, name->data, name->len);
+    node->node.str.len = name->len;
+    node->node.node.key = hash;
+    node->pool = pool;
+    node->uniq = ngx_file_uniq(&fi);
+    node->mtime = ngx_file_mtime(&fi);
+    node->parent = elcf;
+
+    node->main_conf = main_conf;
+    node->srv_conf = srv_conf;
+    node->loc_conf = loc_conf;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http eval create %p", node);
+
+    return node;
+
+failed:
+
+    ngx_destroy_pool(pool);
+
+    return NULL;
+}
+
+
+static ngx_int_t
+ngx_http_eval_read(ngx_http_request_t *r, ngx_pool_t *pool, ngx_str_t *name,
+    ngx_buf_t *buf, ngx_file_info_t *fi)
+{
+    u_char      *p;
+    size_t       size;
+    ssize_t      n;
+    ngx_fd_t     fd;
+    ngx_file_t   file;
+
+    ngx_memzero(buf, sizeof(ngx_buf_t));
+
+    if (name->len >= 5 && ngx_strncmp(name->data, "data:", 5) == 0) {
+
+        buf->pos = name->data + 5;
+        buf->last = name->data + name->len;
+        buf->start = buf->pos;
+        buf->end = buf->last;
+        buf->memory = 1;
+
+        if (buf->pos != buf->last && *(buf->last - 1) == '\0') {
+            buf->last--;
+        }
+
+        ngx_memzero(fi, sizeof(ngx_file_info_t));
+
+        return NGX_OK;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http eval read \"%V\"", name);
+
+    ngx_memzero(&file, sizeof(ngx_file_t));
+
+    file.log = r->connection->log;
+    file.name = *name;
+
+    if (ngx_get_full_name(pool, (ngx_str_t *) &ngx_cycle->conf_prefix,
+                          &file.name)
+        != NGX_OK)
+    {
+        return NGX_ERROR;
+    }
+
+    fd = ngx_open_file(file.name.data, NGX_FILE_RDONLY, NGX_FILE_OPEN, 0);
+
+    if (fd == NGX_INVALID_FILE) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, ngx_errno,
+                      ngx_open_file_n " \"%s\" failed", name->data);
+        return NGX_ERROR;
+    }
+
+    if (ngx_fd_info(fd, fi) == NGX_FILE_ERROR) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, ngx_errno,
+                      ngx_fd_info_n " \"%s\" failed", name->data);
+
+        (void) ngx_close_file(fd);
+        return NGX_ERROR;
+    }
+
+    size = (size_t) ngx_file_size(fi);
+
+    p = ngx_pnalloc(pool, size);
+    if (p == NULL) {
+        (void) ngx_close_file(fd);
+        return NGX_ERROR;
+    }
+
+    file.fd = fd;
+
+    n = ngx_read_file(&file, p, size, 0);
+
+    if (n == NGX_ERROR) {
+        (void) ngx_close_file(fd);
+        return NGX_ERROR;
+    }
+
+    if (n != (ssize_t) size) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                           ngx_read_file_n " returned "
+                           "only %z bytes instead of %z", n, size);
+        (void) ngx_close_file(fd);
+        return NGX_ERROR;
+    }
+
+    if (ngx_close_file(fd) == NGX_FILE_ERROR) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, ngx_errno,
+                      ngx_close_file_n " %s failed", name->data);
+        return NGX_ERROR;
+    }
+
+    buf->pos = p;
+    buf->last = p + size;
+    buf->start = buf->pos;
+    buf->end = buf->last;
+    buf->temporary = 1;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_eval_set(ngx_http_request_t *r, ngx_http_eval_loc_conf_t *node)
+{
+    ngx_http_variable_value_t  *v;
+    ngx_http_core_main_conf_t  *ocmcf, *cmcf;
+
+    ocmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+    r->main_conf = node->main_conf;
+    r->srv_conf = node->srv_conf;
+    r->loc_conf = node->loc_conf;
+
+    cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+    if (cmcf->variables.nelts > ocmcf->variables.nelts) {
+        v = ngx_pcalloc(r->pool, cmcf->variables.nelts
+                                 * sizeof(ngx_http_variable_value_t));
+        if (v == NULL) {
+            return NGX_ERROR;
+        }
+
+        ngx_memcpy(v, r->variables, ocmcf->variables.nelts
+                                    * sizeof(ngx_http_variable_value_t));
+
+        r->variables = v;
+    }
+
+    r->realloc_captures = 1;
+
+    /* clear the modules contexts */
+    ngx_memzero(r->ctx, sizeof(void *) * ngx_http_max_module);
+
+    ngx_http_update_location_config(r);
+
+    return NGX_OK;
+}
+
+
+static char *
+ngx_http_eval(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_eval_loc_conf_t *elcf = conf;
+
+    ngx_str_t                         *value;
+    ngx_pool_cleanup_t                *cln;
+    ngx_http_core_loc_conf_t          *clcf;
+    ngx_http_compile_complex_value_t   ccv;
+
+    if (elcf->value != NGX_CONF_UNSET_PTR) {
+        return "is duplicate";
+    }
+
+    elcf->value = ngx_palloc(cf->pool, sizeof(ngx_http_complex_value_t));
+    if (elcf->value == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    value = cf->args->elts;
+
+    ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
+
+    ccv.cf = cf;
+    ccv.value = &value[1];
+    ccv.complex_value = elcf->value;
+    ccv.zero = 1;
+
+    if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
+
+    clcf->handler = ngx_http_eval_handler;
+
+    cln = ngx_pool_cleanup_add(cf->pool, 0);
+    if (cln == NULL) {
+        return NULL;
+    }
+
+    cln->handler = ngx_http_eval_cleanup;
+    cln->data = elcf;
+
+    return NGX_CONF_OK;
+}
+
+
+static void
+ngx_http_eval_cleanup(void *data)
+{
+    ngx_http_eval_loc_conf_t  *elcf = data;
+
+    ngx_queue_t               *q;
+    ngx_http_eval_loc_conf_t  *node;
+
+    q = ngx_queue_head(&elcf->evict);
+
+    while (q != ngx_queue_sentinel(&elcf->evict)) {
+        node = ngx_queue_data(q, ngx_http_eval_loc_conf_t, queue);
+        q = ngx_queue_next(q);
+
+        if (node->count) {
+            ngx_log_error(NGX_LOG_ALERT, node->pool->log, 0,
+                          "eval node count is non-zero on cleanup");
+        }
+
+        ngx_http_eval_evict(elcf, node);
+    }
+}
+
+
+static void *
+ngx_http_eval_create_loc_conf(ngx_conf_t *cf)
+{
+    ngx_http_eval_loc_conf_t  *elcf;
+
+    elcf = ngx_pcalloc(cf->pool, sizeof(ngx_http_eval_loc_conf_t));
+    if (elcf == NULL) {
+        return NULL;
+    }
+
+    elcf->value = NGX_CONF_UNSET_PTR;
+    elcf->max_cached = NGX_CONF_UNSET_UINT;
+    elcf->valid = NGX_CONF_UNSET_MSEC;
+
+    ngx_rbtree_init(&elcf->rbtree, &elcf->sentinel,
+                    ngx_str_rbtree_insert_value);
+
+    ngx_queue_init(&elcf->evict);
+
+    return elcf;
+}
+
+
+static char *
+ngx_http_eval_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+    ngx_http_eval_loc_conf_t *prev = parent;
+    ngx_http_eval_loc_conf_t *conf = child;
+
+    ngx_conf_init_ptr_value(conf->value, NULL);
+
+    ngx_conf_merge_uint_value(conf->max_cached, prev->max_cached, 16);
+
+    ngx_conf_merge_msec_value(conf->valid, prev->valid, 100);
+
+    return NGX_CONF_OK;
+}

--- a/src/http/modules/ngx_http_limit_conn_module.c
+++ b/src/http/modules/ngx_http_limit_conn_module.c
@@ -145,7 +145,7 @@ static ngx_http_module_t  ngx_http_limit_conn_module_ctx = {
 
 
 ngx_module_t  ngx_http_limit_conn_module = {
-    NGX_MODULE_V1,
+    NGX_DYNAMIC_MODULE_V1,
     &ngx_http_limit_conn_module_ctx,       /* module context */
     ngx_http_limit_conn_commands,          /* module directives */
     NGX_HTTP_MODULE,                       /* module type */

--- a/src/http/modules/ngx_http_limit_req_module.c
+++ b/src/http/modules/ngx_http_limit_req_module.c
@@ -158,7 +158,7 @@ static ngx_http_module_t  ngx_http_limit_req_module_ctx = {
 
 
 ngx_module_t  ngx_http_limit_req_module = {
-    NGX_MODULE_V1,
+    NGX_DYNAMIC_MODULE_V1,
     &ngx_http_limit_req_module_ctx,        /* module context */
     ngx_http_limit_req_commands,           /* module directives */
     NGX_HTTP_MODULE,                       /* module type */

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -728,7 +728,7 @@ static ngx_http_module_t  ngx_http_proxy_module_ctx = {
 
 
 ngx_module_t  ngx_http_proxy_module = {
-    NGX_MODULE_V1,
+    NGX_DYNAMIC_MODULE_V1,
     &ngx_http_proxy_module_ctx,            /* module context */
     ngx_http_proxy_commands,               /* module directives */
     NGX_HTTP_MODULE,                       /* module type */
@@ -4133,7 +4133,8 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
      */
 
     if (prev->headers.hash.buckets == NULL
-        && conf->headers_source == prev->headers_source)
+        && conf->headers_source == prev->headers_source
+        && !clcf->dynamic)
     {
         prev->headers = conf->headers;
 #if (NGX_HTTP_CACHE)
@@ -4350,7 +4351,7 @@ ngx_http_proxy_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     n = ngx_http_script_variables_count(url);
 
-    if (n) {
+    if (n || cf->dynamic) {
 
         ngx_memzero(&sc, sizeof(ngx_http_script_compile_t));
 
@@ -5241,7 +5242,10 @@ static ngx_int_t
 ngx_http_proxy_merge_ssl(ngx_conf_t *cf, ngx_http_proxy_loc_conf_t *conf,
     ngx_http_proxy_loc_conf_t *prev)
 {
-    ngx_uint_t  preserve;
+    ngx_uint_t                 preserve;
+    ngx_http_core_loc_conf_t  *clcf;
+
+    clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 
     if (conf->ssl_protocols == 0
         && conf->ssl_ciphers.data == NULL
@@ -5255,12 +5259,12 @@ ngx_http_proxy_merge_ssl(ngx_conf_t *cf, ngx_http_proxy_loc_conf_t *conf,
         && conf->upstream.ssl_session_reuse == NGX_CONF_UNSET
         && conf->ssl_conf_commands == NGX_CONF_UNSET_PTR)
     {
-        if (prev->upstream.ssl) {
+        if (prev->upstream.ssl && (!clcf->dynamic || prev->upstream.ssl->ctx)) {
             conf->upstream.ssl = prev->upstream.ssl;
             return NGX_OK;
         }
 
-        preserve = 1;
+        preserve = !clcf->dynamic;
 
     } else {
         preserve = 0;

--- a/src/http/modules/ngx_http_rewrite_module.c
+++ b/src/http/modules/ngx_http_rewrite_module.c
@@ -118,7 +118,7 @@ static ngx_http_module_t  ngx_http_rewrite_module_ctx = {
 
 
 ngx_module_t  ngx_http_rewrite_module = {
-    NGX_MODULE_V1,
+    NGX_DYNAMIC_MODULE_V1,
     &ngx_http_rewrite_module_ctx,          /* module context */
     ngx_http_rewrite_commands,             /* module directives */
     NGX_HTTP_MODULE,                       /* module type */
@@ -558,8 +558,17 @@ ngx_http_rewrite_if(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return NGX_CONF_ERROR;
     }
 
+    ngx_memcpy(ctx->loc_conf, pctx->loc_conf,
+               sizeof(void *) * ngx_http_max_module);
+
     for (i = 0; cf->cycle->modules[i]; i++) {
         if (cf->cycle->modules[i]->type != NGX_HTTP_MODULE) {
+            continue;
+        }
+
+        if (cf->dynamic
+            && !(cf->cycle->modules[i]->flags & NGX_DYNAMIC_MODULE))
+        {
             continue;
         }
 

--- a/src/http/modules/ngx_http_try_files_module.c
+++ b/src/http/modules/ngx_http_try_files_module.c
@@ -60,7 +60,7 @@ static ngx_http_module_t  ngx_http_try_files_module_ctx = {
 
 
 ngx_module_t  ngx_http_try_files_module = {
-    NGX_MODULE_V1,
+    NGX_DYNAMIC_MODULE_V1,
     &ngx_http_try_files_module_ctx,        /* module context */
     ngx_http_try_files_commands,           /* module directives */
     NGX_HTTP_MODULE,                       /* module type */

--- a/src/http/ngx_http.c
+++ b/src/http/ngx_http.c
@@ -30,13 +30,6 @@ static ngx_int_t ngx_http_add_server(ngx_conf_t *cf,
 static char *ngx_http_merge_servers(ngx_conf_t *cf,
     ngx_http_core_main_conf_t *cmcf, ngx_http_module_t *module,
     ngx_uint_t ctx_index);
-static char *ngx_http_merge_locations(ngx_conf_t *cf,
-    ngx_queue_t *locations, void **loc_conf, ngx_http_module_t *module,
-    ngx_uint_t ctx_index);
-static ngx_int_t ngx_http_init_locations(ngx_conf_t *cf,
-    ngx_http_core_srv_conf_t *cscf, ngx_http_core_loc_conf_t *pclcf);
-static ngx_int_t ngx_http_init_static_location_trees(ngx_conf_t *cf,
-    ngx_http_core_loc_conf_t *pclcf);
 static ngx_int_t ngx_http_escape_location_name(ngx_conf_t *cf,
     ngx_http_core_loc_conf_t *clcf);
 static ngx_int_t ngx_http_cmp_locations(const ngx_queue_t *one,
@@ -622,7 +615,7 @@ failed:
 }
 
 
-static char *
+char *
 ngx_http_merge_locations(ngx_conf_t *cf, ngx_queue_t *locations,
     void **loc_conf, ngx_http_module_t *module, ngx_uint_t ctx_index)
 {
@@ -667,7 +660,7 @@ ngx_http_merge_locations(ngx_conf_t *cf, ngx_queue_t *locations,
 }
 
 
-static ngx_int_t
+ngx_int_t
 ngx_http_init_locations(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
     ngx_http_core_loc_conf_t *pclcf)
 {
@@ -748,6 +741,10 @@ ngx_http_init_locations(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
             return NGX_ERROR;
         }
 
+        if (cscf == NULL) {
+            return NGX_ERROR;
+        }
+
         cscf->named_locations = clcfp;
 
         for (q = named;
@@ -796,7 +793,7 @@ ngx_http_init_locations(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
 }
 
 
-static ngx_int_t
+ngx_int_t
 ngx_http_init_static_location_trees(ngx_conf_t *cf,
     ngx_http_core_loc_conf_t *pclcf)
 {

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -81,6 +81,12 @@ typedef struct {
 #define ngx_http_set_ctx(r, c, module)      r->ctx[module.ctx_index] = c;
 
 
+char *ngx_http_merge_locations(ngx_conf_t *cf, ngx_queue_t *locations,
+    void **loc_conf, ngx_http_module_t *module, ngx_uint_t ctx_index);
+ngx_int_t ngx_http_init_locations(ngx_conf_t *cf,
+    ngx_http_core_srv_conf_t *cscf, ngx_http_core_loc_conf_t *pclcf);
+ngx_int_t ngx_http_init_static_location_trees(ngx_conf_t *cf,
+    ngx_http_core_loc_conf_t *pclcf);
 ngx_int_t ngx_http_add_location(ngx_conf_t *cf, ngx_queue_t **locations,
     ngx_http_core_loc_conf_t *clcf);
 ngx_int_t ngx_http_add_listen(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -322,6 +322,7 @@ struct ngx_http_core_loc_conf_s {
     unsigned      noregex:1;
 
     unsigned      auto_redirect:1;
+    unsigned      dynamic:1;
 #if (NGX_HTTP_GZIP)
     unsigned      gzip_disable_msie6:2;
     unsigned      gzip_disable_degradation:2;
@@ -480,6 +481,8 @@ struct ngx_http_location_tree_node_s {
     u_char                           name[1];
 };
 
+
+void *ngx_http_core_recreate_main_conf(ngx_conf_t *cf);
 
 void ngx_http_core_run_phases(ngx_http_request_t *r);
 ngx_int_t ngx_http_core_generic_phase(ngx_http_request_t *r,

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -7004,10 +7004,11 @@ ngx_http_upstream_hide_headers_hash(ngx_conf_t *cf,
     ngx_http_upstream_conf_t *conf, ngx_http_upstream_conf_t *prev,
     ngx_str_t *default_hide_headers, ngx_hash_init_t *hash)
 {
-    ngx_str_t       *h;
-    ngx_uint_t       i, j;
-    ngx_array_t      hide_headers;
-    ngx_hash_key_t  *hk;
+    ngx_str_t                 *h;
+    ngx_uint_t                 i, j;
+    ngx_array_t                hide_headers;
+    ngx_hash_key_t            *hk;
+    ngx_http_core_loc_conf_t  *clcf;
 
     if (conf->hide_headers == NGX_CONF_UNSET_PTR
         && conf->pass_headers == NGX_CONF_UNSET_PTR)
@@ -7111,9 +7112,12 @@ ngx_http_upstream_hide_headers_hash(ngx_conf_t *cf,
      * in the "http" section to inherit it to all servers
      */
 
+    clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
+
     if (prev->hide_headers_hash.buckets == NULL
         && conf->hide_headers == prev->hide_headers
-        && conf->pass_headers == prev->pass_headers)
+        && conf->pass_headers == prev->pass_headers
+        && !clcf->dynamic)
     {
         prev->hide_headers_hash = conf->hide_headers_hash;
     }

--- a/src/http/ngx_http_variables.h
+++ b/src/http/ngx_http_variables.h
@@ -107,6 +107,7 @@ void *ngx_http_map_find(ngx_http_request_t *r, ngx_http_map_t *map,
 
 
 ngx_int_t ngx_http_variables_add_core_vars(ngx_conf_t *cf);
+ngx_int_t ngx_http_variables_merge_core_vars(ngx_conf_t *cf, void *conf);
 ngx_int_t ngx_http_variables_init_vars(ngx_conf_t *cf);
 
 


### PR DESCRIPTION
The `eval` directive receives a location configuration that is evaluated at runtime. If the argument is prefixed with "data:", the configuration should immediately follow the prefix.  Otherwise the argument is treated as a file name.

Only the modules that explicitly support dynamic locations are allowed to process their directives in an eval configuration. Only several modules are currently supported (see commits).

Modules need to follow the strict hierarchy rules to make their directives are eligible for eval locations:
    
- modules should not modify main configurations
- modules should not modify server configurations
- modules should not modify static location configurations
    
Example:
```    
server {                                                                     
    listen 8000;                                                             

    location = / {
        root html;
    }

    eval eval1.conf;                                          
} 
```

eval1.conf:
```
set $buz 1;

if ($arg_bar = 1) {
    return 200 $buz;
}

location /1 {
    return 200 foo;
}

location /2 {
    eval eval2.conf;
}

location /3 {
    eval data:$arg_loc;
}

resolver 8.8.8.8;

proxy_pass https://$arg_server;
```

eval2.conf:
```
return 200 $remote_addr-$buz;
```

The `eval1.conf` and `eval2.conf` files can change at runtime. Their content will be parsed by nginx on demand and cached while processing a client request.