### PR TITLE
Added max_headers directive

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -252,6 +252,13 @@ static ngx_command_t  ngx_http_core_commands[] = {
       offsetof(ngx_http_core_srv_conf_t, large_client_header_buffers),
       NULL },
 
+    { ngx_string("max_headers"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_core_srv_conf_t, max_headers),
+      NULL },
+
     { ngx_string("ignore_invalid_headers"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
@@ -3511,6 +3518,7 @@ ngx_http_core_create_srv_conf(ngx_conf_t *cf)
     cscf->request_pool_size = NGX_CONF_UNSET_SIZE;
     cscf->client_header_timeout = NGX_CONF_UNSET_MSEC;
     cscf->client_header_buffer_size = NGX_CONF_UNSET_SIZE;
+    cscf->max_headers = NGX_CONF_UNSET_UINT;
     cscf->ignore_invalid_headers = NGX_CONF_UNSET;
     cscf->merge_slashes = NGX_CONF_UNSET;
     cscf->underscores_in_headers = NGX_CONF_UNSET;
@@ -3551,6 +3559,8 @@ ngx_http_core_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
                            "equal to or greater than \"connection_pool_size\"");
         return NGX_CONF_ERROR;
     }
+
+    ngx_conf_merge_uint_value(conf->max_headers, prev->max_headers, 1000);
 
     ngx_conf_merge_value(conf->ignore_invalid_headers,
                               prev->ignore_invalid_headers, 1);

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -199,6 +199,8 @@ typedef struct {
 
     ngx_msec_t                  client_header_timeout;
 
+    ngx_uint_t                  max_headers;
+
     ngx_flag_t                  ignore_invalid_headers;
     ngx_flag_t                  merge_slashes;
     ngx_flag_t                  underscores_in_headers;

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -1494,6 +1494,15 @@ ngx_http_process_request_headers(ngx_event_t *rev)
 
             /* a header line has been parsed successfully */
 
+            if (r->headers_in.count++ >= cscf->max_headers) {
+                r->lingering_close = 1;
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "client sent too many header lines");
+                ngx_http_finalize_request(r,
+                                          NGX_HTTP_REQUEST_HEADER_TOO_LARGE);
+                break;
+            }
+
             h = ngx_list_push(&r->headers_in.headers);
             if (h == NULL) {
                 ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -184,6 +184,7 @@ typedef struct {
 
 typedef struct {
     ngx_list_t                        headers;
+    ngx_uint_t                        count;
 
     ngx_table_elt_t                  *host;
     ngx_table_elt_t                  *connection;

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1823,6 +1823,15 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
         }
 
     } else {
+        cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+
+        if (r->headers_in.count++ >= cscf->max_headers) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent too many header lines");
+            ngx_http_finalize_request(r, NGX_HTTP_REQUEST_HEADER_TOO_LARGE);
+            goto error;
+        }
+
         h = ngx_list_push(&r->headers_in.headers);
         if (h == NULL) {
             return ngx_http_v2_connection_error(h2c,

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -665,6 +665,15 @@ ngx_http_v3_process_header(ngx_http_request_t *r, ngx_str_t *name,
         }
 
     } else {
+        cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+
+        if (r->headers_in.count++ >= cscf->max_headers) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent too many header lines");
+            ngx_http_finalize_request(r, NGX_HTTP_REQUEST_HEADER_TOO_LARGE);
+            return NGX_ERROR;
+        }
+
         h = ngx_list_push(&r->headers_in.headers);
         if (h == NULL) {
             ngx_http_close_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
## Proposed Changes

This change introduces a new directive called `max_headers` that limits the number of HTTP request headers accepted from a client. The default maximum headers accepted is set to 1000.

Although `client_header_buffer_size` and `large_client_header_buffers` already constrain the total volume of header data, the volume of data and the count of headers are different things that require different limits. A creative attacker (or an "enterprise" Java client) can pack hundreds of tiny headers into a legitimate request and make your backend choke on parsing them one by one. This directive allows you to catch that state early.

## Implementation

A counter `r->headers_in.count` is incremented for each parsed header. When it exceeds `cscf->max_headers`, the request is terminated with `NGX_HTTP_REQUEST_HEADER_TOO_LARGE`(494/431). This change is a symmetrical implementation across all three protocol versions. No allocations, no new structures, no surprises.

### Configuration

```
http {
  # applies to main and server contexts
  max_headers 100;   # for the paranoid (respect)
  max_headers 1000;  # default, reasonable for most
}
```

### Notes

Buffer size limits protect nginx memory. Header count limits protect what sits behind nginx. Your average Python/Ruby/Java backend does O(n) or worse work per header: auth checks, logging, middleware chains. Flooding it with 500 `X-Garbage-N: yes` headers is a cheap way to burn CPU. Now you can say "nyet" at the front door.

* Counter uses >= (post-increment), so the limit is exact: max_headers 100 allows exactly 100 headers
* Pseudo-headers in HTTP/2 and HTTP/3 (:method, :path, etc.) are not counted — only real headers
* Response code is NGX_HTTP_REQUEST_HEADER_TOO_LARGE, consistent with existing header limit behavior
* lingering_close = 1 is set for HTTP/1.x to properly drain the connection
* Scope: NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF — per-server granularity, inherits from main

### Origin

This change comes from Maxim Dounin's [freenginx repository](https://freenginx.org/hg/nginx/). The feature was originally requested by Maksim Yevmenkin. This code is authored by Maxim Dounin and my role as PR contributor has been to just migrate the patch to the latest nginx code.

Commit Origin: https://freenginx.org/hg/nginx/rev/199dc0d6b05be814b5c811876c20af58cd361fea

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [X] I have checked that NGINX compiles and runs after adding my changes.