### PR TITLE
Allow certificates to be loaded using `store:`

### DIFF
--- a/src/event/ngx_event_openssl_cache.c
+++ b/src/event/ngx_event_openssl_cache.c
@@ -633,7 +633,20 @@ ngx_ssl_cache_cert_create(ngx_ssl_cache_key_t *id, char **err, void *data)
             return NULL;
         }
 
-        return x509;
+        chain = sk_X509_new_null();
+        if (chain == NULL) {
+            *err = "sk_X509_new_null() failed";
+            return NULL;
+        }
+
+        if (sk_X509_push(chain, x509) == 0) {
+            *err = "sk_X509_push() failed";
+            X509_free(x509);
+            sk_X509_pop_free(chain, X509_free);
+            return NULL;
+        }
+
+        return chain;
 
 #else
 

--- a/src/event/ngx_event_openssl_cache.c
+++ b/src/event/ngx_event_openssl_cache.c
@@ -465,7 +465,7 @@ ngx_ssl_cache_init_key(ngx_pool_t *pool, ngx_uint_t index, ngx_str_t *path,
     {
         id->type = NGX_SSL_CACHE_ENGINE;
 
-    } else if (index == NGX_SSL_CACHE_PKEY
+    } else if ((index == NGX_SSL_CACHE_CERT || index == NGX_SSL_CACHE_PKEY)
         && ngx_strncmp(path->data, "store:", sizeof("store:") - 1) == 0)
     {
         id->type = NGX_SSL_CACHE_STORE;

--- a/src/event/ngx_event_openssl_cache.c
+++ b/src/event/ngx_event_openssl_cache.c
@@ -610,9 +610,9 @@ ngx_ssl_cache_cert_create(ngx_ssl_cache_key_t *id, char **err, void *data)
             return NULL;
         }
 
-        cert = NULL;
+        x509 = NULL;
 
-        while (cert == NULL && !OSSL_STORE_eof(store)) {
+        while (x509 == NULL && !OSSL_STORE_eof(store)) {
             info = OSSL_STORE_load(store);
 
             if (info == NULL) {
@@ -620,7 +620,7 @@ ngx_ssl_cache_cert_create(ngx_ssl_cache_key_t *id, char **err, void *data)
             }
 
             if (OSSL_STORE_INFO_get_type(info) == OSSL_STORE_INFO_CERT) {
-                cert = OSSL_STORE_INFO_get1_CERT(info);
+                x509 = OSSL_STORE_INFO_get1_CERT(info);
             }
 
             OSSL_STORE_INFO_free(info);
@@ -628,12 +628,12 @@ ngx_ssl_cache_cert_create(ngx_ssl_cache_key_t *id, char **err, void *data)
 
         OSSL_STORE_close(store);
 
-        if (cert == NULL) {
+        if (x509 == NULL) {
             *err = "OSSL_STORE_load() failed";
             return NULL;
         }
 
-        return cert;
+        return x509;
 
 #else
 


### PR DESCRIPTION
### Proposed changes

This PR allows `ssl_certificate` to load a certificate using `store:` in the same way as `ssl_certificate_key`, as asked in https://github.com/nginx/nginx/issues/1086.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
