### PR TITLE
SCGI: fixed passing CONTENT_LENGTH in unbuffered mode.

### DIFF
--- a/src/http/modules/ngx_http_scgi_module.c
+++ b/src/http/modules/ngx_http_scgi_module.c
@@ -658,11 +658,9 @@ ngx_http_scgi_create_request(ngx_http_request_t *r)
     u_char                        buffer[NGX_OFF_T_LEN];
 
     content_length_n = 0;
-    body = r->upstream->request_bufs;
 
-    while (body) {
-        content_length_n += ngx_buf_size(body->buf);
-        body = body->next;
+    if (r->headers_in.content_length_n > 0) {
+        content_length_n = r->headers_in.content_length_n;
     }
 
     content_length.data = buffer;


### PR DESCRIPTION
Passing requests to SCGI uses a recalculated size of a request body as per changes made in d60b8d10f (1.3.9) to support CONTENT_LENGTH with chunked requests.  This is not compatible with unbuffered mode introduced later in 7ec559df5 (1.7.11), where CONTENT_LENGTH may not represent complete request body.  The fix is to follow the approach in the $content_length variable used with fastcgi and uwsgi modules, i.e. use original Content-Length readily available or a recalculated value from request body filters.

Reported by Mufeed VH.
