### PR TITLE
QUIC: avoid redundant 0-RTT key discard on each 1-RTT packet.

### DIFF
--- a/src/event/quic/ngx_event_quic.c
+++ b/src/event/quic/ngx_event_quic.c
@@ -1032,7 +1032,9 @@ ngx_quic_handle_payload(ngx_connection_t *c, ngx_quic_header_t *pkt)
         }
     }
 
-    if (pkt->level == NGX_QUIC_ENCRYPTION_APPLICATION) {
+    if (pkt->level == NGX_QUIC_ENCRYPTION_APPLICATION
+        && ngx_quic_keys_available(qc->keys, NGX_QUIC_ENCRYPTION_EARLY_DATA, 0))
+    {
         /*
          * RFC 9001, 4.9.3.  Discarding 0-RTT Keys
          *


### PR DESCRIPTION
The 0-RTT key discard block in `ngx_quic_handle_payload()` runs unconditionally for every 1-RTT packet received, calling `ngx_quic_keys_discard()` repeatedly after keys have already been cleaned up.  While the call is idempotent, it is redundant work on every application data packet.

Resolves #1127 

### Proposed changes

- Add `ngx_quic_keys_available()` guard to the 0-RTT key discard block
  in `ngx_quic_handle_payload()`, so `ngx_quic_keys_discard()` is only
  called once when keys are still present
- Consistent with the existing guard in `ngx_quic_discard_ctx()`

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
