### PR TITLE
Request body: fixed segfault on early errors

### DIFF
--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -1286,6 +1286,9 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
         ctx->internal_body_length = -1;
         ctx->internal_chunked = 1;
 
+    } else if (r->discard_body) {
+        ctx->internal_body_length = -1;
+
     } else {
         ctx->internal_body_length = r->headers_in.content_length_n;
     }

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -2507,6 +2507,7 @@ ngx_http_subrequest(ngx_http_request_t *r,
     sr->internal = 1;
 
     sr->discard_body = r->discard_body;
+    sr->discarding_body = r->discarding_body;
     sr->expect_tested = 1;
     sr->main_filter_need_in_memory = r->main_filter_need_in_memory;
 

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -2910,7 +2910,7 @@ ngx_http_finalize_connection(ngx_http_request_t *r)
 
     if (r->main->count != 1) {
 
-        if (r->discard_body) {
+        if (r->discarding_body) {
             r->read_event_handler = ngx_http_discarded_request_body_handler;
             ngx_add_timer(r->connection->read, clcf->lingering_timeout);
 
@@ -2975,7 +2975,7 @@ ngx_http_set_write_handler(ngx_http_request_t *r)
 
     r->http_state = NGX_HTTP_WRITING_REQUEST_STATE;
 
-    r->read_event_handler = r->discard_body ?
+    r->read_event_handler = r->discarding_body ?
                                 ngx_http_discarded_request_body_handler:
                                 ngx_http_test_reading;
     r->write_event_handler = ngx_http_writer;

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -543,6 +543,7 @@ struct ngx_http_request_s {
     unsigned                          keepalive:1;
     unsigned                          lingering_close:1;
     unsigned                          discard_body:1;
+    unsigned                          discarding_body:1;
     unsigned                          reading_body:1;
     unsigned                          internal:1;
     unsigned                          error_page:1;

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -306,6 +306,7 @@ typedef struct {
     ngx_chain_t                      *busy;
     ngx_http_chunked_t               *chunked;
     ngx_http_client_body_handler_pt   post_handler;
+    unsigned                          no_buffering:1;
     unsigned                          filter_need_buffering:1;
     unsigned                          last_sent:1;
     unsigned                          last_saved:1;

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -222,6 +222,7 @@ done:
 
     if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
         r->main->count--;
+        r->read_event_handler = ngx_http_block_reading;
     }
 
     return rc;
@@ -286,6 +287,7 @@ ngx_http_read_client_request_body_handler(ngx_http_request_t *r)
     rc = ngx_http_do_read_client_request_body(r);
 
     if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+        r->read_event_handler = ngx_http_block_reading;
         ngx_http_finalize_request(r, rc);
     }
 }

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -238,7 +238,10 @@ done:
 
         r->lingering_close = 1;
         r->discard_body = 1;
-        r->request_body->bufs = NULL;
+
+        if (r->request_body) {
+            r->request_body->bufs = NULL;
+        }
 
         r->main->count--;
         r->read_event_handler = ngx_http_block_reading;

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -684,6 +684,8 @@ ngx_http_discard_request_body(ngx_http_request_t *r)
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, rev->log, 0, "http set discard body");
 
+    r->discard_body = 1;
+
     if (rev->timer_set) {
         ngx_del_timer(rev);
     }
@@ -726,7 +728,7 @@ ngx_http_discard_request_body(ngx_http_request_t *r)
     }
 
     r->count++;
-    r->discard_body = 1;
+    r->discarding_body = 1;
 
     return NGX_OK;
 }
@@ -755,7 +757,7 @@ ngx_http_discarded_request_body_handler(ngx_http_request_t *r)
         timer = (ngx_msec_t) r->lingering_time - (ngx_msec_t) ngx_time();
 
         if ((ngx_msec_int_t) timer <= 0) {
-            r->discard_body = 0;
+            r->discarding_body = 0;
             r->lingering_close = 0;
             ngx_http_finalize_request(r, NGX_ERROR);
             return;
@@ -768,7 +770,7 @@ ngx_http_discarded_request_body_handler(ngx_http_request_t *r)
     rc = ngx_http_read_discarded_request_body(r);
 
     if (rc == NGX_OK) {
-        r->discard_body = 0;
+        r->discarding_body = 0;
         r->lingering_close = 0;
         r->lingering_time = 0;
         ngx_http_finalize_request(r, NGX_DONE);

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -221,6 +221,11 @@ done:
     }
 
     if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+
+        r->lingering_close = 1;
+        r->headers_in.content_length_n = 0;
+        r->request_body->bufs = NULL;
+
         r->main->count--;
         r->read_event_handler = ngx_http_block_reading;
     }
@@ -287,6 +292,11 @@ ngx_http_read_client_request_body_handler(ngx_http_request_t *r)
     rc = ngx_http_do_read_client_request_body(r);
 
     if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+
+        r->lingering_close = 1;
+        r->headers_in.content_length_n = 0;
+        r->request_body->bufs = NULL;
+
         r->read_event_handler = ngx_http_block_reading;
         ngx_http_finalize_request(r, rc);
     }
@@ -1150,8 +1160,6 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
                                   "body: %O+%O bytes",
                                   r->headers_in.content_length_n,
                                   rb->chunked->size);
-
-                    r->lingering_close = 1;
 
                     return NGX_HTTP_REQUEST_ENTITY_TOO_LARGE;
                 }

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -1206,11 +1206,7 @@ ngx_http_variable_content_length(ngx_http_request_t *r,
         v->no_cacheable = 1;
 
     } else if (r->discard_body) {
-        v->len = 1;
-        v->data = (u_char *) "0";
-        v->valid = 1;
-        v->no_cacheable = 0;
-        v->not_found = 0;
+        v->not_found = 1;
 
     } else if (r->headers_in.content_length_n >= 0) {
         p = ngx_pnalloc(r->pool, NGX_OFF_T_LEN);

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -1194,16 +1194,23 @@ ngx_http_variable_content_length(ngx_http_request_t *r,
 {
     u_char  *p;
 
-    if (r->headers_in.content_length) {
+    if (r->reading_body && r->headers_in.content_length) {
         v->len = r->headers_in.content_length->value.len;
         v->data = r->headers_in.content_length->value.data;
         v->valid = 1;
-        v->no_cacheable = 0;
+        v->no_cacheable = 1;
         v->not_found = 0;
 
     } else if (r->reading_body) {
         v->not_found = 1;
         v->no_cacheable = 1;
+
+    } else if (r->discard_body) {
+        v->len = 1;
+        v->data = (u_char *) "0";
+        v->valid = 1;
+        v->no_cacheable = 0;
+        v->not_found = 0;
 
     } else if (r->headers_in.content_length_n >= 0) {
         p = ngx_pnalloc(r->pool, NGX_OFF_T_LEN);
@@ -1214,7 +1221,7 @@ ngx_http_variable_content_length(ngx_http_request_t *r,
         v->len = ngx_sprintf(p, "%O", r->headers_in.content_length_n) - p;
         v->data = p;
         v->valid = 1;
-        v->no_cacheable = 0;
+        v->no_cacheable = 1;
         v->not_found = 0;
 
     } else if (r->headers_in.chunked) {

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1112,7 +1112,11 @@ ngx_http_v2_state_read_data(ngx_http_v2_connection_t *h2c, u_char *pos,
                                               stream->in_closed, 0);
 
         if (rc != NGX_OK && rc != NGX_AGAIN) {
+
             stream->skip_data = 1;
+            r->headers_in.content_length_n = 0;
+            r->request_body->bufs = NULL;
+
             ngx_http_finalize_request(r, rc);
         }
 
@@ -3862,6 +3866,7 @@ ngx_http_v2_run_request(ngx_http_request_t *r)
                           "client prematurely closed stream");
 
             r->stream->skip_data = 1;
+            r->headers_in.content_length_n = 0;
 
             ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
             goto failed;
@@ -4303,6 +4308,8 @@ ngx_http_v2_read_client_request_body_handler(ngx_http_request_t *r)
 
     if (rc != NGX_OK && rc != NGX_AGAIN) {
         r->stream->skip_data = 1;
+        r->headers_in.content_length_n = 0;
+        r->request_body->bufs = NULL;
         ngx_http_finalize_request(r, rc);
         return;
     }
@@ -4343,6 +4350,8 @@ ngx_http_v2_read_client_request_body_handler(ngx_http_request_t *r)
                           "http2 negative window update");
 
             stream->skip_data = 1;
+            r->headers_in.content_length_n = 0;
+            r->request_body->bufs = NULL;
 
             ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
             return;
@@ -4356,6 +4365,8 @@ ngx_http_v2_read_client_request_body_handler(ngx_http_request_t *r)
         == NGX_ERROR)
     {
         stream->skip_data = 1;
+        r->headers_in.content_length_n = 0;
+        r->request_body->bufs = NULL;
         ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
         return;
     }
@@ -4364,6 +4375,8 @@ ngx_http_v2_read_client_request_body_handler(ngx_http_request_t *r)
 
     if (ngx_http_v2_send_output_queue(h2c) == NGX_ERROR) {
         stream->skip_data = 1;
+        r->headers_in.content_length_n = 0;
+        r->request_body->bufs = NULL;
         ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
         return;
     }

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1084,13 +1084,6 @@ ngx_http_v2_state_read_data(ngx_http_v2_connection_t *h2c, u_char *pos,
     r = stream->request;
     fc = r->connection;
 
-    if (r->reading_body && !r->request_body_no_buffering) {
-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
-                       "skipping http2 DATA frame");
-
-        return ngx_http_v2_state_skip_padded(h2c, pos, end);
-    }
-
     if (r->headers_in.content_length_n < 0 && !r->headers_in.chunked) {
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
                        "skipping http2 DATA frame");

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1107,7 +1107,7 @@ ngx_http_v2_state_read_data(ngx_http_v2_connection_t *h2c, u_char *pos,
         if (rc != NGX_OK && rc != NGX_AGAIN) {
 
             stream->skip_data = 1;
-            r->headers_in.content_length_n = 0;
+            r->discard_body = 1;
             r->request_body->bufs = NULL;
 
             ngx_http_finalize_request(r, rc);
@@ -3859,7 +3859,7 @@ ngx_http_v2_run_request(ngx_http_request_t *r)
                           "client prematurely closed stream");
 
             r->stream->skip_data = 1;
-            r->headers_in.content_length_n = 0;
+            r->discard_body = 1;
 
             ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
             goto failed;
@@ -4301,7 +4301,7 @@ ngx_http_v2_read_client_request_body_handler(ngx_http_request_t *r)
 
     if (rc != NGX_OK && rc != NGX_AGAIN) {
         r->stream->skip_data = 1;
-        r->headers_in.content_length_n = 0;
+        r->discard_body = 1;
         r->request_body->bufs = NULL;
         ngx_http_finalize_request(r, rc);
         return;
@@ -4343,7 +4343,7 @@ ngx_http_v2_read_client_request_body_handler(ngx_http_request_t *r)
                           "http2 negative window update");
 
             stream->skip_data = 1;
-            r->headers_in.content_length_n = 0;
+            r->discard_body = 1;
             r->request_body->bufs = NULL;
 
             ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
@@ -4358,7 +4358,7 @@ ngx_http_v2_read_client_request_body_handler(ngx_http_request_t *r)
         == NGX_ERROR)
     {
         stream->skip_data = 1;
-        r->headers_in.content_length_n = 0;
+        r->discard_body = 1;
         r->request_body->bufs = NULL;
         ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
         return;
@@ -4368,7 +4368,7 @@ ngx_http_v2_read_client_request_body_handler(ngx_http_request_t *r)
 
     if (ngx_http_v2_send_output_queue(h2c) == NGX_ERROR) {
         stream->skip_data = 1;
-        r->headers_in.content_length_n = 0;
+        r->discard_body = 1;
         r->request_body->bufs = NULL;
         ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
         return;

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -1301,6 +1301,10 @@ ngx_http_v3_read_client_request_body_handler(ngx_http_request_t *r)
     rc = ngx_http_v3_do_read_client_request_body(r);
 
     if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+
+        r->headers_in.content_length_n = 0;
+        r->request_body->bufs = NULL;
+
         ngx_http_finalize_request(r, rc);
     }
 }

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -1302,7 +1302,7 @@ ngx_http_v3_read_client_request_body_handler(ngx_http_request_t *r)
 
     if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
 
-        r->headers_in.content_length_n = 0;
+        r->discard_body = 1;
         r->request_body->bufs = NULL;
 
         ngx_http_finalize_request(r, rc);


### PR DESCRIPTION
### Proposed changes

Backports a chain of request body error-handling improvements from freenginx, culminating in a fix for a segfault reported on the nginx-devel mailing list by Jiří Setnička
([thread](https://freenginx.org/pipermail/nginx-devel/2024-August/000484.html)).

**The bug:** When a client sends an `Expect: 100-continue` header and closes the connection before the server completes request body initialization, `ngx_http_read_client_request_body()` dereferences `r->request_body->bufs` while `r->request_body` is still NULL. This crashes the worker process. The NULL pointer access was introduced by an earlier change (`81082b5521dd`) that clears the request body on errors
but did not guard against the structure being unallocated.

The fix itself is a one-line NULL check, but it depends on a series of prerequisite commits that built up the body-clearing and discard mechanisms. Without these prerequisites the fix does not apply and the
broader error-handling improvements are incomplete. Three additional adaptation commits are included because mainline nginx's HTTP/2 and HTTP/3 code paths have diverged from freenginx and require equivalent
changes.

#### Commits (in application order)

| # | Commit | Description | Type |
|---|--------|-------------|------|
| 1 | `74d459d` | Reorder Content-Length / Transfer-Encoding checks so `content_length_n` is not set when both headers are present, making error page handling safer. | Backport |
| 2 | `2306bcf` | Call `ngx_http_block_reading` on error paths during body reading to prevent undefined behaviour from continued client writes. | Backport |
| 3 | `4342e8c` | Clear `r->request_body->bufs` and set `content_length_n = 0` on HTTP/1.x error paths so the body is in a consistent state for `error_page` handling. | Backport |
| 4 | `1a93eb7` | Apply the same body-clearing logic to all HTTP/2 and HTTP/3 error paths in mainline nginx. | Adaptation |
| 5 | `3580599` | Add `no_buffering` flag to track unbuffered reading state; clear body state when re-reading after unbuffered mode. | Backport |
| 6 | `a86e91f` | Remove stale HTTP/2 workaround for unbuffered proxying that is no longer needed after the `no_buffering` flag. | Adaptation |
| 7 | `5ca06d1` | Introduce `discarding_body` flag and fix `error_page 413` handling for HTTP/2 and HTTP/3. | Backport |
| 8 | `15c8093` | Make `$content_length` reflect available body length — return empty when body was discarded or errored, mark non-cacheable during active reading. | Backport |
| 9 | `be1d5a1` | Change discarded body semantics from "zero-length body" to "no body" — proxied requests omit `Content-Length` instead of sending `Content-Length: 0`. | Backport |
| 10 | `a13b1dc` | Apply the discard_body flag changes to all HTTP/2 and HTTP/3 error paths in mainline. | Adaptation |
| 11 | `4de6f56` | **Target fix.** Guard `r->request_body->bufs` access with a NULL check to prevent the segfault on early errors. | Backport |

#### Companion test changes

The corresponding test backports are in the
[`nginx-tests`](https://github.com/dekobon/nginx-tests) repository on the`cherry/body-discard-tests` branch:

| Commit | Description |
|--------|-------------|
| [`6647488`](https://github.com/dekobon/nginx-tests/commit/6647488665cb1d0e210459bf628c0485d58e0412) | Adjust `http_headers_multi.t` so `$content_length` is evaluated before body discard. |
| [`cb3152b`](https://github.com/dekobon/nginx-tests/commit/cb3152b35f565c77a6d9be30cb6ac3ec4e5e4e2f) | Add `body_discard.t`, `h2_request_body_discard.t`, and `h3_request_body_discard.t` covering `error_page 413`, `$content_length`, and proxy forwarding after body discard. |
| [`c60e1f1`](https://github.com/dekobon/nginx-tests/commit/c60e1f1422c548abe48c93d8ea33bbc4bc951d4e) | Increase sleep delays in body discard tests to fix flaky failures on slow hosts. |

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [X] I have checked that NGINX compiles and runs after adding my changes.