### PR TITLE
Proxy: reset pending control frames on HTTP/2 upstream reinit.

### DIFF
--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -946,6 +946,7 @@ ngx_http_proxy_v2_reinit_request(ngx_http_request_t *r)
     ctx->connection = NULL;
     ctx->in = NULL;
     ctx->busy = NULL;
+    ctx->out = NULL;
 
     return NGX_OK;
 }


### PR DESCRIPTION
Previously, ctx->out was not cleared in ngx_http_proxy_v2_reinit_request(), which could cause stale HTTP/2 control frames (SETTINGS ACK, PING ACK, WINDOW_UPDATE) queued for the old upstream connection to be sent to a new upstream connection during a retry.

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR's description or commit message.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
