### PR TITLE
gRPC: reset buffer chains on upstream reinit.

### DIFF
--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -1224,6 +1224,9 @@ ngx_http_grpc_reinit_request(ngx_http_request_t *r)
     ctx->rst = 0;
     ctx->goaway = 0;
     ctx->connection = NULL;
+    ctx->in = NULL;
+    ctx->busy = NULL;
+    ctx->out = NULL;
 
     return NGX_OK;
 }


### PR DESCRIPTION
## Summary

Previously, ctx->out was not cleared in ngx_http_grpc_reinit_request(),
which could cause queued HTTP/2 control frames (SETTINGS ACK, PING ACK,
WINDOW_UPDATE) to be sent on next upstream.

Additionally, ctx->in and ctx->busy needs to be cleared to avoid similar
problems with buffered request body fixed in cd12dc4f1.

## Test plan

- [x] Verify nginx compiles and runs with the change
- [x] Run the nginx test suite from https://github.com/nginx/nginx-tests