### PR TITLE
auto/options: Exit with exit code 0 when --help option is passed

### DIFF
--- a/auto/options
+++ b/auto/options
@@ -608,7 +608,7 @@ cat << END
 
 END
 
-    exit 1
+    exit 0
 fi
 
 


### PR DESCRIPTION
`auto/options` calls `exit 1` when `--help` is passed to configure, which doesn't really align with how most utilities handle `--help`.

Since `--help` is a totally legal option, this commit makes script exit with the successful exit code, i.e. the exit code 0.

`./configure` exiting with 1 requires us in Gentoo to ignore the exit code when `--help` is passed:
https://github.com/gentoo/gentoo/blob/e2f21f1361b6be24fc18a53dd6a7b41b3b69e166/eclass/nginx.eclass#L270-L277
(The fact the linked code just calls `return` and not  `return 0` is a bug on its own).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
