### PR TITLE
Mp4: avoid zero size buffers in output.

### DIFF
--- a/src/http/modules/ngx_http_mp4_module.c
+++ b/src/http/modules/ngx_http_mp4_module.c
@@ -901,8 +901,11 @@ ngx_http_mp4_process(ngx_http_mp4_file_t *mp4)
         }
     }
 
-    if (end_offset < start_offset) {
-        end_offset = start_offset;
+    if (end_offset <= start_offset) {
+        ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                      "no data between start time and end time in \"%s\"",
+                      mp4->file.name.data);
+        return NGX_ERROR;
     }
 
     mp4->moov_size += 8;
@@ -913,7 +916,7 @@ ngx_http_mp4_process(ngx_http_mp4_file_t *mp4)
 
     *prev = &mp4->mdat_atom;
 
-    if (start_offset > mp4->mdat_data.buf->file_last) {
+    if (start_offset >= mp4->mdat_data.buf->file_last) {
         ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
                       "start time is out mp4 mdat atom in \"%s\"",
                       mp4->file.name.data);
@@ -3444,7 +3447,7 @@ ngx_http_mp4_update_stsz_atom(ngx_http_mp4_file_t *mp4,
     if (data) {
         entries = trak->sample_sizes_entries;
 
-        if (trak->start_sample > entries) {
+        if (trak->start_sample >= entries) {
             ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
                           "start time is out mp4 stsz samples in \"%s\"",
                           mp4->file.name.data);
@@ -3619,7 +3622,7 @@ ngx_http_mp4_update_stco_atom(ngx_http_mp4_file_t *mp4,
         return NGX_ERROR;
     }
 
-    if (trak->start_chunk > trak->chunks) {
+    if (trak->start_chunk >= trak->chunks) {
         ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
                       "start time is out mp4 stco chunks in \"%s\"",
                       mp4->file.name.data);
@@ -3834,7 +3837,7 @@ ngx_http_mp4_update_co64_atom(ngx_http_mp4_file_t *mp4,
         return NGX_ERROR;
     }
 
-    if (trak->start_chunk > trak->chunks) {
+    if (trak->start_chunk >= trak->chunks) {
         ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
                       "start time is out mp4 co64 chunks in \"%s\"",
                       mp4->file.name.data);


### PR DESCRIPTION
Following up on #1147, this change adds more validation for empty buffers in output.

Reproducing via patching:
```
diff --git a/src/http/modules/ngx_http_mp4_module.c b/src/http/modules/ngx_http_mp4_module.c
index b7bd192df..40f851f83 100644
--- a/src/http/modules/ngx_http_mp4_module.c
+++ b/src/http/modules/ngx_http_mp4_module.c
@@ -901,6 +901,8 @@ ngx_http_mp4_process(ngx_http_mp4_file_t *mp4)
         }
     }
 
+    end_offset = start_offset;
+
     if (end_offset < start_offset) {
         end_offset = start_offset;
     }
```

```
diff --git a/src/http/modules/ngx_http_mp4_module.c b/src/http/modules/ngx_http_mp4_module.c
index b7bd192df..f5844cfc1 100644
--- a/src/http/modules/ngx_http_mp4_module.c
+++ b/src/http/modules/ngx_http_mp4_module.c
@@ -3431,6 +3431,7 @@ ngx_http_mp4_update_stsz_atom(ngx_http_mp4_file_t *mp4,
 
     if (data) {
         entries = trak->sample_sizes_entries;
+        trak->start_sample = entries;
 
         if (trak->start_sample > entries) {
             ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
```