### PR TITLE
Resolver: fixed off-by-one read in ngx_resolver_copy().

### DIFF
--- a/src/core/ngx_resolver.c
+++ b/src/core/ngx_resolver.c
@@ -2757,7 +2757,7 @@ ngx_resolver_process_srv(ngx_resolver_t *r, u_char *buf, size_t n,
 
         case NGX_RESOLVE_SRV:
 
-            if (i + 6 > n) {
+            if (i + 6 >= n) {
                 goto short_response;
             }
 


### PR DESCRIPTION
It is believed to be harmless, see a similar change 077a890a76ff.

Reported-by: geeknik <geeknik@protonmail.ch>