### PR TITLE
QUIC: improved error handling in OpenSSL compat layer.

### DIFF
--- a/src/event/quic/ngx_event_quic_openssl_compat.c
+++ b/src/event/quic/ngx_event_quic_openssl_compat.c
@@ -213,8 +213,12 @@ ngx_quic_compat_keylog_callback(const SSL *ssl, const char *line)
         com->method->set_read_secret((SSL *) ssl, level, cipher, secret, n);
         com->read_record = 0;
 
-        (void) ngx_quic_compat_set_encryption_secret(c, &com->keys, level,
-                                                     cipher, secret, n);
+        if (ngx_quic_compat_set_encryption_secret(c, &com->keys, level,
+                                                  cipher, secret, n)
+            != NGX_OK)
+        {
+            qc->error = NGX_QUIC_ERR_INTERNAL_ERROR;
+        }
     }
 
     ngx_explicit_memzero(secret, n);
@@ -590,6 +594,11 @@ ngx_quic_compat_create_record(ngx_quic_compat_record_t *rec, ngx_str_t *res)
 #endif
 
     secret = &rec->keys->secret;
+
+    if (secret->ctx == NULL) {
+        ngx_log_error(NGX_LOG_EMERG, rec->log, 0, "missing QUIC compat key");
+        return NGX_ERROR;
+    }
 
     ngx_memcpy(nonce, secret->iv.data, secret->iv.len);
     ngx_quic_compute_nonce(nonce, sizeof(nonce), rec->number);


### PR DESCRIPTION
Previously ngx_quic_compat_create_record() could try to encrypt a TLS record even if encryption context was missing, which resulted in a NULL pointer dereference.

The context is created by ngx_quic_compat_set_encryption_secret() called from the OpenSSL keylog callback.  If an error occured in that function, the context could remain missing.  This could happen under memory pressure, if an allocation failed inside this function.

The fix is to handle errors from ngx_quic_compat_set_encryption_secret() and set qc->error to trigger an error after SSL_do_handshake() return. Also, a check for context is added to ngx_quic_compat_create_record() to avoid other simnilar issues.

Co-authored-by: lukefr09