### PR TITLE
QUIC: worker-bound stateless reset tokens.

### DIFF
--- a/src/event/quic/ngx_event_quic_tokens.c
+++ b/src/event/quic/ngx_event_quic_tokens.c
@@ -20,9 +20,13 @@ ngx_quic_new_sr_token(ngx_connection_t *c, ngx_str_t *cid, u_char *secret,
     u_char *token)
 {
     ngx_str_t  tmp;
+    u_char     buf[NGX_QUIC_SR_KEY_LEN + sizeof(ngx_uint_t)];
 
-    tmp.data = secret;
-    tmp.len = NGX_QUIC_SR_KEY_LEN;
+    ngx_memcpy(buf, secret, NGX_QUIC_SR_KEY_LEN);
+    ngx_memcpy(buf + NGX_QUIC_SR_KEY_LEN, &ngx_worker, sizeof(ngx_uint_t));
+
+    tmp.data = buf;
+    tmp.len = sizeof(buf);
 
     if (ngx_quic_derive_key(c->log, "sr_token_key", &tmp, cid, token,
                             NGX_QUIC_SR_TOKEN_LEN)


### PR DESCRIPTION
Previously, it was possible to obtain a stateless reset token for a connection by routing its packet to a wrong worker.  This allowed to terminate the connection.

The fix is to bind steteless reset token to worker number.
