### PR TITLE
Upstream: added sticky sessions support for upstreams.

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -950,6 +950,20 @@ if [ $HTTP = YES ]; then
         . auto/module
     fi
 
+    if [ $HTTP_UPSTREAM_STICKY = YES ]; then
+        have=NGX_HTTP_UPSTREAM_STICKY . auto/have
+        have=NGX_HTTP_UPSTREAM_SID . auto/have
+
+        ngx_module_name=ngx_http_upstream_sticky_module
+        ngx_module_incs=
+        ngx_module_deps=
+        ngx_module_srcs=src/http/modules/ngx_http_upstream_sticky_module.c
+        ngx_module_libs=
+        ngx_module_link=$HTTP_UPSTREAM_STICKY
+
+        . auto/module
+    fi
+
     if [ $HTTP_STUB_STATUS = YES ]; then
         have=NGX_STAT_STUB . auto/have
 

--- a/auto/options
+++ b/auto/options
@@ -107,6 +107,7 @@ HTTP_UPSTREAM_LEAST_CONN=YES
 HTTP_UPSTREAM_RANDOM=YES
 HTTP_UPSTREAM_KEEPALIVE=YES
 HTTP_UPSTREAM_ZONE=YES
+HTTP_UPSTREAM_STICKY=YES
 
 # STUB
 HTTP_STUB_STATUS=NO
@@ -292,6 +293,7 @@ $0: warning: the \"--with-ipv6\" option is deprecated"
                                          HTTP_UPSTREAM_RANDOM=NO    ;;
         --without-http_upstream_keepalive_module) HTTP_UPSTREAM_KEEPALIVE=NO ;;
         --without-http_upstream_zone_module) HTTP_UPSTREAM_ZONE=NO  ;;
+        --without-http_upstream_sticky)  HTTP_UPSTREAM_STICKY=NO    ;;
 
         --with-http_perl_module)         HTTP_PERL=YES              ;;
         --with-http_perl_module=dynamic) HTTP_PERL=DYNAMIC          ;;
@@ -516,6 +518,7 @@ cat << END
                                      disable ngx_http_upstream_keepalive_module
   --without-http_upstream_zone_module
                                      disable ngx_http_upstream_zone_module
+  --without-http_upstream_sticky     disable sticky upstream modules
 
   --with-http_perl_module            enable ngx_http_perl_module
   --with-http_perl_module=dynamic    enable dynamic ngx_http_perl_module

--- a/src/event/ngx_event_connect.h
+++ b/src/event/ngx_event_connect.h
@@ -60,6 +60,11 @@ struct ngx_peer_connection_s {
 
     ngx_log_t                       *log;
 
+#if (NGX_HTTP_UPSTREAM_SID || NGX_COMPAT)
+    ngx_str_t                       *hint;
+    ngx_str_t                       *sid;
+#endif
+
     unsigned                         cached:1;
     unsigned                         transparent:1;
     unsigned                         so_keepalive:1;
@@ -68,7 +73,7 @@ struct ngx_peer_connection_s {
                                      /* ngx_connection_log_error_e */
     unsigned                         log_error:2;
 
-    NGX_COMPAT_BEGIN(2)
+    NGX_COMPAT_BEGIN(1)
     NGX_COMPAT_END
 };
 

--- a/src/http/modules/ngx_http_upstream_hash_module.c
+++ b/src/http/modules/ngx_http_upstream_hash_module.c
@@ -200,6 +200,17 @@ ngx_http_upstream_get_hash_peer(ngx_peer_connection_t *pc, void *data)
     pc->cached = 0;
     pc->connection = NULL;
 
+#if (NGX_HTTP_UPSTREAM_SID)
+    peer = ngx_http_upstream_get_rr_peer_by_sid(&hp->rrp, pc->hint, &p, 1);
+
+    if (peer) {
+        n = p / (8 * sizeof(uintptr_t));
+        m = (uintptr_t) 1 << p % (8 * sizeof(uintptr_t));
+
+        goto found;
+    }
+#endif
+
     for ( ;; ) {
 
         /*
@@ -273,12 +284,20 @@ ngx_http_upstream_get_hash_peer(ngx_peer_connection_t *pc, void *data)
         }
     }
 
+#if (NGX_HTTP_UPSTREAM_SID)
+found:
+#endif
+
     hp->rrp.current = peer;
     ngx_http_upstream_rr_peer_ref(hp->rrp.peers, peer);
 
     pc->sockaddr = peer->sockaddr;
     pc->socklen = peer->socklen;
     pc->name = &peer->name;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+    pc->sid = &peer->sid;
+#endif
 
     peer->conns++;
 
@@ -591,6 +610,14 @@ ngx_http_upstream_get_chash_peer(ngx_peer_connection_t *pc, void *data)
     points = hcf->points;
     point = &points->point[0];
 
+#if (NGX_HTTP_UPSTREAM_SID)
+    best = ngx_http_upstream_get_rr_peer_by_sid(&hp->rrp, pc->hint, &best_i, 0);
+
+    if (best) {
+        goto found;
+    }
+#endif
+
     for ( ;; ) {
         server = point[hp->hash % points->number].server;
 
@@ -670,6 +697,10 @@ found:
     pc->sockaddr = best->sockaddr;
     pc->socklen = best->socklen;
     pc->name = &best->name;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+    pc->sid = &best->sid;
+#endif
 
     best->conns++;
 

--- a/src/http/modules/ngx_http_upstream_ip_hash_module.c
+++ b/src/http/modules/ngx_http_upstream_ip_hash_module.c
@@ -183,6 +183,17 @@ ngx_http_upstream_get_ip_hash_peer(ngx_peer_connection_t *pc, void *data)
 
     hash = iphp->hash;
 
+#if (NGX_HTTP_UPSTREAM_SID)
+    peer = ngx_http_upstream_get_rr_peer_by_sid(&iphp->rrp, pc->hint, &p, 1);
+
+    if (peer) {
+        n = p / (8 * sizeof(uintptr_t));
+        m = (uintptr_t) 1 << p % (8 * sizeof(uintptr_t));
+
+        goto found;
+    }
+#endif
+
     for ( ;; ) {
 
         for (i = 0; i < (ngx_uint_t) iphp->addrlen; i++) {
@@ -239,12 +250,20 @@ ngx_http_upstream_get_ip_hash_peer(ngx_peer_connection_t *pc, void *data)
         }
     }
 
+#if (NGX_HTTP_UPSTREAM_SID)
+found:
+#endif
+
     iphp->rrp.current = peer;
     ngx_http_upstream_rr_peer_ref(iphp->rrp.peers, peer);
 
     pc->sockaddr = peer->sockaddr;
     pc->socklen = peer->socklen;
     pc->name = &peer->name;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+    pc->sid = &peer->sid;
+#endif
 
     peer->conns++;
 

--- a/src/http/modules/ngx_http_upstream_keepalive_module.c
+++ b/src/http/modules/ngx_http_upstream_keepalive_module.c
@@ -52,6 +52,8 @@ typedef struct {
     ngx_event_save_peer_session_pt     original_save_session;
 #endif
 
+    ngx_event_notify_peer_pt           original_notify;
+
 } ngx_http_upstream_keepalive_peer_data_t;
 
 
@@ -72,6 +74,9 @@ static ngx_int_t ngx_http_upstream_keepalive_set_session(
 static void ngx_http_upstream_keepalive_save_session(ngx_peer_connection_t *pc,
     void *data);
 #endif
+
+static void ngx_http_upstream_notify_keepalive_peer(ngx_peer_connection_t *pc,
+    void *data, ngx_uint_t type);
 
 static void *ngx_http_upstream_keepalive_create_conf(ngx_conf_t *cf);
 static char *ngx_http_upstream_keepalive(ngx_conf_t *cf, ngx_command_t *cmd,
@@ -227,6 +232,11 @@ ngx_http_upstream_init_keepalive_peer(ngx_http_request_t *r,
     r->upstream->peer.set_session = ngx_http_upstream_keepalive_set_session;
     r->upstream->peer.save_session = ngx_http_upstream_keepalive_save_session;
 #endif
+
+    if (r->upstream->peer.notify) {
+        kp->original_notify = r->upstream->peer.notify;
+        r->upstream->peer.notify = ngx_http_upstream_notify_keepalive_peer;
+    }
 
     return NGX_OK;
 }
@@ -505,6 +515,16 @@ ngx_http_upstream_keepalive_save_session(ngx_peer_connection_t *pc, void *data)
 }
 
 #endif
+
+
+static void
+ngx_http_upstream_notify_keepalive_peer(ngx_peer_connection_t *pc, void *data,
+    ngx_uint_t type)
+{
+    ngx_http_upstream_keepalive_peer_data_t  *kp = data;
+
+    kp->original_notify(pc, kp->data, type);
+}
 
 
 static void *

--- a/src/http/modules/ngx_http_upstream_least_conn_module.c
+++ b/src/http/modules/ngx_http_upstream_least_conn_module.c
@@ -138,6 +138,14 @@ ngx_http_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
     p = 0;
 #endif
 
+#if (NGX_HTTP_UPSTREAM_SID)
+    best = ngx_http_upstream_get_rr_peer_by_sid(rrp, pc->hint, &p, 0);
+
+    if (best) {
+        goto best_chosen;
+    }
+#endif
+
     for (peer = peers->peer, i = 0;
          peer;
          peer = peer->next, i++)
@@ -239,6 +247,10 @@ ngx_http_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
 
     best->current_weight -= total;
 
+#if (NGX_HTTP_UPSTREAM_SID)
+best_chosen:
+#endif
+
     if (now - best->checked > best->fail_timeout) {
         best->checked = now;
     }
@@ -246,6 +258,10 @@ ngx_http_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
     pc->sockaddr = best->sockaddr;
     pc->socklen = best->socklen;
     pc->name = &best->name;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+    pc->sid = &best->sid;
+#endif
 
     best->conns++;
 

--- a/src/http/modules/ngx_http_upstream_random_module.c
+++ b/src/http/modules/ngx_http_upstream_random_module.c
@@ -249,6 +249,17 @@ ngx_http_upstream_get_random_peer(ngx_peer_connection_t *pc, void *data)
 
     now = ngx_time();
 
+#if (NGX_HTTP_UPSTREAM_SID)
+    peer = ngx_http_upstream_get_rr_peer_by_sid(rrp, pc->hint, &i, 1);
+
+    if (peer) {
+        n = i / (8 * sizeof(uintptr_t));
+        m = (uintptr_t) 1 << i % (8 * sizeof(uintptr_t));
+
+        goto found;
+    }
+#endif
+
     for ( ;; ) {
 
         i = ngx_http_upstream_peek_random_peer(peers, rp);
@@ -292,6 +303,10 @@ ngx_http_upstream_get_random_peer(ngx_peer_connection_t *pc, void *data)
         }
     }
 
+#if (NGX_HTTP_UPSTREAM_SID)
+found:
+#endif
+
     rrp->current = peer;
     ngx_http_upstream_rr_peer_ref(peers, peer);
 
@@ -302,6 +317,10 @@ ngx_http_upstream_get_random_peer(ngx_peer_connection_t *pc, void *data)
     pc->sockaddr = peer->sockaddr;
     pc->socklen = peer->socklen;
     pc->name = &peer->name;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+    pc->sid = &peer->sid;
+#endif
 
     peer->conns++;
 
@@ -357,6 +376,17 @@ ngx_http_upstream_get_random2_peer(ngx_peer_connection_t *pc, void *data)
     p = 0;
 #endif
 
+#if (NGX_HTTP_UPSTREAM_SID)
+    peer = ngx_http_upstream_get_rr_peer_by_sid(rrp, pc->hint, &i, 0);
+
+    if (peer) {
+        n = i / (8 * sizeof(uintptr_t));
+        m = (uintptr_t) 1 << i % (8 * sizeof(uintptr_t));
+
+        goto found;
+    }
+#endif
+
     for ( ;; ) {
 
         i = ngx_http_upstream_peek_random_peer(peers, rp);
@@ -410,6 +440,10 @@ ngx_http_upstream_get_random2_peer(ngx_peer_connection_t *pc, void *data)
         }
     }
 
+#if (NGX_HTTP_UPSTREAM_SID)
+found:
+#endif
+
     rrp->current = peer;
     ngx_http_upstream_rr_peer_ref(peers, peer);
 
@@ -420,6 +454,10 @@ ngx_http_upstream_get_random2_peer(ngx_peer_connection_t *pc, void *data)
     pc->sockaddr = peer->sockaddr;
     pc->socklen = peer->socklen;
     pc->name = &peer->name;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+    pc->sid = &peer->sid;
+#endif
 
     peer->conns++;
 

--- a/src/http/modules/ngx_http_upstream_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_sticky_module.c
@@ -1,0 +1,592 @@
+
+/*
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <ngx_md5.h>
+
+
+#define NGX_HTTP_STICKY_COOKIE_MAX_EXPIRES  2145916555
+
+
+/* per-upstream sticky configuration */
+typedef struct {
+    ngx_http_upstream_init_pt                   original_init_upstream;
+    ngx_http_upstream_init_peer_pt              original_init_peer;
+
+    ngx_array_t                                *lookup_vars; /* of ngx_int_t */
+
+    ngx_str_t                                   cookie_name;
+    ngx_str_t                                   cookie_domain;
+    ngx_str_t                                   cookie_path;
+    time_t                                      cookie_expires;
+} ngx_http_upstream_sticky_srv_conf_t;
+
+
+typedef struct {
+    void                                       *original_data;
+    ngx_http_request_t                         *request;
+
+    ngx_http_upstream_sticky_srv_conf_t        *conf;
+
+    ngx_str_t                                   id;
+    ngx_table_elt_t                            *cookie;
+
+    ngx_event_get_peer_pt                       original_get_peer;
+    ngx_event_free_peer_pt                      original_free_peer;
+
+#if (NGX_HTTP_SSL)
+    ngx_event_set_peer_session_pt               original_set_session;
+    ngx_event_save_peer_session_pt              original_save_session;
+#endif
+} ngx_http_upstream_sticky_peer_data_t;
+
+
+static ngx_int_t ngx_http_upstream_sticky_init_upstream(ngx_conf_t *cf,
+    ngx_http_upstream_srv_conf_t *us);
+static ngx_int_t ngx_http_upstream_sticky_init_peer(ngx_http_request_t *r,
+    ngx_http_upstream_srv_conf_t *us);
+static ngx_int_t ngx_http_upstream_sticky_get_id(
+    ngx_http_upstream_sticky_srv_conf_t *stcf, ngx_http_request_t *r,
+    ngx_str_t *id);
+static ngx_int_t ngx_http_upstream_sticky_get_peer(ngx_peer_connection_t *pc,
+    void *data);
+static void ngx_http_upstream_sticky_free_peer(ngx_peer_connection_t *pc,
+    void *data, ngx_uint_t state);
+
+
+#if (NGX_HTTP_SSL)
+static ngx_int_t ngx_http_upstream_sticky_set_session(
+    ngx_peer_connection_t *pc, void *data);
+static void ngx_http_upstream_sticky_save_session(ngx_peer_connection_t *pc,
+    void *data);
+#endif
+
+
+static ngx_int_t ngx_http_upstream_sticky_cookie_insert(
+    ngx_peer_connection_t *pc, ngx_http_upstream_sticky_peer_data_t *stp);
+
+
+static void *ngx_http_upstream_sticky_create_conf(ngx_conf_t *cf);
+static char *ngx_http_upstream_sticky(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+
+static u_char expires[] = "; expires=Thu, 31-Dec-37 23:55:55 GMT";
+
+
+static ngx_command_t  ngx_http_upstream_sticky_commands[] = {
+
+    { ngx_string("sticky"),
+      NGX_HTTP_UPS_CONF|NGX_CONF_2MORE,
+      ngx_http_upstream_sticky,
+      0,
+      0,
+      NULL },
+
+      ngx_null_command
+};
+
+
+static ngx_http_module_t
+ngx_http_upstream_sticky_module_ctx = {
+    NULL,                                 /* preconfiguration */
+    NULL,                                 /* postconfiguration */
+
+    NULL,                                 /* create main configuration */
+    NULL,                                 /* init main configuration */
+
+    ngx_http_upstream_sticky_create_conf, /* create server configuration */
+    NULL,                                 /* merge server configuration */
+
+    NULL,                                 /* create location configuration */
+    NULL                                  /* merge location configuration */
+};
+
+
+ngx_module_t
+ngx_http_upstream_sticky_module =
+{
+    NGX_MODULE_V1,
+
+    &ngx_http_upstream_sticky_module_ctx, /* module context */
+    ngx_http_upstream_sticky_commands,    /* module directives */
+
+    NGX_HTTP_MODULE,                      /* module type */
+    NULL,                                 /* init master */
+
+    NULL,                                 /* init module */
+    NULL,                                 /* init process */
+
+    NULL,                                 /* init thread */
+    NULL,                                 /* exit thread */
+
+    NULL,                                 /* exit process */
+    NULL,                                 /* exit master */
+
+    NGX_MODULE_V1_PADDING
+};
+
+
+static ngx_int_t
+ngx_http_upstream_sticky_init_upstream(ngx_conf_t *cf,
+    ngx_http_upstream_srv_conf_t *us)
+{
+    ngx_http_upstream_sticky_srv_conf_t  *stcf;
+
+    stcf = ngx_http_conf_upstream_srv_conf(us, ngx_http_upstream_sticky_module);
+
+    if (stcf->original_init_upstream(cf, us) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    stcf->original_init_peer = us->peer.init;
+    us->peer.init = ngx_http_upstream_sticky_init_peer;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_sticky_init_peer(ngx_http_request_t *r,
+    ngx_http_upstream_srv_conf_t *us)
+{
+    ngx_int_t                              rc;
+    ngx_http_upstream_t                   *u;
+    ngx_http_upstream_sticky_srv_conf_t   *stcf;
+    ngx_http_upstream_sticky_peer_data_t  *stp;
+
+    stcf = ngx_http_conf_upstream_srv_conf(us, ngx_http_upstream_sticky_module);
+
+    stp = ngx_pcalloc(r->pool, sizeof(ngx_http_upstream_sticky_peer_data_t));
+    if (stp == NULL) {
+        return NGX_ERROR;
+    }
+
+    rc = stcf->original_init_peer(r, us);
+
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    u = r->upstream;
+
+    stp->original_data = u->peer.data;
+    stp->original_get_peer = u->peer.get;
+    stp->original_free_peer = u->peer.free;
+
+    stp->request = r;
+    stp->conf = stcf;
+
+    u->peer.get = ngx_http_upstream_sticky_get_peer;
+    u->peer.free = ngx_http_upstream_sticky_free_peer;
+    u->peer.data = stp;
+
+#if (NGX_HTTP_SSL)
+    stp->original_set_session = u->peer.set_session;
+    stp->original_save_session = u->peer.save_session;
+    u->peer.set_session = ngx_http_upstream_sticky_set_session;
+    u->peer.save_session = ngx_http_upstream_sticky_save_session;
+#endif
+
+    ngx_http_upstream_sticky_get_id(stcf, r, &stp->id);
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_sticky_get_id(ngx_http_upstream_sticky_srv_conf_t *stcf,
+    ngx_http_request_t *r, ngx_str_t *id)
+{
+    ngx_int_t                  *index;
+    ngx_uint_t                  i;
+    ngx_http_variable_value_t  *v;
+
+    index = stcf->lookup_vars->elts;
+
+    for (i = 0; i < stcf->lookup_vars->nelts; i++) {
+
+        v = ngx_http_get_flushed_variable(r, index[i]);
+
+        if (v == NULL || v->not_found || v->len == 0) {
+            continue;
+        }
+
+        id->data = v->data;
+        id->len = v->len;
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "sticky: using \"%v\" found in variable #%i", v, i + 1);
+
+        return NGX_OK;
+    }
+
+    ngx_str_null(id);
+
+    return NGX_DONE;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_sticky_get_peer(ngx_peer_connection_t *pc, void *data)
+{
+    ngx_http_upstream_sticky_peer_data_t  *stp = data;
+
+    ngx_int_t  rc;
+
+    if (pc->hint == NULL && stp->id.len) {
+        pc->hint = &stp->id;
+    }
+
+    rc = stp->original_get_peer(pc, stp->original_data);
+
+    pc->hint = NULL;
+
+    if (rc != NGX_OK && rc != NGX_DONE) {
+        return rc;
+    }
+
+    if (stp->conf->cookie_name.len == 0) {
+        return rc;
+    }
+
+    if (ngx_http_upstream_sticky_cookie_insert(pc, stp) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    return rc;
+}
+
+
+static void
+ngx_http_upstream_sticky_free_peer(ngx_peer_connection_t *pc, void *data,
+    ngx_uint_t state)
+{
+    ngx_http_upstream_sticky_peer_data_t  *stp = data;
+
+    stp->original_free_peer(pc, stp->original_data, state);
+}
+
+
+#if (NGX_HTTP_SSL)
+
+static ngx_int_t
+ngx_http_upstream_sticky_set_session(ngx_peer_connection_t *pc, void *data)
+{
+    ngx_http_upstream_sticky_peer_data_t  *stp = data;
+
+    return stp->original_set_session(pc, stp->original_data);
+}
+
+
+static void
+ngx_http_upstream_sticky_save_session(ngx_peer_connection_t *pc, void *data)
+{
+    ngx_http_upstream_sticky_peer_data_t  *stp = data;
+
+    stp->original_save_session(pc, stp->original_data);
+}
+
+#endif
+
+
+static ngx_int_t
+ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
+    ngx_http_upstream_sticky_peer_data_t *stp)
+{
+    size_t                                len;
+    u_char                               *data, *p;
+    ngx_table_elt_t                      *cookie;
+    ngx_http_request_t                   *r;
+    ngx_http_upstream_sticky_srv_conf_t  *stcf;
+
+    stcf = stp->conf;
+    r = stp->request;
+
+    if (pc->sid == NULL) {
+        ngx_log_error(NGX_LOG_WARN, pc->log, 0,
+                      "balancer does not support sticky");
+        return NGX_OK;
+    }
+
+#if (NGX_DEBUG)
+
+    if (stp->id.len) {
+
+        /* check that the selected peer matches SID from request */
+
+        if (pc->sid->len != stp->id.len
+            || ngx_memcmp(pc->sid->data, stp->id.data, stp->id.len) != 0)
+        {
+            ngx_log_debug0(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                           "sticky: server with requested SID is unavailable");
+        }
+    }
+
+#endif
+
+    len = stcf->cookie_name.len + 1 + pc->sid->len + stcf->cookie_domain.len
+          + stcf->cookie_path.len;
+
+    if (stcf->cookie_expires != (time_t) NGX_CONF_UNSET) {
+        len += sizeof(expires) - 1;
+    }
+
+    data = ngx_pnalloc(r->pool, len);
+    if (data == NULL) {
+        return NGX_ERROR;
+    }
+
+    p = ngx_copy(data, stcf->cookie_name.data, stcf->cookie_name.len);
+    *p++ = '=';
+    p = ngx_copy(p, pc->sid->data, pc->sid->len);
+
+    if (stcf->cookie_expires != (time_t) NGX_CONF_UNSET) {
+
+        if (stcf->cookie_expires == NGX_HTTP_STICKY_COOKIE_MAX_EXPIRES) {
+            p = ngx_cpymem(p, expires, sizeof(expires) - 1);
+
+        } else {
+            p = ngx_cpymem(p, "; expires=", 10);
+            p = ngx_http_cookie_time(p, ngx_time() + stcf->cookie_expires);
+        }
+    }
+
+    p = ngx_copy(p, stcf->cookie_domain.data, stcf->cookie_domain.len);
+    ngx_memcpy(p, stcf->cookie_path.data, stcf->cookie_path.len);
+
+    cookie = stp->cookie;
+
+    if (cookie == NULL) {
+
+        cookie = ngx_list_push(&r->headers_out.headers);
+        if (cookie == NULL) {
+            return NGX_ERROR;
+        }
+
+        cookie->hash = 1;
+        cookie->next = NULL;
+        ngx_str_set(&cookie->key, "Set-Cookie");
+
+        stp->cookie = cookie;
+    }
+
+    cookie->value.len = len;
+    cookie->value.data = data;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "sticky: set cookie: \"%V\"", &cookie->value);
+
+    return NGX_OK;
+}
+
+
+static void *
+ngx_http_upstream_sticky_create_conf(ngx_conf_t *cf)
+{
+    ngx_http_upstream_sticky_srv_conf_t  *stcf;
+
+    stcf = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_sticky_srv_conf_t));
+    if (stcf == NULL) {
+        return NULL;
+    }
+
+    /*
+     * set by ngx_pcalloc():
+     *
+     *     stcf->original_init_upstream = NULL;
+     *     stcf->original_init_peer = NULL;
+     *
+     *     stcf->lookup_vars = NULL;
+     *
+     *     stcf->cookie_name = { 0, NULL };
+     *     stcf->cookie_domain = { 0, NULL };
+     *     stcf->cookie_path = { 0, NULL };
+     */
+
+    stcf->cookie_expires = NGX_CONF_UNSET;
+
+    return stcf;
+}
+
+
+static char *
+ngx_http_upstream_sticky(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    u_char                               *p;
+    ngx_str_t                            *value, varname;
+    ngx_int_t                             index, *indexp;
+    ngx_uint_t                            i;
+    ngx_http_upstream_srv_conf_t         *us;
+    ngx_http_upstream_sticky_srv_conf_t  *stcf;
+
+    us = ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module);
+    stcf = ngx_http_conf_upstream_srv_conf(us, ngx_http_upstream_sticky_module);
+
+    if (stcf->lookup_vars != NULL) {
+        return "is duplicate";
+    }
+
+    stcf->lookup_vars = ngx_array_create(cf->pool, 1, sizeof(ngx_int_t));
+    if (stcf->lookup_vars == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    value = cf->args->elts;
+
+    if (ngx_strcmp(value[1].data, "route") == 0) {
+
+        for (i = 2; i < cf->args->nelts; i++) {
+
+            if (value[i].data[0] != '$') {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "invalid variable name \"%V\"", &value[i]);
+                return NGX_CONF_ERROR;
+            }
+
+            value[i].len--;
+            value[i].data++;
+
+            index = ngx_http_get_variable_index(cf, &value[i]);
+            if (index == NGX_ERROR) {
+                return NGX_CONF_ERROR;
+            }
+
+            indexp = ngx_array_push(stcf->lookup_vars);
+            if (indexp == NULL) {
+                return NGX_CONF_ERROR;
+            }
+
+            *indexp = index;
+        }
+
+        /*
+         * stcf->stick = NULL;
+         */
+
+    } else if (ngx_strcmp(value[1].data, "cookie") == 0) {
+
+        if (value[2].len == 0) {
+            return "empty cookie name";
+        }
+
+        stcf->cookie_name = value[2];
+
+        for (i = 3; i < cf->args->nelts; i++) {
+
+            if (ngx_strncmp(value[i].data, "domain=", 7) == 0) {
+
+                if (stcf->cookie_domain.data != NULL) {
+                    return "parameter \"domain\" is duplicate";
+                }
+
+                value[i].data += 7;
+                value[i].len -= 7;
+
+                if (value[i].len == 0) {
+                    return "no value for \"domain\"";
+                }
+
+                stcf->cookie_domain.len = sizeof("; domain=") - 1
+                                          + value[i].len;
+
+                stcf->cookie_domain.data = ngx_pnalloc(cf->pool,
+                                                       stcf->cookie_domain.len);
+                if (stcf->cookie_domain.data == NULL) {
+                    return NGX_CONF_ERROR;
+                }
+
+                p = ngx_cpymem(stcf->cookie_domain.data,
+                               "; domain=", sizeof("; domain=") - 1);
+                ngx_memcpy(p, value[i].data, value[i].len);
+
+
+            } else if (ngx_strncmp(value[i].data, "path=", 5) == 0) {
+
+                if (stcf->cookie_path.data != NULL) {
+                    return "parameter \"path\" is duplicate";
+                }
+
+                value[i].data += 5;
+                value[i].len -= 5;
+
+                if (value[i].len == 0) {
+                    return "no value for \"path\"";
+                }
+
+                stcf->cookie_path.len = sizeof("; path=") - 1 + value[i].len;
+
+                stcf->cookie_path.data = ngx_pnalloc(cf->pool,
+                                                     stcf->cookie_path.len);
+                if (stcf->cookie_path.data == NULL) {
+                    return NGX_CONF_ERROR;
+                }
+
+                p = ngx_cpymem(stcf->cookie_path.data,
+                               "; path=", sizeof("; path=") - 1);
+                ngx_memcpy(p, value[i].data, value[i].len);
+
+
+            } else if (ngx_strncmp(value[i].data, "expires=", 8) == 0) {
+
+                if (stcf->cookie_expires != (time_t) NGX_CONF_UNSET) {
+                    return "parameter \"expires\" is duplicate";
+                }
+
+                value[i].data += 8;
+                value[i].len -= 8;
+
+                if (ngx_strcmp(value[i].data, "max") == 0) {
+                    stcf->cookie_expires = NGX_HTTP_STICKY_COOKIE_MAX_EXPIRES;
+
+                } else {
+                    stcf->cookie_expires = ngx_parse_time(&value[i], 1);
+                    if (stcf->cookie_expires == (time_t) NGX_ERROR) {
+                        return "invalid \"expires\" parameter value";
+                    }
+                }
+
+            } else {
+                return "unknown parameter";
+            }
+        }
+
+        varname.len = sizeof("cookie_") - 1  + stcf->cookie_name.len;
+        varname.data = ngx_pnalloc(cf->pool, varname.len);
+        if (varname.data == NULL) {
+             return NGX_CONF_ERROR;
+        }
+
+        ngx_sprintf(varname.data, "cookie_%V", &stcf->cookie_name);
+
+        index = ngx_http_get_variable_index(cf, &varname);
+        if (index == NGX_ERROR) {
+            return NGX_CONF_ERROR;
+        }
+
+        indexp = ngx_array_push(stcf->lookup_vars);
+        if (indexp == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        *indexp = index;
+
+    } else {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "unknown parameter \"%V\"",
+                           &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    stcf->original_init_upstream = us->peer.init_upstream
+                                   ? us->peer.init_upstream
+                                   : ngx_http_upstream_init_round_robin;
+
+    us->peer.init_upstream = ngx_http_upstream_sticky_init_upstream;
+
+    return NGX_CONF_OK;
+}

--- a/src/http/modules/ngx_http_upstream_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_sticky_module.c
@@ -149,7 +149,8 @@ static char *ngx_http_upstream_sticky_learn(ngx_conf_t *cf,
     ngx_http_upstream_srv_conf_t *us);
 
 
-static u_char expires[] = "; expires=Thu, 31-Dec-37 23:55:55 GMT";
+static u_char expires[] =
+    "; expires=Thu, 31-Dec-37 23:55:55 GMT; max-age=315360000";
 static u_char httponly[] = "; httponly";
 static u_char secure[] = "; secure";
 
@@ -566,7 +567,7 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
     }
 
     if (stcf->cookie_expires != (time_t) NGX_CONF_UNSET) {
-        len += sizeof(expires) - 1;
+        len += sizeof(expires) - 1 + NGX_TIME_T_LEN;
     }
 
     if (stcf->cookie_httponly) {
@@ -594,6 +595,7 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
         } else {
             p = ngx_cpymem(p, "; expires=", 10);
             p = ngx_http_cookie_time(p, ngx_time() + stcf->cookie_expires);
+            p = ngx_sprintf(p, "; max-age=%T", stcf->cookie_expires);
         }
     }
 
@@ -610,7 +612,7 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
         p = ngx_copy(p, secure, sizeof(secure) - 1);
     }
 
-    ngx_memcpy(p, stcf->cookie_path.data, stcf->cookie_path.len);
+    p = ngx_cpymem(p, stcf->cookie_path.data, stcf->cookie_path.len);
 
     cookie = stp->cookie;
 
@@ -628,7 +630,7 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
         stp->cookie = cookie;
     }
 
-    cookie->value.len = len;
+    cookie->value.len = p - data;
     cookie->value.data = data;
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,

--- a/src/http/modules/ngx_http_upstream_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_sticky_module.c
@@ -148,7 +148,6 @@ static ngx_msec_t ngx_http_upstream_sticky_sess_expire(
 static ngx_int_t ngx_http_upstream_sticky_sess_init_zone(
     ngx_shm_zone_t *shm_zone, void *data);
 
-
 static void *ngx_http_upstream_sticky_create_conf(ngx_conf_t *cf);
 static char *ngx_http_upstream_sticky(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
@@ -157,6 +156,8 @@ static char *ngx_http_upstream_sticky_cookie(ngx_conf_t *cf,
 static char *ngx_http_upstream_sticky_learn(ngx_conf_t *cf,
     ngx_http_upstream_sticky_srv_conf_t *stcf,
     ngx_http_upstream_srv_conf_t *us);
+
+static ngx_int_t ngx_http_upstream_sticky_init_worker(ngx_cycle_t *cycle);
 
 
 static u_char expires[] =
@@ -206,7 +207,7 @@ ngx_http_upstream_sticky_module =
     NULL,                                 /* init master */
 
     NULL,                                 /* init module */
-    NULL,                                 /* init process */
+    ngx_http_upstream_sticky_init_worker, /* init process */
 
     NULL,                                 /* init thread */
     NULL,                                 /* exit thread */
@@ -1455,4 +1456,58 @@ ngx_http_upstream_sticky_learn(ngx_conf_t *cf,
     stcf->shm_zone = shm_zone;
 
     return NGX_CONF_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_sticky_init_worker(ngx_cycle_t *cycle)
+{
+    ngx_msec_t                             wait;
+    ngx_uint_t                             i;
+    ngx_http_upstream_srv_conf_t         **uscfp;
+    ngx_http_upstream_main_conf_t         *umcf;
+    ngx_http_upstream_sticky_sess_t       *sess;
+    ngx_http_upstream_sticky_srv_conf_t   *stcf;
+
+    if ((ngx_process != NGX_PROCESS_WORKER || ngx_worker != 0)
+        && ngx_process != NGX_PROCESS_SINGLE)
+    {
+        return NGX_OK;
+    }
+
+    umcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_upstream_module);
+
+    if (umcf == NULL) {
+        return NGX_OK;
+    }
+
+    uscfp = umcf->upstreams.elts;
+
+    for (i = 0; i < umcf->upstreams.nelts; i++) {
+
+        if (uscfp[i]->srv_conf == NULL) {
+            continue;
+        }
+
+        stcf = ngx_http_conf_upstream_srv_conf(uscfp[i],
+                                               ngx_http_upstream_sticky_module);
+
+        if (stcf == NULL || stcf->shm_zone == NULL) {
+            continue;
+        }
+
+        sess = stcf->shm_zone->data;
+
+        ngx_shmtx_lock(&sess->shpool->mutex);
+
+        wait = ngx_http_upstream_sticky_sess_expire(sess, 0);
+
+        ngx_shmtx_unlock(&sess->shpool->mutex);
+
+        if (wait > 0) {
+            ngx_add_timer(&sess->event, wait);
+        }
+    }
+
+    return NGX_OK;
 }

--- a/src/http/modules/ngx_http_upstream_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_sticky_module.c
@@ -72,6 +72,7 @@ typedef struct {
     ngx_http_complex_value_t                   *cookie_domain;
     ngx_str_t                                   cookie_path;
     time_t                                      cookie_expires;
+    ngx_http_complex_value_t                   *cookie_samesite;
     unsigned                                    cookie_httponly:1;
     unsigned                                    cookie_secure:1;
     unsigned                                    learn_after_headers:1;
@@ -129,6 +130,7 @@ static void ngx_http_upstream_sticky_notify_peer(
     ngx_peer_connection_t *pc, void *data, ngx_uint_t type);
 static ngx_int_t ngx_http_upstream_sticky_cookie_insert(
     ngx_peer_connection_t *pc, ngx_http_upstream_sticky_peer_data_t *stp);
+static ngx_int_t ngx_http_upstream_sticky_samesite(ngx_str_t *value);
 
 
 static ngx_http_upstream_sticky_sess_node_t *
@@ -557,7 +559,7 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
 {
     size_t                                len;
     u_char                               *data, *p;
-    ngx_str_t                             domain;
+    ngx_str_t                             domain, samesite;
     ngx_table_elt_t                      *cookie;
     ngx_http_request_t                   *r;
     ngx_http_upstream_sticky_srv_conf_t  *stcf;
@@ -615,6 +617,30 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
         len += sizeof(secure) - 1;
     }
 
+    ngx_str_set(&samesite, "");
+
+    if (stcf->cookie_samesite) {
+
+        if (ngx_http_complex_value(r, stcf->cookie_samesite, &samesite)
+            != NGX_OK)
+        {
+            return NGX_ERROR;
+        }
+
+        if (stcf->cookie_samesite->lengths && samesite.len
+            && ngx_http_upstream_sticky_samesite(&samesite) != NGX_OK)
+        {
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "sticky: invalid cookie samesite value \"%V\"",
+                           &samesite);
+            ngx_str_set(&samesite, "strict");
+        }
+    }
+
+    if (samesite.len) {
+        len += sizeof("; samesite=") - 1 + samesite.len;
+    }
+
     data = ngx_pnalloc(r->pool, len);
     if (data == NULL) {
         return NGX_ERROR;
@@ -649,6 +675,11 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
         p = ngx_copy(p, secure, sizeof(secure) - 1);
     }
 
+    if (samesite.len) {
+        p = ngx_cpymem(p, "; samesite=", 11);
+        p = ngx_copy(p, samesite.data, samesite.len);
+    }
+
     p = ngx_cpymem(p, stcf->cookie_path.data, stcf->cookie_path.len);
 
     cookie = stp->cookie;
@@ -674,6 +705,31 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
                    "sticky: set cookie: \"%V\"", &cookie->value);
 
     return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_sticky_samesite(ngx_str_t *value)
+{
+    ngx_uint_t  i;
+
+    static ngx_str_t samesite[] = {
+        ngx_string("strict"),
+        ngx_string("lax"),
+        ngx_string("none"),
+        ngx_null_string
+    };
+
+    for (i = 0; samesite[i].len != 0; i++) {
+
+        if (samesite[i].len == value->len
+            && ngx_strncasecmp(samesite[i].data, value->data, value->len) == 0)
+        {
+            return NGX_OK;
+        }
+    }
+
+    return NGX_ERROR;
 }
 
 
@@ -971,6 +1027,7 @@ ngx_http_upstream_sticky_create_conf(ngx_conf_t *cf)
      *     stcf->cookie_path = { 0, NULL };
      *     stcf->cookie_httponly = 0;
      *     stcf->cookie_secure = 0;
+     *     stcf->cookie_samesite = NULL;
      *
      *     stcf->learn_after_headers = 0;
      */
@@ -1160,6 +1217,37 @@ ngx_http_upstream_sticky_cookie(ngx_conf_t *cf,
             }
 
             stcf->cookie_secure = 1;
+
+        } else if (ngx_strncmp(value[i].data, "samesite=", 9) == 0) {
+
+            if (stcf->cookie_samesite) {
+                return "parameter \"samesite\" is duplicate";
+            }
+
+            value[i].data += 9;
+            value[i].len -= 9;
+
+            ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
+
+            stcf->cookie_samesite = ngx_palloc(cf->pool,
+                                             sizeof(ngx_http_complex_value_t));
+            if (stcf->cookie_samesite == NULL) {
+                return NGX_CONF_ERROR;
+            }
+
+            ccv.cf = cf;
+            ccv.value = &value[i];
+            ccv.complex_value = stcf->cookie_samesite;
+
+            if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+                return NGX_CONF_ERROR;
+            }
+
+            if (stcf->cookie_samesite->lengths == NULL
+                && ngx_http_upstream_sticky_samesite(&value[i]) != NGX_OK)
+            {
+                return "invalid \"samesite\" parameter value";
+            }
 
         } else {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,

--- a/src/http/modules/ngx_http_upstream_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_sticky_module.c
@@ -72,6 +72,8 @@ typedef struct {
     ngx_str_t                                   cookie_domain;
     ngx_str_t                                   cookie_path;
     time_t                                      cookie_expires;
+    unsigned                                    cookie_httponly:1;
+    unsigned                                    cookie_secure:1;
 } ngx_http_upstream_sticky_srv_conf_t;
 
 
@@ -148,6 +150,8 @@ static char *ngx_http_upstream_sticky_learn(ngx_conf_t *cf,
 
 
 static u_char expires[] = "; expires=Thu, 31-Dec-37 23:55:55 GMT";
+static u_char httponly[] = "; httponly";
+static u_char secure[] = "; secure";
 
 
 static ngx_command_t  ngx_http_upstream_sticky_commands[] = {
@@ -551,6 +555,14 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
         len += sizeof(expires) - 1;
     }
 
+    if (stcf->cookie_httponly) {
+        len += sizeof(httponly) - 1;
+    }
+
+    if (stcf->cookie_secure) {
+        len += sizeof(secure) - 1;
+    }
+
     data = ngx_pnalloc(r->pool, len);
     if (data == NULL) {
         return NGX_ERROR;
@@ -572,6 +584,15 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
     }
 
     p = ngx_copy(p, stcf->cookie_domain.data, stcf->cookie_domain.len);
+
+    if (stcf->cookie_httponly) {
+        p = ngx_copy(p, httponly, sizeof(httponly) - 1);
+    }
+
+    if (stcf->cookie_secure) {
+        p = ngx_copy(p, secure, sizeof(secure) - 1);
+    }
+
     ngx_memcpy(p, stcf->cookie_path.data, stcf->cookie_path.len);
 
     cookie = stp->cookie;
@@ -892,6 +913,8 @@ ngx_http_upstream_sticky_create_conf(ngx_conf_t *cf)
      *     stcf->cookie_name = { 0, NULL };
      *     stcf->cookie_domain = { 0, NULL };
      *     stcf->cookie_path = { 0, NULL };
+     *     stcf->cookie_httponly = 0;
+     *     stcf->cookie_secure = 0;
      */
 
     stcf->cookie_expires = NGX_CONF_UNSET;
@@ -1060,6 +1083,22 @@ ngx_http_upstream_sticky_cookie(ngx_conf_t *cf,
                     return "invalid \"expires\" parameter value";
                 }
             }
+
+        } else if (ngx_strcmp(value[i].data, "httponly") == 0) {
+
+            if (stcf->cookie_httponly) {
+                return "parameter \"httponly\" is duplicate";
+            }
+
+            stcf->cookie_httponly = 1;
+
+        } else if (ngx_strcmp(value[i].data, "secure") == 0) {
+
+            if (stcf->cookie_secure) {
+                return "parameter \"secure\" is duplicate";
+            }
+
+            stcf->cookie_secure = 1;
 
         } else {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,

--- a/src/http/modules/ngx_http_upstream_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_sticky_module.c
@@ -69,7 +69,7 @@ typedef struct {
     ngx_shm_zone_t                             *shm_zone;    /* sessions */
 
     ngx_str_t                                   cookie_name;
-    ngx_str_t                                   cookie_domain;
+    ngx_http_complex_value_t                   *cookie_domain;
     ngx_str_t                                   cookie_path;
     time_t                                      cookie_expires;
     unsigned                                    cookie_httponly:1;
@@ -519,6 +519,7 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
 {
     size_t                                len;
     u_char                               *data, *p;
+    ngx_str_t                             domain;
     ngx_table_elt_t                      *cookie;
     ngx_http_request_t                   *r;
     ngx_http_upstream_sticky_srv_conf_t  *stcf;
@@ -548,8 +549,21 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
 
 #endif
 
-    len = stcf->cookie_name.len + 1 + pc->sid->len + stcf->cookie_domain.len
-          + stcf->cookie_path.len;
+    len = stcf->cookie_name.len + 1 + pc->sid->len + stcf->cookie_path.len;
+
+    ngx_str_set(&domain, "");
+
+    if (stcf->cookie_domain) {
+        if (ngx_http_complex_value(r, stcf->cookie_domain, &domain)
+            != NGX_OK)
+        {
+            return NGX_ERROR;
+        }
+    }
+
+    if (domain.len) {
+        len += sizeof("; domain=") - 1 + domain.len;
+    }
 
     if (stcf->cookie_expires != (time_t) NGX_CONF_UNSET) {
         len += sizeof(expires) - 1;
@@ -583,7 +597,10 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
         }
     }
 
-    p = ngx_copy(p, stcf->cookie_domain.data, stcf->cookie_domain.len);
+    if (domain.len) {
+        p = ngx_cpymem(p, "; domain=", 9);
+        p = ngx_copy(p, domain.data, domain.len);
+    }
 
     if (stcf->cookie_httponly) {
         p = ngx_copy(p, httponly, sizeof(httponly) - 1);
@@ -911,7 +928,7 @@ ngx_http_upstream_sticky_create_conf(ngx_conf_t *cf)
      *     stcf->shm_zone = NULL;
      *
      *     stcf->cookie_name = { 0, NULL };
-     *     stcf->cookie_domain = { 0, NULL };
+     *     stcf->cookie_domain = NULL;
      *     stcf->cookie_path = { 0, NULL };
      *     stcf->cookie_httponly = 0;
      *     stcf->cookie_secure = 0;
@@ -997,10 +1014,11 @@ static char *
 ngx_http_upstream_sticky_cookie(ngx_conf_t *cf,
     ngx_http_upstream_sticky_srv_conf_t *stcf)
 {
-    u_char      *p;
-    ngx_str_t    name, *value;
-    ngx_int_t    index, *indexp;
-    ngx_uint_t   i;
+    u_char                            *p;
+    ngx_str_t                          name, *value;
+    ngx_int_t                          index, *indexp;
+    ngx_uint_t                         i;
+    ngx_http_compile_complex_value_t   ccv;
 
     value = cf->args->elts;
 
@@ -1014,7 +1032,7 @@ ngx_http_upstream_sticky_cookie(ngx_conf_t *cf,
 
         if (ngx_strncmp(value[i].data, "domain=", 7) == 0) {
 
-            if (stcf->cookie_domain.data != NULL) {
+            if (stcf->cookie_domain != NULL) {
                 return "parameter \"domain\" is duplicate";
             }
 
@@ -1025,19 +1043,21 @@ ngx_http_upstream_sticky_cookie(ngx_conf_t *cf,
                 return "no value for \"domain\"";
             }
 
-            stcf->cookie_domain.len = sizeof("; domain=") - 1
-                                      + value[i].len;
+            ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
 
-            stcf->cookie_domain.data = ngx_pnalloc(cf->pool,
-                                                   stcf->cookie_domain.len);
-            if (stcf->cookie_domain.data == NULL) {
+            stcf->cookie_domain = ngx_palloc(cf->pool,
+                                             sizeof(ngx_http_complex_value_t));
+            if (stcf->cookie_domain == NULL) {
                 return NGX_CONF_ERROR;
             }
 
-            p = ngx_cpymem(stcf->cookie_domain.data,
-                           "; domain=", sizeof("; domain=") - 1);
-            ngx_memcpy(p, value[i].data, value[i].len);
+            ccv.cf = cf;
+            ccv.value = &value[i];
+            ccv.complex_value = stcf->cookie_domain;
 
+            if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+                return NGX_CONF_ERROR;
+            }
 
         } else if (ngx_strncmp(value[i].data, "path=", 5) == 0) {
 

--- a/src/http/modules/ngx_http_upstream_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_sticky_module.c
@@ -74,6 +74,7 @@ typedef struct {
     time_t                                      cookie_expires;
     unsigned                                    cookie_httponly:1;
     unsigned                                    cookie_secure:1;
+    unsigned                                    learn_after_headers:1;
 } ngx_http_upstream_sticky_srv_conf_t;
 
 
@@ -93,6 +94,9 @@ typedef struct {
     ngx_event_set_peer_session_pt               original_set_session;
     ngx_event_save_peer_session_pt              original_save_session;
 #endif
+
+    ngx_event_notify_peer_pt                    original_notify;
+
 } ngx_http_upstream_sticky_peer_data_t;
 
 
@@ -109,6 +113,8 @@ static ngx_int_t ngx_http_upstream_sticky_get_peer(ngx_peer_connection_t *pc,
     void *data);
 static void ngx_http_upstream_sticky_free_peer(ngx_peer_connection_t *pc,
     void *data, ngx_uint_t state);
+static void ngx_http_upstream_sticky_learn_peer(
+    ngx_http_upstream_sticky_peer_data_t *stp, ngx_peer_connection_t *pc);
 
 
 #if (NGX_HTTP_SSL)
@@ -119,6 +125,8 @@ static void ngx_http_upstream_sticky_save_session(ngx_peer_connection_t *pc,
 #endif
 
 
+static void ngx_http_upstream_sticky_notify_peer(
+    ngx_peer_connection_t *pc, void *data, ngx_uint_t type);
 static ngx_int_t ngx_http_upstream_sticky_cookie_insert(
     ngx_peer_connection_t *pc, ngx_http_upstream_sticky_peer_data_t *stp);
 
@@ -269,6 +277,11 @@ ngx_http_upstream_sticky_init_peer(ngx_http_request_t *r,
     u->peer.save_session = ngx_http_upstream_sticky_save_session;
 #endif
 
+    if (u->peer.notify || stcf->learn_after_headers) {
+        stp->original_notify = u->peer.notify;
+        u->peer.notify = ngx_http_upstream_sticky_notify_peer;
+    }
+
     ngx_http_upstream_sticky_get_id(stcf, r, stcf->lookup_vars, &stp->id);
 
     return NGX_OK;
@@ -393,6 +406,24 @@ ngx_http_upstream_sticky_free_peer(ngx_peer_connection_t *pc, void *data,
 {
     ngx_http_upstream_sticky_peer_data_t  *stp = data;
 
+    if (state & (NGX_PEER_FAILED|NGX_PEER_NEXT)) {
+        goto done;
+    }
+
+    if (stp->conf->shm_zone && !stp->conf->learn_after_headers) {
+        ngx_http_upstream_sticky_learn_peer(stp, pc);
+    }
+
+done:
+
+    stp->original_free_peer(pc, stp->original_data, state);
+}
+
+
+static void
+ngx_http_upstream_sticky_learn_peer(ngx_http_upstream_sticky_peer_data_t *stp,
+    ngx_peer_connection_t *pc)
+{
     ngx_str_t                              sess_id;
     ngx_msec_t                             now;
     ngx_time_t                            *tp;
@@ -403,21 +434,13 @@ ngx_http_upstream_sticky_free_peer(ngx_peer_connection_t *pc, void *data,
     ngx_http_upstream_sticky_srv_conf_t   *stcf;
     ngx_http_upstream_sticky_sess_node_t  *sn;
 
-    if (state & (NGX_PEER_FAILED|NGX_PEER_NEXT)) {
-        goto done;
-    }
-
-    stcf = stp->conf;
-
-    if (stcf->shm_zone == NULL) {
-        goto done;
-    }
-
     if (pc->sid == NULL) {
         ngx_log_error(NGX_LOG_WARN, pc->log, 0,
                       "balancer does not support sticky");
-        goto done;
+        return;
     }
+
+    stcf = stp->conf;
 
     r = stp->request;
 
@@ -485,10 +508,6 @@ ngx_http_upstream_sticky_free_peer(ngx_peer_connection_t *pc, void *data,
     }
 
     ngx_shmtx_unlock(&sess->shpool->mutex);
-
-done:
-
-    stp->original_free_peer(pc, stp->original_data, state);
 }
 
 
@@ -512,6 +531,24 @@ ngx_http_upstream_sticky_save_session(ngx_peer_connection_t *pc, void *data)
 }
 
 #endif
+
+
+static void
+ngx_http_upstream_sticky_notify_peer(ngx_peer_connection_t *pc, void *data,
+    ngx_uint_t type)
+{
+    ngx_http_upstream_sticky_peer_data_t  *stp = data;
+
+    if (type == NGX_HTTP_UPSTREAM_NOTIFY_HEADER
+        && stp->conf->learn_after_headers)
+    {
+        ngx_http_upstream_sticky_learn_peer(stp, pc);
+    }
+
+    if (stp->original_notify) {
+        stp->original_notify(pc, stp->original_data, type);
+    }
+}
 
 
 static ngx_int_t
@@ -934,6 +971,8 @@ ngx_http_upstream_sticky_create_conf(ngx_conf_t *cf)
      *     stcf->cookie_path = { 0, NULL };
      *     stcf->cookie_httponly = 0;
      *     stcf->cookie_secure = 0;
+     *
+     *     stcf->learn_after_headers = 0;
      */
 
     stcf->cookie_expires = NGX_CONF_UNSET;
@@ -1266,6 +1305,9 @@ ngx_http_upstream_sticky_learn(ngx_conf_t *cf,
             }
 
             *indexp = index;
+
+        } else if (ngx_strcmp(value[i].data, "header") == 0) {
+            stcf->learn_after_headers = 1;
 
         } else {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,

--- a/src/http/modules/ngx_http_upstream_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_sticky_module.c
@@ -12,6 +12,52 @@
 
 #define NGX_HTTP_STICKY_COOKIE_MAX_EXPIRES  2145916555
 
+#define ngx_http_upstream_sticky_sess_node(rbn, mb)                           \
+    (ngx_http_upstream_sticky_sess_node_t *)                                  \
+        ((char *) (rbn) - offsetof(ngx_http_upstream_sticky_sess_node_t, mb))
+
+
+typedef union {
+    u_char                                      md5[16];
+    ngx_uint_t                                  hash;
+} ngx_http_upstream_sticky_sess_key_t;
+
+
+typedef struct {
+    ngx_rbtree_t                                rbtree;
+    ngx_rbtree_node_t                           sentinel;
+
+    ngx_rbtree_t                                exp_rbtree;
+    ngx_rbtree_node_t                           exp_sentinel;
+} ngx_http_upstream_sticky_sess_shared_t;
+
+
+typedef struct {
+    ngx_http_upstream_sticky_sess_shared_t     *sh;
+    ngx_slab_pool_t                            *shpool;
+    ngx_str_t                                  *host;
+
+    ngx_msec_t                                  timeout;
+    ngx_event_t                                 event;
+} ngx_http_upstream_sticky_sess_t;
+
+
+/* session data: mapping of session ID hash to server ID */
+typedef struct {
+    ngx_rbtree_node_t                           rbnode;
+    ngx_rbtree_node_t                           enode;
+
+    union {
+        u_char                                  md5[16];
+        ngx_uint_t                              hash;
+    } u;
+
+    ngx_msec_t                                  last;
+
+    u_char                                      sid_len;
+    u_char                                      sid[NGX_HTTP_UPSTREAM_SID_LEN];
+} ngx_http_upstream_sticky_sess_node_t;
+
 
 /* per-upstream sticky configuration */
 typedef struct {
@@ -19,6 +65,8 @@ typedef struct {
     ngx_http_upstream_init_peer_pt              original_init_peer;
 
     ngx_array_t                                *lookup_vars; /* of ngx_int_t */
+    ngx_array_t                                *create_vars; /* of ngx_int_t */
+    ngx_shm_zone_t                             *shm_zone;    /* sessions */
 
     ngx_str_t                                   cookie_name;
     ngx_str_t                                   cookie_domain;
@@ -52,7 +100,9 @@ static ngx_int_t ngx_http_upstream_sticky_init_peer(ngx_http_request_t *r,
     ngx_http_upstream_srv_conf_t *us);
 static ngx_int_t ngx_http_upstream_sticky_get_id(
     ngx_http_upstream_sticky_srv_conf_t *stcf, ngx_http_request_t *r,
-    ngx_str_t *id);
+    ngx_array_t *vars, ngx_str_t *id);
+static void ngx_http_upstream_sticky_sess_init_key(ngx_str_t *sess_id,
+    ngx_http_upstream_sticky_sess_key_t *key);
 static ngx_int_t ngx_http_upstream_sticky_get_peer(ngx_peer_connection_t *pc,
     void *data);
 static void ngx_http_upstream_sticky_free_peer(ngx_peer_connection_t *pc,
@@ -71,9 +121,30 @@ static ngx_int_t ngx_http_upstream_sticky_cookie_insert(
     ngx_peer_connection_t *pc, ngx_http_upstream_sticky_peer_data_t *stp);
 
 
+static ngx_http_upstream_sticky_sess_node_t *
+    ngx_http_upstream_sticky_sess_lookup(ngx_http_upstream_sticky_sess_t *sess,
+    ngx_http_upstream_sticky_sess_key_t *key);
+static ngx_http_upstream_sticky_sess_node_t *
+    ngx_http_upstream_sticky_sess_create(ngx_http_upstream_sticky_sess_t *sess,
+    ngx_http_upstream_sticky_sess_key_t *key, ngx_str_t *sid);
+static void ngx_http_upstream_sticky_sess_rbtree_insert_value(
+    ngx_rbtree_node_t *temp, ngx_rbtree_node_t *node,
+    ngx_rbtree_node_t *sentinel);
+static void ngx_http_upstream_sticky_sess_timer_handler(ngx_event_t *ev);
+static ngx_msec_t ngx_http_upstream_sticky_sess_expire(
+    ngx_http_upstream_sticky_sess_t *sess, ngx_uint_t force);
+static ngx_int_t ngx_http_upstream_sticky_sess_init_zone(
+    ngx_shm_zone_t *shm_zone, void *data);
+
+
 static void *ngx_http_upstream_sticky_create_conf(ngx_conf_t *cf);
 static char *ngx_http_upstream_sticky(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+static char *ngx_http_upstream_sticky_cookie(ngx_conf_t *cf,
+    ngx_http_upstream_sticky_srv_conf_t *stcf);
+static char *ngx_http_upstream_sticky_learn(ngx_conf_t *cf,
+    ngx_http_upstream_sticky_srv_conf_t *stcf,
+    ngx_http_upstream_srv_conf_t *us);
 
 
 static u_char expires[] = "; expires=Thu, 31-Dec-37 23:55:55 GMT";
@@ -193,7 +264,7 @@ ngx_http_upstream_sticky_init_peer(ngx_http_request_t *r,
     u->peer.save_session = ngx_http_upstream_sticky_save_session;
 #endif
 
-    ngx_http_upstream_sticky_get_id(stcf, r, &stp->id);
+    ngx_http_upstream_sticky_get_id(stcf, r, stcf->lookup_vars, &stp->id);
 
     return NGX_OK;
 }
@@ -201,15 +272,15 @@ ngx_http_upstream_sticky_init_peer(ngx_http_request_t *r,
 
 static ngx_int_t
 ngx_http_upstream_sticky_get_id(ngx_http_upstream_sticky_srv_conf_t *stcf,
-    ngx_http_request_t *r, ngx_str_t *id)
+    ngx_http_request_t *r, ngx_array_t *vars, ngx_str_t *id)
 {
     ngx_int_t                  *index;
     ngx_uint_t                  i;
     ngx_http_variable_value_t  *v;
 
-    index = stcf->lookup_vars->elts;
+    index = vars->elts;
 
-    for (i = 0; i < stcf->lookup_vars->nelts; i++) {
+    for (i = 0; i < vars->nelts; i++) {
 
         v = ngx_http_get_flushed_variable(r, index[i]);
 
@@ -232,14 +303,62 @@ ngx_http_upstream_sticky_get_id(ngx_http_upstream_sticky_srv_conf_t *stcf,
 }
 
 
+static ngx_inline void
+ngx_http_upstream_sticky_sess_init_key(ngx_str_t *sess_id,
+    ngx_http_upstream_sticky_sess_key_t *key)
+{
+    ngx_md5_t  md5;
+
+    ngx_md5_init(&md5);
+    ngx_md5_update(&md5, sess_id->data, sess_id->len);
+    ngx_md5_final(key->md5, &md5);
+}
+
+
 static ngx_int_t
 ngx_http_upstream_sticky_get_peer(ngx_peer_connection_t *pc, void *data)
 {
     ngx_http_upstream_sticky_peer_data_t  *stp = data;
 
-    ngx_int_t  rc;
+    ngx_int_t                              rc;
+    ngx_str_t                              sid;
+    ngx_http_upstream_sticky_sess_t       *sess;
+    ngx_http_upstream_sticky_sess_key_t    key;
+    ngx_http_upstream_sticky_sess_node_t  *sn;
+    u_char                                 sid_data[NGX_HTTP_UPSTREAM_SID_LEN];
 
-    if (pc->hint == NULL && stp->id.len) {
+    if (pc->hint == NULL && stp->conf->shm_zone && stp->id.len) {
+
+        /* request holds session ID, extract server ID from session */
+
+        sess = stp->conf->shm_zone->data;
+
+        ngx_http_upstream_sticky_sess_init_key(&stp->id, &key);
+
+        ngx_shmtx_lock(&sess->shpool->mutex);
+
+        sn = ngx_http_upstream_sticky_sess_lookup(sess, &key);
+        if (sn == NULL) {
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                           "sticky: session \"%V\" not found", &stp->id);
+
+        } else {
+            ngx_memcpy(sid_data, sn->sid, sn->sid_len);
+            sid.len = sn->sid_len;
+            sid.data = sid_data;
+            pc->hint = &sid;
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                           "sticky: session \"%V\", SID \"%V\"",
+                           &stp->id, &sid);
+        }
+
+        ngx_shmtx_unlock(&sess->shpool->mutex);
+
+    } else if (pc->hint == NULL && stp->id.len) {
+
+        /* request holds server ID */
+
         pc->hint = &stp->id;
     }
 
@@ -268,6 +387,101 @@ ngx_http_upstream_sticky_free_peer(ngx_peer_connection_t *pc, void *data,
     ngx_uint_t state)
 {
     ngx_http_upstream_sticky_peer_data_t  *stp = data;
+
+    ngx_str_t                              sess_id;
+    ngx_msec_t                             now;
+    ngx_time_t                            *tp;
+    ngx_uint_t                             create;
+    ngx_http_request_t                    *r;
+    ngx_http_upstream_sticky_sess_t       *sess;
+    ngx_http_upstream_sticky_sess_key_t    key;
+    ngx_http_upstream_sticky_srv_conf_t   *stcf;
+    ngx_http_upstream_sticky_sess_node_t  *sn;
+
+    if (state & (NGX_PEER_FAILED|NGX_PEER_NEXT)) {
+        goto done;
+    }
+
+    stcf = stp->conf;
+
+    if (stcf->shm_zone == NULL) {
+        goto done;
+    }
+
+    if (pc->sid == NULL) {
+        ngx_log_error(NGX_LOG_WARN, pc->log, 0,
+                      "balancer does not support sticky");
+        goto done;
+    }
+
+    r = stp->request;
+
+    sess = stcf->shm_zone->data;
+
+    if (ngx_http_upstream_sticky_get_id(stcf, r, stcf->create_vars, &sess_id)
+        == NGX_OK)
+    {
+        create = 1;
+
+    } else if (stp->id.len) {
+        sess_id = stp->id;
+        create = 0;
+
+    } else {
+        return;
+    }
+
+    tp = ngx_timeofday();
+    now = tp->sec * 1000 + tp->msec;
+
+    ngx_http_upstream_sticky_sess_init_key(&sess_id, &key);
+
+    ngx_shmtx_lock(&sess->shpool->mutex);
+
+    sn = ngx_http_upstream_sticky_sess_lookup(sess, &key);
+
+    if (sn) {
+        if (pc->sid->len != sn->sid_len
+            || ngx_memcmp(pc->sid->data, sn->sid, sn->sid_len) != 0)
+        {
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                           "sticky: session \"%V\" reused for SID \"%V\"",
+                           &sess_id, pc->sid);
+
+            sn->sid_len = pc->sid->len;
+            ngx_memcpy(sn->sid, pc->sid->data, pc->sid->len);
+        }
+
+        ngx_rbtree_delete(&sess->sh->exp_rbtree, &sn->enode);
+        sn->last = now;
+        sn->enode.key = sn->last;
+        ngx_rbtree_insert(&sess->sh->exp_rbtree, &sn->enode);
+
+        ngx_shmtx_unlock(&sess->shpool->mutex);
+        return;
+    }
+
+    if (create) {
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                       "sticky: creating session \"%V\", SID \"%V\"",
+                       &sess_id, pc->sid);
+
+        sn = ngx_http_upstream_sticky_sess_create(sess, &key, pc->sid);
+
+        if (sn) {
+            sn->last = now;
+            sn->enode.key = sn->last;
+            ngx_rbtree_insert(&sess->sh->exp_rbtree, &sn->enode);
+
+            if (!sess->event.timer_set) {
+                ngx_add_timer(&sess->event, sess->timeout);
+            }
+        }
+    }
+
+    ngx_shmtx_unlock(&sess->shpool->mutex);
+
+done:
 
     stp->original_free_peer(pc, stp->original_data, state);
 }
@@ -386,6 +600,275 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
 }
 
 
+static ngx_http_upstream_sticky_sess_node_t *
+ngx_http_upstream_sticky_sess_lookup(ngx_http_upstream_sticky_sess_t *sess,
+    ngx_http_upstream_sticky_sess_key_t *key)
+{
+    ngx_int_t                              rc;
+    ngx_uint_t                             hash;
+    ngx_rbtree_node_t                     *node, *sentinel;
+    ngx_http_upstream_sticky_sess_node_t  *sn;
+
+    hash = key->hash;
+    node = sess->sh->rbtree.root;
+    sentinel = sess->sh->rbtree.sentinel;
+
+    while (node != sentinel) {
+
+        if (hash < node->key) {
+            node = node->left;
+            continue;
+        }
+
+        if (hash > node->key) {
+            node = node->right;
+            continue;
+        }
+
+        /* hash == node->key */
+
+        do {
+
+            sn = (ngx_http_upstream_sticky_sess_node_t *) node;
+
+            rc = ngx_memcmp(key->md5, sn->u.md5, 16);
+
+            if (rc == 0) {
+                return sn;
+            }
+
+            node = (rc < 0) ? node->left : node->right;
+
+        } while (node != sentinel && hash == node->key);
+
+        break;
+    }
+
+    return NULL;
+}
+
+
+static ngx_http_upstream_sticky_sess_node_t *
+ngx_http_upstream_sticky_sess_create(ngx_http_upstream_sticky_sess_t *sess,
+    ngx_http_upstream_sticky_sess_key_t *key, ngx_str_t *sid)
+{
+    size_t                                 n;
+    ngx_rbtree_node_t                     *node;
+    ngx_http_upstream_sticky_sess_node_t  *sn;
+
+    n = sizeof(ngx_http_upstream_sticky_sess_node_t);
+
+    sn = ngx_slab_alloc_locked(sess->shpool, n);
+    if (sn == NULL) {
+
+        ngx_log_error(NGX_LOG_WARN, ngx_cycle->log, 0,
+                      "could not allocate node%s, expiring least "
+                      "recently used session", sess->shpool->log_ctx);
+
+        (void) ngx_http_upstream_sticky_sess_expire(sess, 1);
+
+        sn = ngx_slab_alloc_locked(sess->shpool, n);
+        if (sn == NULL) {
+            ngx_log_error(NGX_LOG_ALERT, ngx_cycle->log, 0,
+                          "could not allocate node%s", sess->shpool->log_ctx);
+            return NULL;
+        }
+    }
+
+    ngx_memcpy(sn->u.md5, key->md5, 16);
+
+    sn->sid_len = sid->len;
+    ngx_memcpy(sn->sid, sid->data, sid->len);
+
+    node = &sn->rbnode;
+    node->key = sn->u.hash;
+
+    ngx_rbtree_insert(&sess->sh->rbtree, node);
+
+    return sn;
+}
+
+
+static void
+ngx_http_upstream_sticky_sess_rbtree_insert_value(ngx_rbtree_node_t *temp,
+    ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel)
+{
+    ngx_rbtree_node_t                     **p;
+    ngx_http_upstream_sticky_sess_node_t  *sn, *snt;
+
+    for ( ;; ) {
+
+        if (node->key < temp->key) {
+
+            p = &temp->left;
+
+        } else if (node->key > temp->key) {
+
+            p = &temp->right;
+
+        } else { /* node->key == temp->key */
+
+            sn = (ngx_http_upstream_sticky_sess_node_t *) node;
+            snt = (ngx_http_upstream_sticky_sess_node_t *) temp;
+
+            p = (ngx_memcmp(sn->u.md5, snt->u.md5, 16) < 0)
+                ? &temp->left : &temp->right;
+        }
+
+        if (*p == sentinel) {
+            break;
+        }
+
+        temp = *p;
+    }
+
+    *p = node;
+    node->parent = temp;
+    node->left = sentinel;
+    node->right = sentinel;
+    ngx_rbt_red(node);
+}
+
+
+static void
+ngx_http_upstream_sticky_sess_timer_handler(ngx_event_t *ev)
+{
+    ngx_msec_t                        wait;
+    ngx_http_upstream_sticky_sess_t  *sess;
+
+    sess = ev->data;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_EVENT, ev->log, 0,
+                   "sticky: session timer");
+
+    ngx_shmtx_lock(&sess->shpool->mutex);
+
+    wait = ngx_http_upstream_sticky_sess_expire(sess, 0);
+
+    ngx_shmtx_unlock(&sess->shpool->mutex);
+
+    if (wait > 0) {
+        ngx_add_timer(&sess->event, wait);
+    }
+}
+
+
+static ngx_msec_t
+ngx_http_upstream_sticky_sess_expire(ngx_http_upstream_sticky_sess_t *sess,
+    ngx_uint_t force)
+{
+    ngx_msec_t                             now, wait;
+    ngx_time_t                            *tp;
+    ngx_rbtree_node_t                     *node, *next;
+    ngx_http_upstream_sticky_sess_node_t  *sn;
+
+    wait = 0;
+
+    tp = ngx_timeofday();
+    now = tp->sec * 1000 + tp->msec;
+
+    if (sess->sh->exp_rbtree.root == sess->sh->exp_rbtree.sentinel) {
+        return 0;
+    }
+
+#if (NGX_SUPPRESS_WARN)
+    next = NULL;
+#endif
+
+    for (node = ngx_rbtree_min(sess->sh->exp_rbtree.root,
+                               sess->sh->exp_rbtree.sentinel);
+         node;
+         node = next)
+    {
+
+        sn = ngx_http_upstream_sticky_sess_node(node, enode);
+        wait = sn->last + sess->timeout - now;
+
+        if (!force && (ngx_msec_int_t) wait > 0) {
+            break;
+        }
+
+        force = 0;
+
+        next = ngx_rbtree_next(&sess->sh->exp_rbtree, node);
+
+        /* remove node */
+        node = &sn->enode;
+        ngx_rbtree_delete(&sess->sh->exp_rbtree, node);
+
+        node = &sn->rbnode;
+        ngx_rbtree_delete(&sess->sh->rbtree, node);
+        ngx_slab_free_locked(sess->shpool, node);
+    }
+
+    return wait;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_sticky_sess_init_zone(ngx_shm_zone_t *shm_zone, void *data)
+{
+    ngx_http_upstream_sticky_sess_t  *old_sess = data;
+
+    size_t                            len;
+    ngx_http_upstream_sticky_sess_t  *sess;
+
+    sess = shm_zone->data;
+
+    if (old_sess) {
+
+        if (ngx_strcmp(sess->host->data, old_sess->host->data) != 0) {
+
+            ngx_log_error(NGX_LOG_EMERG, shm_zone->shm.log, 0,
+                          "sticky zone \"%V\" is used in upstream \"%V\" "
+                          "while previously it was used in upstream \"%V\"",
+                          &shm_zone->shm.name, sess->host, old_sess->host);
+
+            return NGX_ERROR;
+        }
+
+        sess->sh = old_sess->sh;
+        sess->shpool = old_sess->shpool;
+        return NGX_OK;
+    }
+
+    sess->shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
+
+    if (shm_zone->shm.exists) {
+        sess->sh = sess->shpool->data;
+        return NGX_OK;
+    }
+
+    sess->sh = ngx_slab_alloc(sess->shpool,
+                              sizeof(ngx_http_upstream_sticky_sess_shared_t));
+    if (sess->sh == NULL) {
+        return NGX_ERROR;
+    }
+
+    sess->shpool->data = sess->sh;
+
+    ngx_rbtree_init(&sess->sh->rbtree, &sess->sh->sentinel,
+                    ngx_http_upstream_sticky_sess_rbtree_insert_value);
+
+    ngx_rbtree_init(&sess->sh->exp_rbtree, &sess->sh->exp_sentinel,
+                    ngx_rbtree_insert_timer_value);
+
+    len = sizeof(" in sticky session zone \"\"") + shm_zone->shm.name.len;
+
+    sess->shpool->log_ctx = ngx_slab_alloc(sess->shpool, len);
+    if (sess->shpool->log_ctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_sprintf(sess->shpool->log_ctx, " in sticky session zone \"%V\"%Z",
+                &shm_zone->shm.name);
+
+    sess->shpool->log_nomem = 0;
+
+    return NGX_OK;
+}
+
+
 static void *
 ngx_http_upstream_sticky_create_conf(ngx_conf_t *cf)
 {
@@ -403,6 +886,8 @@ ngx_http_upstream_sticky_create_conf(ngx_conf_t *cf)
      *     stcf->original_init_peer = NULL;
      *
      *     stcf->lookup_vars = NULL;
+     *     stcf->create_vars = NULL;
+     *     stcf->shm_zone = NULL;
      *
      *     stcf->cookie_name = { 0, NULL };
      *     stcf->cookie_domain = { 0, NULL };
@@ -418,9 +903,8 @@ ngx_http_upstream_sticky_create_conf(ngx_conf_t *cf)
 static char *
 ngx_http_upstream_sticky(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-    u_char                               *p;
-    ngx_str_t                            *value, varname;
-    ngx_int_t                             index, *indexp;
+    ngx_str_t                            *value;
+    ngx_int_t                            *indexp, index;
     ngx_uint_t                            i;
     ngx_http_upstream_srv_conf_t         *us;
     ngx_http_upstream_sticky_srv_conf_t  *stcf;
@@ -437,9 +921,18 @@ ngx_http_upstream_sticky(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return NGX_CONF_ERROR;
     }
 
+    stcf->original_init_upstream = us->peer.init_upstream
+                                   ? us->peer.init_upstream
+                                   : ngx_http_upstream_init_round_robin;
+
+    us->peer.init_upstream = ngx_http_upstream_sticky_init_upstream;
+
     value = cf->args->elts;
 
-    if (ngx_strcmp(value[1].data, "route") == 0) {
+    if (ngx_strcmp(value[1].data, "cookie") == 0) {
+        return ngx_http_upstream_sticky_cookie(cf, stcf);
+
+    } else if (ngx_strcmp(value[1].data, "route") == 0) {
 
         for (i = 2; i < cf->args->nelts; i++) {
 
@@ -465,128 +958,310 @@ ngx_http_upstream_sticky(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             *indexp = index;
         }
 
-        /*
-         * stcf->stick = NULL;
-         */
+        return NGX_CONF_OK;
 
-    } else if (ngx_strcmp(value[1].data, "cookie") == 0) {
+    } else if (ngx_strcmp(value[1].data, "learn") == 0) {
+        return ngx_http_upstream_sticky_learn(cf, stcf, us);
+    }
 
-        if (value[2].len == 0) {
-            return "empty cookie name";
-        }
-
-        stcf->cookie_name = value[2];
-
-        for (i = 3; i < cf->args->nelts; i++) {
-
-            if (ngx_strncmp(value[i].data, "domain=", 7) == 0) {
-
-                if (stcf->cookie_domain.data != NULL) {
-                    return "parameter \"domain\" is duplicate";
-                }
-
-                value[i].data += 7;
-                value[i].len -= 7;
-
-                if (value[i].len == 0) {
-                    return "no value for \"domain\"";
-                }
-
-                stcf->cookie_domain.len = sizeof("; domain=") - 1
-                                          + value[i].len;
-
-                stcf->cookie_domain.data = ngx_pnalloc(cf->pool,
-                                                       stcf->cookie_domain.len);
-                if (stcf->cookie_domain.data == NULL) {
-                    return NGX_CONF_ERROR;
-                }
-
-                p = ngx_cpymem(stcf->cookie_domain.data,
-                               "; domain=", sizeof("; domain=") - 1);
-                ngx_memcpy(p, value[i].data, value[i].len);
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "unknown parameter \"%V\"",
+                       &value[1]);
+    return NGX_CONF_ERROR;
+}
 
 
-            } else if (ngx_strncmp(value[i].data, "path=", 5) == 0) {
+static char *
+ngx_http_upstream_sticky_cookie(ngx_conf_t *cf,
+    ngx_http_upstream_sticky_srv_conf_t *stcf)
+{
+    u_char      *p;
+    ngx_str_t    name, *value;
+    ngx_int_t    index, *indexp;
+    ngx_uint_t   i;
 
-                if (stcf->cookie_path.data != NULL) {
-                    return "parameter \"path\" is duplicate";
-                }
+    value = cf->args->elts;
 
-                value[i].data += 5;
-                value[i].len -= 5;
+    if (value[2].len == 0) {
+        return "empty cookie name";
+    }
 
-                if (value[i].len == 0) {
-                    return "no value for \"path\"";
-                }
+    stcf->cookie_name = value[2];
 
-                stcf->cookie_path.len = sizeof("; path=") - 1 + value[i].len;
+    for (i = 3; i < cf->args->nelts; i++) {
 
-                stcf->cookie_path.data = ngx_pnalloc(cf->pool,
-                                                     stcf->cookie_path.len);
-                if (stcf->cookie_path.data == NULL) {
-                    return NGX_CONF_ERROR;
-                }
+        if (ngx_strncmp(value[i].data, "domain=", 7) == 0) {
 
-                p = ngx_cpymem(stcf->cookie_path.data,
-                               "; path=", sizeof("; path=") - 1);
-                ngx_memcpy(p, value[i].data, value[i].len);
+            if (stcf->cookie_domain.data != NULL) {
+                return "parameter \"domain\" is duplicate";
+            }
+
+            value[i].data += 7;
+            value[i].len -= 7;
+
+            if (value[i].len == 0) {
+                return "no value for \"domain\"";
+            }
+
+            stcf->cookie_domain.len = sizeof("; domain=") - 1
+                                      + value[i].len;
+
+            stcf->cookie_domain.data = ngx_pnalloc(cf->pool,
+                                                   stcf->cookie_domain.len);
+            if (stcf->cookie_domain.data == NULL) {
+                return NGX_CONF_ERROR;
+            }
+
+            p = ngx_cpymem(stcf->cookie_domain.data,
+                           "; domain=", sizeof("; domain=") - 1);
+            ngx_memcpy(p, value[i].data, value[i].len);
 
 
-            } else if (ngx_strncmp(value[i].data, "expires=", 8) == 0) {
+        } else if (ngx_strncmp(value[i].data, "path=", 5) == 0) {
 
-                if (stcf->cookie_expires != (time_t) NGX_CONF_UNSET) {
-                    return "parameter \"expires\" is duplicate";
-                }
+            if (stcf->cookie_path.data != NULL) {
+                return "parameter \"path\" is duplicate";
+            }
 
-                value[i].data += 8;
-                value[i].len -= 8;
+            value[i].data += 5;
+            value[i].len -= 5;
 
-                if (ngx_strcmp(value[i].data, "max") == 0) {
-                    stcf->cookie_expires = NGX_HTTP_STICKY_COOKIE_MAX_EXPIRES;
+            if (value[i].len == 0) {
+                return "no value for \"path\"";
+            }
 
-                } else {
-                    stcf->cookie_expires = ngx_parse_time(&value[i], 1);
-                    if (stcf->cookie_expires == (time_t) NGX_ERROR) {
-                        return "invalid \"expires\" parameter value";
-                    }
-                }
+            stcf->cookie_path.len = sizeof("; path=") - 1 + value[i].len;
+
+            stcf->cookie_path.data = ngx_pnalloc(cf->pool,
+                                                 stcf->cookie_path.len);
+            if (stcf->cookie_path.data == NULL) {
+                return NGX_CONF_ERROR;
+            }
+
+            p = ngx_cpymem(stcf->cookie_path.data,
+                           "; path=", sizeof("; path=") - 1);
+            ngx_memcpy(p, value[i].data, value[i].len);
+
+
+        } else if (ngx_strncmp(value[i].data, "expires=", 8) == 0) {
+
+            if (stcf->cookie_expires != (time_t) NGX_CONF_UNSET) {
+                return "parameter \"expires\" is duplicate";
+            }
+
+            value[i].data += 8;
+            value[i].len -= 8;
+
+            if (ngx_strcmp(value[i].data, "max") == 0) {
+                stcf->cookie_expires = NGX_HTTP_STICKY_COOKIE_MAX_EXPIRES;
 
             } else {
-                return "unknown parameter";
+                stcf->cookie_expires = ngx_parse_time(&value[i], 1);
+                if (stcf->cookie_expires == (time_t) NGX_ERROR) {
+                    return "invalid \"expires\" parameter value";
+                }
             }
-        }
 
-        varname.len = sizeof("cookie_") - 1  + stcf->cookie_name.len;
-        varname.data = ngx_pnalloc(cf->pool, varname.len);
-        if (varname.data == NULL) {
-             return NGX_CONF_ERROR;
-        }
-
-        ngx_sprintf(varname.data, "cookie_%V", &stcf->cookie_name);
-
-        index = ngx_http_get_variable_index(cf, &varname);
-        if (index == NGX_ERROR) {
+        } else {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "unknown parameter \"%V\"", &value[i]);
             return NGX_CONF_ERROR;
         }
+    }
 
-        indexp = ngx_array_push(stcf->lookup_vars);
-        if (indexp == NULL) {
-            return NGX_CONF_ERROR;
-        }
+    name.len = sizeof("cookie_") - 1  + stcf->cookie_name.len;
+    name.data = ngx_pnalloc(cf->pool, name.len);
+    if (name.data == NULL) {
+         return NGX_CONF_ERROR;
+    }
 
-        *indexp = index;
+    ngx_sprintf(name.data, "cookie_%V", &stcf->cookie_name);
 
-    } else {
-        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "unknown parameter \"%V\"",
-                           &value[1]);
+    index = ngx_http_get_variable_index(cf, &name);
+    if (index == NGX_ERROR) {
         return NGX_CONF_ERROR;
     }
 
-    stcf->original_init_upstream = us->peer.init_upstream
-                                   ? us->peer.init_upstream
-                                   : ngx_http_upstream_init_round_robin;
+    indexp = ngx_array_push(stcf->lookup_vars);
+    if (indexp == NULL) {
+        return NGX_CONF_ERROR;
+    }
 
-    us->peer.init_upstream = ngx_http_upstream_sticky_init_upstream;
+    *indexp = index;
+
+    return NGX_CONF_OK;
+}
+
+
+static char *
+ngx_http_upstream_sticky_learn(ngx_conf_t *cf,
+    ngx_http_upstream_sticky_srv_conf_t *stcf, ngx_http_upstream_srv_conf_t *us)
+{
+    u_char                           *p;
+    ssize_t                           zone_size;
+    ngx_str_t                        *value, name, size;
+    ngx_int_t                         index, *indexp;
+    ngx_uint_t                        i;
+    ngx_msec_t                        timeout;
+    ngx_shm_zone_t                   *shm_zone;
+    ngx_http_upstream_sticky_sess_t  *sess;
+
+    zone_size = 0;
+    timeout = NGX_CONF_UNSET_MSEC;
+
+    stcf->create_vars = ngx_array_create(cf->pool, 1, sizeof(ngx_int_t));
+    if (stcf->create_vars == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    value = cf->args->elts;
+
+    for (i = 2; i < cf->args->nelts; i++) {
+
+        if (ngx_strncmp(value[i].data, "zone=", 5) == 0) {
+
+            if (zone_size != 0) {
+                return "duplicate zone";
+            }
+
+            name.data = value[i].data + 5;
+
+            p = (u_char *) ngx_strchr(name.data, ':');
+
+            if (p == NULL) {
+                return "zone size is not specified";
+            }
+
+            name.len = p - name.data;
+
+            if (name.len == 0) {
+                return "zone name is not specified";
+            }
+
+            size.data = ++p;
+            size.len = value[i].data + value[i].len - p;
+
+            zone_size = ngx_parse_size(&size);
+            if (zone_size == NGX_ERROR) {
+                return "invalid zone size";
+            }
+
+            /* 32k ~ 200 sessions, 1m ~ 8000 sessions */
+            if (zone_size < (ssize_t) (8 * ngx_pagesize)) {
+                return "zone is too small";
+            }
+
+        } else if (ngx_strncmp(value[i].data, "timeout=", 8) == 0) {
+
+            if (timeout != NGX_CONF_UNSET_MSEC) {
+                return "duplicate timeout";
+            }
+
+            value[i].data += 8;
+            value[i].len -= 8;
+
+            timeout = ngx_parse_time(&value[i], 0);
+            if (timeout == (ngx_msec_t) NGX_ERROR || timeout == 0) {
+                return "invalid timeout";
+            }
+
+        } else if (ngx_strncmp(value[i].data, "create=", 7) == 0) {
+
+            if (value[i].data[7] != '$') {
+                return "missing variable in the \"create\" parameter";
+            }
+
+            value[i].data += 8;
+            value[i].len -= 8;
+
+            index = ngx_http_get_variable_index(cf, &value[i]);
+            if (index == NGX_ERROR) {
+                return NGX_CONF_ERROR;
+            }
+
+            indexp = ngx_array_push(stcf->create_vars);
+            if (indexp == NULL) {
+                return NGX_CONF_ERROR;
+            }
+
+            *indexp = index;
+
+        } else if (ngx_strncmp(value[i].data, "lookup=", 7) == 0) {
+
+            if (value[i].data[7] != '$') {
+                return "missing variable in the \"lookup\" parameter";
+            }
+
+            value[i].data += 8;
+            value[i].len -= 8;
+
+            index = ngx_http_get_variable_index(cf, &value[i]);
+            if (index == NGX_ERROR) {
+                return NGX_CONF_ERROR;
+            }
+
+            indexp = ngx_array_push(stcf->lookup_vars);
+            if (indexp == NULL) {
+                return NGX_CONF_ERROR;
+            }
+
+            *indexp = index;
+
+        } else {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "unknown parameter \"%V\"", &value[i]);
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    if (stcf->lookup_vars->nelts == 0) {
+        return "\"lookup\" parameter is not specified";
+    }
+
+    if (stcf->create_vars->nelts == 0) {
+        return "\"create\" parameter is not specified";
+    }
+
+    if (zone_size == 0) {
+        return "\"zone\" parameter is not specified";
+    }
+
+    if (timeout == NGX_CONF_UNSET_MSEC) {
+        timeout = 600000; /* 10m */
+    }
+
+    shm_zone = ngx_shared_memory_add(cf, &name, zone_size,
+                                     &ngx_http_upstream_sticky_module);
+    if (shm_zone == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (shm_zone->data) {
+        sess = shm_zone->data;
+
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "sticky zone \"%V\" is already used in "
+                           "upstream \"%V\"", &name, sess->host);
+
+        return NGX_CONF_ERROR;
+    }
+
+    sess = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_sticky_sess_t));
+    if (sess == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    sess->timeout = timeout;
+    sess->host = &us->host;
+
+    sess->event.data = sess;
+    sess->event.log = &cf->cycle->new_log;
+    sess->event.handler = ngx_http_upstream_sticky_sess_timer_handler;
+    sess->event.cancelable = 1;
+
+    shm_zone->init = ngx_http_upstream_sticky_sess_init_zone;
+    shm_zone->data = sess;
+
+    stcf->shm_zone = shm_zone;
 
     return NGX_CONF_OK;
 }

--- a/src/http/modules/ngx_http_upstream_zone_module.c
+++ b/src/http/modules/ngx_http_upstream_zone_module.c
@@ -385,6 +385,9 @@ ngx_http_upstream_zone_copy_peer(ngx_http_upstream_rr_peers_t *peers,
         ngx_memcpy(dst, src, sizeof(ngx_http_upstream_rr_peer_t));
         dst->sockaddr = NULL;
         dst->name.data = NULL;
+#if (NGX_HTTP_UPSTREAM_SID)
+        dst->sid.data = NULL;
+#endif
         dst->server.data = NULL;
         dst->host = NULL;
     }
@@ -399,9 +402,19 @@ ngx_http_upstream_zone_copy_peer(ngx_http_upstream_rr_peers_t *peers,
         goto failed;
     }
 
+#if (NGX_HTTP_UPSTREAM_SID)
+    dst->sid.data = ngx_slab_calloc_locked(pool, NGX_HTTP_UPSTREAM_SID_LEN);
+    if (dst->sid.data == NULL) {
+        goto failed;
+    }
+#endif
+
     if (src) {
         ngx_memcpy(dst->sockaddr, src->sockaddr, src->socklen);
         ngx_memcpy(dst->name.data, src->name.data, src->name.len);
+#if (NGX_HTTP_UPSTREAM_SID)
+        ngx_memcpy(dst->sid.data, src->sid.data, src->sid.len);
+#endif
 
         dst->server.data = ngx_slab_alloc_locked(pool, src->server.len);
         if (dst->server.data == NULL) {
@@ -459,6 +472,12 @@ failed:
     if (dst->server.data) {
         ngx_slab_free_locked(pool, dst->server.data);
     }
+
+#if (NGX_HTTP_UPSTREAM_SID)
+    if (dst->sid.data) {
+        ngx_slab_free_locked(pool, dst->sid.data);
+    }
+#endif
 
     if (dst->name.data) {
         ngx_slab_free_locked(pool, dst->name.data);
@@ -572,6 +591,10 @@ ngx_http_upstream_zone_preresolve(ngx_http_upstream_rr_peer_t *resolve,
                 peer->max_fails = template->max_fails;
                 peer->fail_timeout = template->fail_timeout;
                 peer->down = template->down;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+                ngx_http_upstream_copy_round_robin_sid(peer, template);
+#endif
 
                 (*peers->config)++;
 
@@ -965,6 +988,10 @@ again:
         peer->max_fails = template->max_fails;
         peer->fail_timeout = template->fail_timeout;
         peer->down = template->down;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+        ngx_http_upstream_copy_round_robin_sid(peer, template);
+#endif
 
         *peerp = peer;
         peerp = &peer->next;

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -6535,6 +6535,19 @@ ngx_http_upstream_server(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             continue;
         }
 
+#if (NGX_HTTP_UPSTREAM_STICKY)
+        if (ngx_strcmp(value[i].data, "drain") == 0) {
+
+            if (!(uscf->flags & NGX_HTTP_UPSTREAM_DOWN)) {
+                goto not_supported;
+            }
+
+            us->down = NGX_HTTP_UPSTREAM_DRAINING;
+
+            continue;
+        }
+#endif
+
 #if (NGX_HTTP_UPSTREAM_SID)
         if (ngx_strncmp(value[i].data, "route=", 6) == 0) {
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -4593,6 +4593,10 @@ ngx_http_upstream_next(ngx_http_request_t *r, ngx_http_upstream_t *u,
 
         u->peer.free(&u->peer, u->peer.data, state);
         u->peer.sockaddr = NULL;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+        u->peer.sid = NULL;
+#endif
     }
 
     if (ft_type == NGX_HTTP_UPSTREAM_FT_TIMEOUT) {
@@ -4776,6 +4780,10 @@ ngx_http_upstream_finalize_request(ngx_http_request_t *r,
     if (u->peer.free && u->peer.sockaddr) {
         u->peer.free(&u->peer, u->peer.data, 0);
         u->peer.sockaddr = NULL;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+        u->peer.sid = NULL;
+#endif
     }
 
     if (u->peer.connection) {
@@ -6526,6 +6534,28 @@ ngx_http_upstream_server(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
             continue;
         }
+
+#if (NGX_HTTP_UPSTREAM_SID)
+        if (ngx_strncmp(value[i].data, "route=", 6) == 0) {
+
+            us->sid.data = &value[i].data[6];
+            us->sid.len = value[i].len - 6;
+
+            if (us->sid.len == 0) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "route is empty");
+                return NGX_CONF_ERROR;
+            }
+
+            if (us->sid.len > NGX_HTTP_UPSTREAM_SID_LEN) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "route is longer than %d",
+                                   NGX_HTTP_UPSTREAM_SID_LEN);
+                return NGX_CONF_ERROR;
+            }
+
+            continue;
+        }
+#endif
 
 #if (NGX_HTTP_UPSTREAM_ZONE)
         if (ngx_strcmp(value[i].data, "resolve") == 0) {

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -6530,7 +6530,7 @@ ngx_http_upstream_server(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 goto not_supported;
             }
 
-            us->down = 1;
+            us->down = NGX_HTTP_UPSTREAM_FAILED;
 
             continue;
         }

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -2607,6 +2607,10 @@ ngx_http_upstream_process_header(ngx_http_request_t *r, ngx_http_upstream_t *u)
         }
     }
 
+    if (u->peer.notify) {
+        u->peer.notify(&u->peer, u->peer.data, NGX_HTTP_UPSTREAM_NOTIFY_HEADER);
+    }
+
     if (ngx_http_upstream_process_headers(r, u) != NGX_OK) {
         return;
     }

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -57,6 +57,9 @@
 #define NGX_HTTP_UPSTREAM_IGN_VARY           0x00000200
 
 
+#define NGX_HTTP_UPSTREAM_NOTIFY_HEADER      0x1
+
+
 typedef struct {
     ngx_uint_t                       status;
     ngx_msec_t                       response_time;

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -110,8 +110,9 @@ typedef struct {
     ngx_str_t                        service;
 #endif
 
-    NGX_COMPAT_BEGIN(2)
-    NGX_COMPAT_END
+#if (NGX_HTTP_UPSTREAM_SID || NGX_COMPAT)
+    ngx_str_t                        sid;
+#endif
 } ngx_http_upstream_server_t;
 
 

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -8,14 +8,20 @@
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
+#include <ngx_md5.h>
 
 
 #define ngx_http_upstream_tries(p) ((p)->tries                                \
                                     + ((p)->next ? (p)->next->tries : 0))
 
 
+#if (NGX_HTTP_UPSTREAM_SID)
+static ngx_int_t ngx_http_upstream_create_sid(ngx_conf_t *cf,
+    ngx_http_upstream_rr_peer_t *peer, ngx_str_t *route);
+#endif
+
 static ngx_http_upstream_rr_peer_t *ngx_http_upstream_get_peer(
-    ngx_http_upstream_rr_peer_data_t *rrp);
+    ngx_http_upstream_rr_peer_data_t *rrp, ngx_peer_connection_t *pc);
 
 #if (NGX_HTTP_SSL)
 
@@ -190,6 +196,14 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
                 peer[n].down = server[i].down;
                 peer[n].server = server[i].name;
 
+#if (NGX_HTTP_UPSTREAM_SID)
+                if (ngx_http_upstream_create_sid(cf, &peer[n], &server[i].sid)
+                    != NGX_OK)
+                {
+                    return NGX_ERROR;
+                }
+#endif
+
                 *rpeerp = &peer[n];
                 rpeerp = &peer[n].next;
                 n++;
@@ -210,6 +224,14 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
                 peer[n].fail_timeout = server[i].fail_timeout;
                 peer[n].down = server[i].down;
                 peer[n].server = server[i].name;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+                if (ngx_http_upstream_create_sid(cf, &peer[n], &server[i].sid)
+                    != NGX_OK)
+                {
+                    return NGX_ERROR;
+                }
+#endif
 
                 *peerp = &peer[n];
                 peerp = &peer[n].next;
@@ -316,6 +338,14 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
                 peer[n].down = server[i].down;
                 peer[n].server = server[i].name;
 
+#if (NGX_HTTP_UPSTREAM_SID)
+                if (ngx_http_upstream_create_sid(cf, &peer[n], &server[i].sid)
+                    != NGX_OK)
+                {
+                    return NGX_ERROR;
+                }
+#endif
+
                 *rpeerp = &peer[n];
                 rpeerp = &peer[n].next;
                 n++;
@@ -336,6 +366,14 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
                 peer[n].fail_timeout = server[i].fail_timeout;
                 peer[n].down = server[i].down;
                 peer[n].server = server[i].name;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+                if (ngx_http_upstream_create_sid(cf, &peer[n], &server[i].sid)
+                    != NGX_OK)
+                {
+                    return NGX_ERROR;
+                }
+#endif
 
                 *peerp = &peer[n];
                 peerp = &peer[n].next;
@@ -414,6 +452,63 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
 
     return NGX_OK;
 }
+
+
+#if (NGX_HTTP_UPSTREAM_SID)
+
+static ngx_int_t
+ngx_http_upstream_create_sid(ngx_conf_t *cf, ngx_http_upstream_rr_peer_t *peer,
+    ngx_str_t *route)
+{
+    if (route->len) {
+        peer->route = 1;
+        peer->sid = *route;
+        return NGX_OK;
+    }
+
+    peer->sid.data = ngx_pnalloc(cf->pool, NGX_HTTP_UPSTREAM_SID_LEN);
+    if (peer->sid.data == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_http_upstream_init_round_robin_sid(peer, NULL);
+
+    return NGX_OK;
+}
+
+
+void
+ngx_http_upstream_init_round_robin_sid(ngx_http_upstream_rr_peer_t *peer,
+    ngx_str_t *route)
+{
+    u_char     hash[16];
+    ngx_md5_t  md5;
+
+    if (route && route->len) {
+        peer->route = 1;
+        peer->sid.len = route->len;
+        ngx_memcpy(peer->sid.data, route->data, route->len);
+        return;
+    }
+
+    peer->route = 0;
+
+    /* SID is the MD5 hash of a printable socket address */
+
+    if (peer->name.len == 0) {
+        peer->sid.len = 0;
+        return;
+    }
+
+    ngx_md5_init(&md5);
+    ngx_md5_update(&md5, peer->name.data, peer->name.len);
+    ngx_md5_final(hash, &md5);
+
+    ngx_hex_dump(peer->sid.data, hash, 16);
+    peer->sid.len = NGX_HTTP_UPSTREAM_SID_LEN;
+}
+
+#endif
 
 
 ngx_int_t
@@ -641,7 +736,7 @@ ngx_http_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
 
         /* there are several peers */
 
-        peer = ngx_http_upstream_get_peer(rrp);
+        peer = ngx_http_upstream_get_peer(rrp, pc);
 
         if (peer == NULL) {
             goto failed;
@@ -655,6 +750,10 @@ ngx_http_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
     pc->sockaddr = peer->sockaddr;
     pc->socklen = peer->socklen;
     pc->name = &peer->name;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+    pc->sid = &peer->sid;
+#endif
 
     peer->conns++;
 
@@ -701,13 +800,20 @@ busy:
 
 
 static ngx_http_upstream_rr_peer_t *
-ngx_http_upstream_get_peer(ngx_http_upstream_rr_peer_data_t *rrp)
+ngx_http_upstream_get_peer(ngx_http_upstream_rr_peer_data_t *rrp,
+    ngx_peer_connection_t *pc)
 {
     time_t                        now;
     uintptr_t                     m;
     ngx_int_t                     total;
     ngx_uint_t                    i, n, p;
     ngx_http_upstream_rr_peer_t  *peer, *best;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+    ngx_int_t                     low_limit;
+    ngx_uint_t                    st_p;
+    ngx_http_upstream_rr_peer_t  *st_peer;
+#endif
 
     now = ngx_time();
 
@@ -716,6 +822,29 @@ ngx_http_upstream_get_peer(ngx_http_upstream_rr_peer_data_t *rrp)
 
 #if (NGX_SUPPRESS_WARN)
     p = 0;
+#endif
+
+#if (NGX_HTTP_UPSTREAM_SID)
+    st_peer = ngx_http_upstream_get_rr_peer_by_sid(rrp, pc->hint, &p, 0);
+
+    if (st_peer) {
+
+        low_limit = -((ngx_int_t)(rrp->peers->total_weight - st_peer->weight));
+
+        /*
+         * note: current code accounts only one sticky request in a row, if it
+         *       is required to account more, multiply low_limit by N below
+         */
+        if (st_peer->current_weight <= low_limit) {
+
+            /* do not update weights if the limit exceeded */
+            best = st_peer;
+            goto best_chosen;
+        }
+        /* else: proceed to reweight with existing st_peer */
+    }
+
+    st_p = p;
 #endif
 
     for (peer = rrp->peers->peer, i = 0;
@@ -757,9 +886,24 @@ ngx_http_upstream_get_peer(ngx_http_upstream_rr_peer_data_t *rrp)
         }
     }
 
+#if (NGX_HTTP_UPSTREAM_SID)
+    /* prefer peer chosen by sticky to best from RR */
+
+    if (st_peer) {
+        best = st_peer;
+        p = st_p;
+    }
+#endif
+
     if (best == NULL) {
         return NULL;
     }
+
+    best->current_weight -= total;
+
+#if (NGX_HTTP_UPSTREAM_SID)
+best_chosen:
+#endif
 
     rrp->current = best;
     ngx_http_upstream_rr_peer_ref(rrp->peers, best);
@@ -769,14 +913,83 @@ ngx_http_upstream_get_peer(ngx_http_upstream_rr_peer_data_t *rrp)
 
     rrp->tried[n] |= m;
 
-    best->current_weight -= total;
-
     if (now - best->checked > best->fail_timeout) {
         best->checked = now;
     }
 
     return best;
 }
+
+
+#if (NGX_HTTP_UPSTREAM_SID)
+
+ngx_http_upstream_rr_peer_t *
+ngx_http_upstream_get_rr_peer_by_sid(ngx_http_upstream_rr_peer_data_t *rrp,
+    ngx_str_t *hint, ngx_uint_t *p, ngx_uint_t lock)
+{
+    uintptr_t                     m;
+    ngx_uint_t                    i, n;
+    ngx_http_upstream_rr_peer_t  *peer;
+
+    if (hint == NULL) {
+        return NULL;
+    }
+
+    for (peer = rrp->peers->peer, i = 0;
+         peer;
+         peer = peer->next, i++)
+    {
+
+        if (peer->sid.len == hint->len
+            && ngx_memcmp(peer->sid.data, hint->data, hint->len) == 0)
+        {
+            goto found;
+        }
+    }
+
+    return NULL;
+
+found:
+
+    n = i / (8 * sizeof(uintptr_t));
+    m = (uintptr_t) 1 << i % (8 * sizeof(uintptr_t));
+
+    if (rrp->tried[n] & m) {
+        return NULL;
+    }
+
+    if (lock) {
+        ngx_http_upstream_rr_peer_lock(rrp->peers, peer);
+    }
+
+    if (peer->down) {
+        goto failed;
+    }
+
+    if (peer->max_fails
+        && peer->fails >= peer->max_fails
+        && ngx_time() - peer->checked <= peer->fail_timeout)
+    {
+        goto failed;
+    }
+
+    if (peer->max_conns && peer->conns >= peer->max_conns) {
+        goto failed;
+    }
+
+    *p = i;
+    return peer;
+
+failed:
+
+    if (lock) {
+        ngx_http_upstream_rr_peer_unlock(rrp->peers, peer);
+    }
+
+    return NULL;
+}
+
+#endif
 
 
 void

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -719,15 +719,23 @@ ngx_http_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
 #endif
 
     if (peers->single) {
-        peer = peers->peer;
+#if (NGX_HTTP_UPSTREAM_SID)
+        peer = ngx_http_upstream_get_rr_peer_by_sid(rrp, pc->hint, &i, 0);
 
-        if (peer->down) {
-            goto failed;
-        }
+        if (peer == NULL) {
+#endif
+            peer = peers->peer;
 
-        if (peer->max_conns && peer->conns >= peer->max_conns) {
-            goto failed;
+            if (peer->down) {
+                goto failed;
+            }
+
+            if (peer->max_conns && peer->conns >= peer->max_conns) {
+                goto failed;
+            }
+#if (NGX_HTTP_UPSTREAM_SID)
         }
+#endif
 
         rrp->current = peer;
         ngx_http_upstream_rr_peer_ref(peers, peer);
@@ -962,7 +970,11 @@ found:
         ngx_http_upstream_rr_peer_lock(rrp->peers, peer);
     }
 
-    if (peer->down) {
+    if (peer->down
+#if (NGX_HTTP_UPSTREAM_STICKY)
+        & ~NGX_HTTP_UPSTREAM_DRAINING
+#endif
+    ) {
         goto failed;
     }
 

--- a/src/http/ngx_http_upstream_round_robin.h
+++ b/src/http/ngx_http_upstream_round_robin.h
@@ -18,6 +18,8 @@
 #define NGX_HTTP_UPSTREAM_SID_LEN    32  /* md5 in hex */
 #endif
 
+#define NGX_HTTP_UPSTREAM_FAILED     1
+
 
 typedef struct ngx_http_upstream_rr_peers_s  ngx_http_upstream_rr_peers_t;
 typedef struct ngx_http_upstream_rr_peer_s   ngx_http_upstream_rr_peer_t;

--- a/src/http/ngx_http_upstream_round_robin.h
+++ b/src/http/ngx_http_upstream_round_robin.h
@@ -20,6 +20,10 @@
 
 #define NGX_HTTP_UPSTREAM_FAILED     1
 
+#if (NGX_HTTP_UPSTREAM_STICKY)
+#define NGX_HTTP_UPSTREAM_DRAINING   8
+#endif
+
 
 typedef struct ngx_http_upstream_rr_peers_s  ngx_http_upstream_rr_peers_t;
 typedef struct ngx_http_upstream_rr_peer_s   ngx_http_upstream_rr_peer_t;

--- a/src/http/ngx_http_upstream_round_robin.h
+++ b/src/http/ngx_http_upstream_round_robin.h
@@ -14,6 +14,11 @@
 #include <ngx_http.h>
 
 
+#if (NGX_HTTP_UPSTREAM_SID)
+#define NGX_HTTP_UPSTREAM_SID_LEN    32  /* md5 in hex */
+#endif
+
+
 typedef struct ngx_http_upstream_rr_peers_s  ngx_http_upstream_rr_peers_t;
 typedef struct ngx_http_upstream_rr_peer_s   ngx_http_upstream_rr_peer_t;
 
@@ -62,6 +67,10 @@ struct ngx_http_upstream_rr_peer_s {
     int                             ssl_session_len;
 #endif
 
+#if (NGX_HTTP_UPSTREAM_SID || NGX_COMPAT)
+    unsigned                        route:1;
+#endif
+
 #if (NGX_HTTP_UPSTREAM_ZONE)
     unsigned                        zombie:1;
 
@@ -70,9 +79,13 @@ struct ngx_http_upstream_rr_peer_s {
     ngx_http_upstream_host_t       *host;
 #endif
 
+#if (NGX_HTTP_UPSTREAM_SID || NGX_COMPAT)
+    ngx_str_t                       sid;
+#endif
+
     ngx_http_upstream_rr_peer_t    *next;
 
-    NGX_COMPAT_BEGIN(15)
+    NGX_COMPAT_BEGIN(13)
     NGX_COMPAT_END
 };
 
@@ -151,6 +164,9 @@ ngx_http_upstream_rr_peer_free_locked(ngx_http_upstream_rr_peers_t *peers,
 
     ngx_slab_free_locked(peers->shpool, peer->sockaddr);
     ngx_slab_free_locked(peers->shpool, peer->name.data);
+#if (NGX_HTTP_UPSTREAM_SID)
+    ngx_slab_free_locked(peers->shpool, peer->sid.data);
+#endif
 
     if (peer->server.data) {
         ngx_slab_free_locked(peers->shpool, peer->server.data);
@@ -233,6 +249,20 @@ ngx_int_t
     void *data);
 void ngx_http_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
     void *data);
+#endif
+
+#if (NGX_HTTP_UPSTREAM_SID)
+
+#define ngx_http_upstream_copy_round_robin_sid(dst, src)                      \
+    ngx_http_upstream_init_round_robin_sid(dst,                               \
+                                           (src)->route ? &(src)->sid : NULL)
+
+void ngx_http_upstream_init_round_robin_sid(ngx_http_upstream_rr_peer_t *peer,
+    ngx_str_t *route);
+ngx_http_upstream_rr_peer_t *ngx_http_upstream_get_rr_peer_by_sid(
+    ngx_http_upstream_rr_peer_data_t *rrp, ngx_str_t *hint, ngx_uint_t *p,
+    ngx_uint_t lock);
+
 #endif
 
 

--- a/src/stream/ngx_stream_upstream.c
+++ b/src/stream/ngx_stream_upstream.c
@@ -536,7 +536,7 @@ ngx_stream_upstream_server(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                 goto not_supported;
             }
 
-            us->down = 1;
+            us->down = NGX_STREAM_UPSTREAM_FAILED;
 
             continue;
         }

--- a/src/stream/ngx_stream_upstream_round_robin.h
+++ b/src/stream/ngx_stream_upstream_round_robin.h
@@ -14,6 +14,9 @@
 #include <ngx_stream.h>
 
 
+#define NGX_STREAM_UPSTREAM_FAILED      1
+
+
 typedef struct ngx_stream_upstream_rr_peers_s  ngx_stream_upstream_rr_peers_t;
 typedef struct ngx_stream_upstream_rr_peer_s   ngx_stream_upstream_rr_peer_t;
 


### PR DESCRIPTION
This PR includes about ~80 commits from the NGINX Plus with the full implementation of upstream session affinity (sans API), grouped by the functional changes. All the original credits are preserved.

Differences from the original code:
* Minor changes to support MSVC
* https://github.com/nginx/nginx/commit/9ce752fd6e856a9773b630eefa4f5ff55c3aaee6, which fixes an issue that became visible after replacing API with configuration reload in the tests.

Documentation: https://nginx.org/en/docs/http/ngx_http_upstream_module.html#sticky
Tests: https://github.com/nginx/nginx-tests/pull/32
Fixes: #1124 

