### PR TITLE
Upstream: fix integer underflow in charset parsing

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -5642,7 +5642,7 @@ ngx_http_upstream_copy_content_type(ngx_http_request_t *r, ngx_table_elt_t *h,
 
         last = h->value.data + h->value.len;
 
-        if (*(last - 1) == '"') {
+        if (last > p && *(last - 1) == '"') {
             last--;
         }
 


### PR DESCRIPTION
When parsing the `charset` parameter in the `Content-Type` header within `ngx_http_upstream_copy_content_type`, an input such as `charset="` resulted in an integer underflow.

In this scenario, both `p` and `last` point to the position immediately following the opening quote. The logic to strip a trailing quote checked `*(last - 1)` without verifying that `last > p`. This caused `last` to be decremented to point to the opening quote itself, making `last < p`.

The subsequent length calculation `r->headers_out.charset.len = last - p` resulted in -1, which wrapped to `SIZE_MAX` as `len` is a `size_t`. This invalid length was later passed to `ngx_cpymem` in `ngx_http_header_filter`, leading to an out-of-bounds memory access (detected as `negative-size-param` by AddressSanitizer).

The fix ensures `last > p` before attempting to strip a trailing quote, correctly resulting in a zero-length charset for malformed input.

The oss-fuzz payload that triggers this issue holds multiple 103 status lines, and it's a sequence of 2 of those Content-Type headers that trigger the ASAN report.

Fixes: https://issues.oss-fuzz.com/issues/486561029

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
