### PR TITLE
PR template: fix CONTRIBUTING.md url

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,5 @@ Describe the use case and detail of the change. If this PR addresses an issue on
 
 Before creating a PR, run through this checklist and mark each as complete:
 
-- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md).
-- [ ] I have checked that NGINX compiles and runs after adding my changes.
+- [x] I have read the [contributing guidelines](/nginx/nginx/blob/master/CONTRIBUTING.md).
+- [x] I have checked that NGINX compiles and runs after adding my changes.


### PR DESCRIPTION
Switch the url from effectively pointing at https://github.com/CONTRIBUTING.md to https://github.com/nginx/nginx/CONTRIBUTING.md

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR's description or commit message.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
