### PR TITLE
SSL: support EVP APIs for ticket keys (ticket #981)

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -17,6 +17,17 @@
 #define NGX_SSL_PASSWORD_BUFFER_SIZE  4096
 
 
+#if (NGX_SSL_TICKET_KEY_EVP_CB)
+#define ngx_ssl_ticket_key_mac_ctx_t        EVP_MAC_CTX
+#define ngx_ssl_set_ticket_key_callback     SSL_CTX_set_tlsext_ticket_key_evp_cb
+
+#elif defined SSL_CTX_set_tlsext_ticket_key_cb
+#define ngx_ssl_ticket_key_mac_ctx_t        HMAC_CTX
+#define ngx_ssl_set_ticket_key_callback     SSL_CTX_set_tlsext_ticket_key_cb
+
+#endif
+
+
 typedef struct {
     ngx_uint_t  engine;   /* unsigned  engine:1; */
 } ngx_openssl_conf_t;
@@ -73,10 +84,13 @@ static void ngx_ssl_expire_sessions(ngx_ssl_session_cache_t *cache,
 static void ngx_ssl_session_rbtree_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
 
-#ifdef SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB
+#ifdef ngx_ssl_set_ticket_key_callback
 static int ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
     unsigned char *name, unsigned char *iv, EVP_CIPHER_CTX *ectx,
-    HMAC_CTX *hctx, int enc);
+    ngx_ssl_ticket_key_mac_ctx_t *hctx, int enc);
+static ngx_int_t ngx_ssl_ticket_key_mac_init(ngx_connection_t *c,
+    ngx_ssl_ticket_key_t *key, size_t size,
+    ngx_ssl_ticket_key_mac_ctx_t *hctx);
 static ngx_int_t ngx_ssl_rotate_ticket_keys(SSL_CTX *ssl_ctx, ngx_log_t *log);
 static void ngx_ssl_ticket_keys_cleanup(void *data);
 #endif
@@ -4784,7 +4798,7 @@ ngx_ssl_session_rbtree_insert_value(ngx_rbtree_node_t *temp,
 }
 
 
-#ifdef SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB
+#ifdef ngx_ssl_set_ticket_key_callback
 
 ngx_int_t
 ngx_ssl_session_ticket_keys(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *paths)
@@ -4826,7 +4840,7 @@ ngx_ssl_session_ticket_keys(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *paths)
         return NGX_ERROR;
     }
 
-    if (SSL_CTX_set_tlsext_ticket_key_cb(ssl->ctx, ngx_ssl_ticket_key_callback)
+    if (ngx_ssl_set_ticket_key_callback(ssl->ctx, ngx_ssl_ticket_key_callback)
         == 0)
     {
         ngx_log_error(NGX_LOG_WARN, cf->log, 0,
@@ -4948,7 +4962,7 @@ failed:
 static int
 ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
     unsigned char *name, unsigned char *iv, EVP_CIPHER_CTX *ectx,
-    HMAC_CTX *hctx, int enc)
+    ngx_ssl_ticket_key_mac_ctx_t *hctx, int enc)
 {
     size_t                 size;
     SSL_CTX               *ssl_ctx;
@@ -4956,7 +4970,6 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
     ngx_array_t           *keys;
     ngx_connection_t      *c;
     ngx_ssl_ticket_key_t  *key;
-    const EVP_MD          *digest;
     const EVP_CIPHER      *cipher;
 
     c = ngx_ssl_get_connection(ssl_conn);
@@ -4965,12 +4978,6 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
     if (ngx_ssl_rotate_ticket_keys(ssl_ctx, c->log) != NGX_OK) {
         return -1;
     }
-
-#ifdef OPENSSL_NO_SHA256
-    digest = EVP_sha1();
-#else
-    digest = EVP_sha256();
-#endif
 
     keys = SSL_CTX_get_ex_data(ssl_ctx, ngx_ssl_ticket_keys_index);
     if (keys == NULL) {
@@ -5007,14 +5014,9 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
             return -1;
         }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-        if (HMAC_Init_ex(hctx, key[0].hmac_key, size, digest, NULL) != 1) {
-            ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
+        if (ngx_ssl_ticket_key_mac_init(c, &key[0], size, hctx) != NGX_OK) {
             return -1;
         }
-#else
-        HMAC_Init_ex(hctx, key[0].hmac_key, size, digest, NULL);
-#endif
 
         ngx_memcpy(name, key[0].name, 16);
 
@@ -5050,14 +5052,9 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
             size = 32;
         }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-        if (HMAC_Init_ex(hctx, key[i].hmac_key, size, digest, NULL) != 1) {
-            ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
+        if (ngx_ssl_ticket_key_mac_init(c, &key[i], size, hctx) != NGX_OK) {
             return -1;
         }
-#else
-        HMAC_Init_ex(hctx, key[i].hmac_key, size, digest, NULL);
-#endif
 
         if (EVP_DecryptInit_ex(ectx, cipher, NULL, key[i].aes_key, iv) != 1) {
             ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
@@ -5081,6 +5078,52 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
 
         return 1;
     }
+}
+
+
+static ngx_int_t
+ngx_ssl_ticket_key_mac_init(ngx_connection_t *c, ngx_ssl_ticket_key_t *key,
+    size_t size, ngx_ssl_ticket_key_mac_ctx_t *hctx)
+{
+#if (NGX_SSL_TICKET_KEY_EVP_CB)
+    char        *digest;
+    OSSL_PARAM   params[2];
+
+#ifdef OPENSSL_NO_SHA256
+    digest = (char *) OSSL_DIGEST_NAME_SHA1;
+#else
+    digest = (char *) OSSL_DIGEST_NAME_SHA2_256;
+#endif
+
+    params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
+                                                 digest, 0);
+    params[1] = OSSL_PARAM_construct_end();
+
+    if (EVP_MAC_init(hctx, key->hmac_key, size, params) != 1) {
+        ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "EVP_MAC_init() failed");
+        return NGX_ERROR;
+    }
+
+#else
+    const EVP_MD  *digest;
+
+#ifdef OPENSSL_NO_SHA256
+    digest = EVP_sha1();
+#else
+    digest = EVP_sha256();
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+    if (HMAC_Init_ex(hctx, key->hmac_key, size, digest, NULL) != 1) {
+        ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
+        return NGX_ERROR;
+    }
+#else
+    HMAC_Init_ex(hctx, key->hmac_key, size, digest, NULL);
+#endif
+#endif
+
+    return NGX_OK;
 }
 
 

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -17,11 +17,11 @@
 #define NGX_SSL_PASSWORD_BUFFER_SIZE  4096
 
 
-#if (NGX_SSL_TICKET_KEY_EVP_CB)
-#define ngx_ssl_ticket_key_mac_ctx_t        EVP_MAC_CTX
-
-#elif defined SSL_CTX_set_tlsext_ticket_key_cb
+#ifdef SSL_CTX_set_tlsext_ticket_key_cb
 #define ngx_ssl_ticket_key_mac_ctx_t        HMAC_CTX
+
+#elif (NGX_SSL_TICKET_KEY_EVP_CB)
+#define ngx_ssl_ticket_key_mac_ctx_t        EVP_MAC_CTX
 
 #endif
 
@@ -82,7 +82,7 @@ static void ngx_ssl_expire_sessions(ngx_ssl_session_cache_t *cache,
 static void ngx_ssl_session_rbtree_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
 
-#if (NGX_SSL_TICKET_KEY_EVP_CB) || defined SSL_CTX_set_tlsext_ticket_key_cb
+#if defined SSL_CTX_set_tlsext_ticket_key_cb || (NGX_SSL_TICKET_KEY_EVP_CB)
 static int ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
     unsigned char *name, unsigned char *iv, EVP_CIPHER_CTX *ectx,
     ngx_ssl_ticket_key_mac_ctx_t *hctx, int enc);
@@ -4796,7 +4796,7 @@ ngx_ssl_session_rbtree_insert_value(ngx_rbtree_node_t *temp,
 }
 
 
-#if (NGX_SSL_TICKET_KEY_EVP_CB) || defined SSL_CTX_set_tlsext_ticket_key_cb
+#if defined SSL_CTX_set_tlsext_ticket_key_cb || (NGX_SSL_TICKET_KEY_EVP_CB)
 
 ngx_int_t
 ngx_ssl_session_ticket_keys(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *paths)
@@ -4838,14 +4838,14 @@ ngx_ssl_session_ticket_keys(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *paths)
         return NGX_ERROR;
     }
 
-#if (NGX_SSL_TICKET_KEY_EVP_CB)
-    if (SSL_CTX_set_tlsext_ticket_key_evp_cb(ssl->ctx,
-                                             ngx_ssl_ticket_key_callback)
-        == 0)
-
-#elif defined SSL_CTX_set_tlsext_ticket_key_cb
+#ifdef SSL_CTX_set_tlsext_ticket_key_cb
     if (SSL_CTX_set_tlsext_ticket_key_cb(ssl->ctx,
                                          ngx_ssl_ticket_key_callback)
+        == 0)
+
+#elif (NGX_SSL_TICKET_KEY_EVP_CB)
+    if (SSL_CTX_set_tlsext_ticket_key_evp_cb(ssl->ctx,
+                                             ngx_ssl_ticket_key_callback)
         == 0)
 
 #endif

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5092,22 +5092,7 @@ static ngx_int_t
 ngx_ssl_ticket_key_mac_init(ngx_connection_t *c, ngx_ssl_ticket_key_t *key,
     size_t size, ngx_ssl_ticket_key_mac_ctx_t *hctx)
 {
-#if (NGX_SSL_TICKET_KEY_EVP_CB)
-    char        *digest;
-    OSSL_PARAM   params[2];
-
-    digest = (char *) OSSL_DIGEST_NAME_SHA2_256;
-
-    params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
-                                                 digest, 0);
-    params[1] = OSSL_PARAM_construct_end();
-
-    if (EVP_MAC_init(hctx, key->hmac_key, size, params) != 1) {
-        ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "EVP_MAC_init() failed");
-        return NGX_ERROR;
-    }
-
-#else
+#ifdef SSL_CTX_set_tlsext_ticket_key_cb
     const EVP_MD  *digest;
 
 #ifdef OPENSSL_NO_SHA256
@@ -5124,6 +5109,21 @@ ngx_ssl_ticket_key_mac_init(ngx_connection_t *c, ngx_ssl_ticket_key_t *key,
 #else
     HMAC_Init_ex(hctx, key->hmac_key, size, digest, NULL);
 #endif
+
+#elif (NGX_SSL_TICKET_KEY_EVP_CB)
+    char        *digest;
+    OSSL_PARAM   params[2];
+
+    digest = (char *) OSSL_DIGEST_NAME_SHA2_256;
+
+    params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
+                                                 digest, 0);
+    params[1] = OSSL_PARAM_construct_end();
+
+    if (EVP_MAC_init(hctx, key->hmac_key, size, params) != 1) {
+        ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "EVP_MAC_init() failed");
+        return NGX_ERROR;
+    }
 #endif
 
     return NGX_OK;

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -19,11 +19,9 @@
 
 #if (NGX_SSL_TICKET_KEY_EVP_CB)
 #define ngx_ssl_ticket_key_mac_ctx_t        EVP_MAC_CTX
-#define ngx_ssl_set_ticket_key_callback     SSL_CTX_set_tlsext_ticket_key_evp_cb
 
 #elif defined SSL_CTX_set_tlsext_ticket_key_cb
 #define ngx_ssl_ticket_key_mac_ctx_t        HMAC_CTX
-#define ngx_ssl_set_ticket_key_callback     SSL_CTX_set_tlsext_ticket_key_cb
 
 #endif
 
@@ -84,7 +82,7 @@ static void ngx_ssl_expire_sessions(ngx_ssl_session_cache_t *cache,
 static void ngx_ssl_session_rbtree_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
 
-#ifdef ngx_ssl_set_ticket_key_callback
+#if (NGX_SSL_TICKET_KEY_EVP_CB) || defined SSL_CTX_set_tlsext_ticket_key_cb
 static int ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
     unsigned char *name, unsigned char *iv, EVP_CIPHER_CTX *ectx,
     ngx_ssl_ticket_key_mac_ctx_t *hctx, int enc);
@@ -4798,7 +4796,7 @@ ngx_ssl_session_rbtree_insert_value(ngx_rbtree_node_t *temp,
 }
 
 
-#ifdef ngx_ssl_set_ticket_key_callback
+#if (NGX_SSL_TICKET_KEY_EVP_CB) || defined SSL_CTX_set_tlsext_ticket_key_cb
 
 ngx_int_t
 ngx_ssl_session_ticket_keys(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *paths)
@@ -4840,8 +4838,17 @@ ngx_ssl_session_ticket_keys(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *paths)
         return NGX_ERROR;
     }
 
-    if (ngx_ssl_set_ticket_key_callback(ssl->ctx, ngx_ssl_ticket_key_callback)
+#if (NGX_SSL_TICKET_KEY_EVP_CB)
+    if (SSL_CTX_set_tlsext_ticket_key_evp_cb(ssl->ctx,
+                                             ngx_ssl_ticket_key_callback)
         == 0)
+
+#elif defined SSL_CTX_set_tlsext_ticket_key_cb
+    if (SSL_CTX_set_tlsext_ticket_key_cb(ssl->ctx,
+                                         ngx_ssl_ticket_key_callback)
+        == 0)
+
+#endif
     {
         ngx_log_error(NGX_LOG_WARN, cf->log, 0,
                       "nginx was built with Session Tickets support, however, "

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5089,11 +5089,7 @@ ngx_ssl_ticket_key_mac_init(ngx_connection_t *c, ngx_ssl_ticket_key_t *key,
     char        *digest;
     OSSL_PARAM   params[2];
 
-#ifdef OPENSSL_NO_SHA256
-    digest = (char *) OSSL_DIGEST_NAME_SHA1;
-#else
     digest = (char *) OSSL_DIGEST_NAME_SHA2_256;
-#endif
 
     params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
                                                  digest, 0);

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -26,10 +26,7 @@
 #include <openssl/engine.h>
 #endif
 #include <openssl/evp.h>
-#if (OPENSSL_VERSION_NUMBER >= 0x30000000L                                  \
-     && !defined LIBRESSL_VERSION_NUMBER                                    \
-     && !defined OPENSSL_IS_BORINGSSL                                       \
-     && !defined OPENSSL_IS_AWSLC)
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
 #include <openssl/core_names.h>
 #endif
 #include <openssl/hmac.h>
@@ -94,10 +91,7 @@
 #endif
 
 
-#if (OPENSSL_VERSION_NUMBER >= 0x30000000L                                  \
-     && !defined LIBRESSL_VERSION_NUMBER                                    \
-     && !defined OPENSSL_IS_BORINGSSL                                       \
-     && !defined OPENSSL_IS_AWSLC)
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
 #define NGX_SSL_TICKET_KEY_EVP_CB  1
 #endif
 

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -26,6 +26,12 @@
 #include <openssl/engine.h>
 #endif
 #include <openssl/evp.h>
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L                                  \
+     && !defined LIBRESSL_VERSION_NUMBER                                    \
+     && !defined OPENSSL_IS_BORINGSSL                                       \
+     && !defined OPENSSL_IS_AWSLC)
+#include <openssl/core_names.h>
+#endif
 #include <openssl/hmac.h>
 #ifndef OPENSSL_NO_OCSP
 #include <openssl/ocsp.h>
@@ -85,6 +91,14 @@
 
 #ifdef OPENSSL_NO_DEPRECATED_3_0
 #define EVP_CIPHER_CTX_cipher(c)     EVP_CIPHER_CTX_get0_cipher(c)
+#endif
+
+
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L                                  \
+     && !defined LIBRESSL_VERSION_NUMBER                                    \
+     && !defined OPENSSL_IS_BORINGSSL                                       \
+     && !defined OPENSSL_IS_AWSLC)
+#define NGX_SSL_TICKET_KEY_EVP_CB  1
 #endif
 
 


### PR DESCRIPTION
Use `SSL_CTX_set_tlsext_ticket_key_evp_cb()` with `EVP_MAC_init()` when
OpenSSL 3 APIs are available for session ticket keys.

Keep the legacy `SSL_CTX_set_tlsext_ticket_key_cb()` and `HMAC_Init_ex()`
path for TLS libraries which do not provide the EVP callback.

### Proposed changes

Closes #981.

This change adds dual support for session ticket key callbacks.

When OpenSSL 3 EVP ticket callback APIs are available, nginx now uses
`SSL_CTX_set_tlsext_ticket_key_evp_cb()` together with `EVP_MAC_init()`
for HMAC setup. For TLS libraries which do not provide the EVP callback,
the existing `SSL_CTX_set_tlsext_ticket_key_cb()` and `HMAC_Init_ex()`
path is kept unchanged.

The ticket key rotation, encryption, decryption, and renewal logic are
left intact. The change is limited to selecting the appropriate callback
API and MAC initialization path.

Verified locally by building:
- with OpenSSL 3.6.1
- with OpenSSL 3.6.1 and `OPENSSL_NO_DEPRECATED_3_0`

`nginx-tests/ssl_session_ticket_key.t` was also run locally, but it failed
the same way on this branch and on clean `master`, so it did not indicate
a regression introduced by this change.

### Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
