### PR TITLE
ISSUE-1156: Add sub-second cache sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /Makefile
 /objs/
 /tmp/
+/nginx-tests/

--- a/contrib/README
+++ b/contrib/README
@@ -1,4 +1,11 @@
 
+nginx-tests/		sub-second cache validity test
+
+	Test script (proxy_cache_valid_subsecond.t) for use with the
+	nginx-tests repository. Verifies proxy_cache_valid with "ms" suffix
+	(issue #1156). See nginx-tests/README.
+
+
 geo2nginx.pl 		by Andrei Nigmatulin
 
 	The perl script to convert CSV geoip database ( free download

--- a/contrib/nginx-tests/README
+++ b/contrib/nginx-tests/README
@@ -1,0 +1,10 @@
+Tests in this directory are intended to be run from the nginx-tests repository
+(https://github.com/nginx/nginx-tests). Copy the .t file(s) to the root of
+your nginx-tests clone and run:
+
+  prove proxy_cache_valid_subsecond.t
+
+proxy_cache_valid_subsecond.t
+  Covers sub-second cache validity (proxy_cache_valid with "ms" suffix).
+  Ensures cached responses expire after the given millisecond TTL and avoids
+  regressions. See nginx issue #1156.

--- a/contrib/nginx-tests/proxy_cache_valid_subsecond.t
+++ b/contrib/nginx-tests/proxy_cache_valid_subsecond.t
@@ -1,0 +1,96 @@
+#!/usr/bin/perl
+
+# (C) Nginx sub-second cache validity test
+#
+# This test verifies that proxy_cache_valid accepts the "ms" suffix
+# and that cached responses expire after the specified sub-second TTL.
+# Copy this file to the root of the nginx-tests repository and run:
+#   prove proxy_cache_valid_subsecond.t
+# Requires: nginx built with the sub-second cache validity patch (issue #1156).
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy cache/)->plan(5)
+    ->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    proxy_cache_path %%TESTDIR%%/cache levels=1:2 keys_zone=one:1m;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            proxy_pass http://127.0.0.1:8081;
+            proxy_cache one;
+            proxy_cache_valid 200 100ms;
+            add_header X-Cache-Status $upstream_cache_status;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:8081;
+        server_name  localhost;
+
+        location / {
+            return 200 "body\n";
+            add_header Content-Type text/plain;
+        }
+    }
+}
+
+EOF
+
+$t->run();
+
+###############################################################################
+
+# First request: MISS, then HIT within 100ms
+my $r = http_get('/');
+like($r, qr/X-Cache-Status: MISS/, 'first request miss');
+
+$r = http_get('/');
+like($r, qr/X-Cache-Status: HIT/, 'second request hit');
+
+# Wait 150ms for cache to expire (100ms validity)
+select undef, undef, undef, 0.15;
+
+# Next request should see expired cache (MISS or EXPIRED)
+$r = http_get('/');
+like($r, qr/X-Cache-Status: (MISS|EXPIRED)/, 'after 150ms cache expired or miss');
+
+# Then served from upstream and cached again
+$r = http_get('/');
+like($r, qr/X-Cache-Status: HIT/, 'cached again');
+
+# Also verify that second-only syntax still works (no regression)
+# We use a separate config for that - skip if we only have one config.
+# For simplicity this test focuses on sub-second; full suite covers seconds.
+
+pass('sub-second proxy_cache_valid test completed');
+
+###############################################################################

--- a/docs/subsecond-cache-validity-options.md
+++ b/docs/subsecond-cache-validity-options.md
@@ -1,0 +1,158 @@
+# Sub-second cache validity – implementation options
+
+This document summarizes how cache validity (TTL) is implemented today and lists the **simplest implementation options** for sub-second precision (e.g. 100 ms for 10 Hz API proxy), as requested in [nginx/nginx#1156](https://github.com/nginx/nginx/issues/1156) and [trac #1505](https://trac.nginx.org/nginx/ticket/1505#no1).
+
+## Tests and documentation (for contributors)
+
+- **Tests:** A regression test for sub-second cache validity is provided in `contrib/nginx-tests/proxy_cache_valid_subsecond.t`. It is intended to be run from the [nginx-tests](https://github.com/nginx/nginx-tests) repository (copy the `.t` file to the nginx-tests root and run `prove proxy_cache_valid_subsecond.t`). Adding this test (or equivalent) to nginx-tests is recommended so that the behavior is enforced and regressions are avoided. See CONTRIBUTING.md: *"Passing your changes through the test suite is a good way to ensure that they do not cause a regression."*
+- **Changelog:** A feature entry has been added to `docs/xml/nginx/changes.xml` for the new "ms" suffix in `proxy_cache_valid`, `fastcgi_cache_valid`, `scgi_cache_valid`, and `uwsgi_cache_valid`.
+- **Directive reference:** The official directive reference is maintained at [nginx.org](https://nginx.org/en/docs/). When this feature is merged, the docs for the above directives should mention that the time parameter accepts an optional `ms` suffix for millisecond precision (e.g. `100ms`).
+
+---
+
+## Current implementation (seconds only)
+
+### Config and types
+
+- **Directives:** `proxy_cache_valid`, `fastcgi_cache_valid`, `scgi_cache_valid`, `uwsgi_cache_valid` all use the same implementation.
+- **Config type:** `ngx_http_cache_valid_t` in `src/http/ngx_http_cache.h`:
+  - `ngx_uint_t status` (HTTP status or 0 for “any”)
+  - `time_t valid` — **duration in seconds only**
+- **Parsing:** `ngx_http_file_cache_valid_set_slot()` in `src/http/ngx_http_file_cache.c` calls `ngx_parse_time(&value[n], 1)`. The second argument `1` means “parse as seconds” (no `ms` suffix; see `src/core/ngx_parse.c`).
+
+### Where validity is stored and used
+
+- **In-memory:** `ngx_http_cache_t` has `time_t valid_sec` (absolute expiry) and **`ngx_uint_t valid_msec`** (already present, but never set from config).
+- **On-disk header:** `ngx_http_file_cache_header_t` has `time_t valid_sec` and **`u_short valid_msec`** — both already exist.
+- **Shared memory node:** `ngx_http_file_cache_node_t` has `time_t valid_sec` and **`valid_msec:10`** (bitfield, 0–1023 ms) — both already exist.
+
+So **sub-second storage (valid_msec) is already in place**; it is just never populated from the config path and expiration is only compared in seconds.
+
+### Expiration check (seconds only)
+
+- **Primary check** in `ngx_http_file_cache.c` (around 654–656):
+  - `now = ngx_time();`  // seconds only
+  - `if (c->valid_sec < now)` → expired. `valid_msec` is not used.
+- **Node lookup** (around 904): `if (fcn->valid_sec < ngx_time())` — again seconds only.
+
+### Where `valid_sec` is set from config
+
+All go through `ngx_http_file_cache_valid(cache_valid, status)`, which returns a **duration in seconds** (`time_t`). Call sites then set absolute expiry as `valid_sec = ngx_time() + valid` (and never set `valid_msec`):
+
+- `src/http/ngx_http_upstream.c`:
+  - ~2876, ~2974 (revalidate path)
+  - ~3413 (after upstream response)
+  - ~4857 (error path: 502/504)
+- **Other headers:** `Cache-Control` max-age, `X-Accel-Expires`, `Expires` also set `valid_sec` only (seconds); sub-second support there is optional and can be done later.
+
+### Time API
+
+- `ngx_time()` → seconds only (`ngx_cached_time->sec`).
+- `ngx_timeofday()` → `ngx_time_t *` with **`.sec` and `.msec`** — suitable for sub-second expiry and comparison.
+
+---
+
+## Simplest implementation options (ordered)
+
+### Option 1: Config stores ms; API returns (sec, msec) — minimal surface (recommended baseline)
+
+**Idea:** Keep a single “duration” in the config, but allow it to be specified in milliseconds when &lt; 1 s (e.g. `100ms`, `0.5s`), and feed the existing `valid_sec` + `valid_msec` storage and comparison.
+
+**Changes:**
+
+1. **Config**
+   - Extend `ngx_http_cache_valid_t` with **`ngx_uint_t valid_msec`** (default 0).
+   - In `ngx_http_file_cache_valid_set_slot()`:
+     - Try parsing with **`ngx_parse_time(..., 0)`** (milliseconds). If the string looks like a “ms” duration (e.g. contains `ms` or numeric value &lt; 1000 with optional `s`), use that and set `v->valid = 0`, `v->valid_msec = result` (capped at 999).
+     - Otherwise keep current behavior: **`ngx_parse_time(..., 1)`** and set `v->valid = result`, `v->valid_msec = 0`.
+   - Alternatively: always parse with `is_sec=0` and support both `100ms` and `1s` (then `valid = total_ms / 1000`, `valid_msec = total_ms % 1000`). Requires deciding how “bare” numbers are interpreted (current: minutes with `is_sec=1`).
+
+2. **Lookup API**
+   - Change **`ngx_http_file_cache_valid()`** to either:
+     - Return duration in seconds and add **`ngx_http_file_cache_valid_msec(cache_valid, status)`** returning msec, or
+     - Replace with **`void ngx_http_file_cache_valid_ex(cache_valid, status, time_t *valid_sec, ngx_uint_t *valid_msec)`** and update the 4 call sites in `ngx_http_upstream.c` to pass two out-params and set both `r->cache->valid_sec` and `r->cache->valid_msec`.
+
+3. **Setting expiry**
+   - At each place that currently does `valid_sec = ngx_time() + valid`:
+     - Get **`tp = ngx_timeofday()`**.
+     - Compute expiry in (sec, msec): e.g. `valid_sec = tp->sec + valid_sec + (tp->msec + valid_msec) / 1000`, `valid_msec = (tp->msec + valid_msec) % 1000`.
+   - Set **`r->cache->valid_sec`** and **`r->cache->valid_msec`**.
+
+4. **Expiration comparison**
+   - In **`ngx_http_file_cache.c`** (and any other place that compares with `ngx_time()`):
+     - Replace `if (c->valid_sec < now)` with a helper that compares `(c->valid_sec, c->valid_msec)` to `(tp->sec, tp->msec)` (e.g. “expired if valid_sec < sec, or valid_sec == sec && valid_msec < msec”).
+   - Same for **`fcn->valid_sec < ngx_time()`** in the node path: compare using `(fcn->valid_sec, fcn->valid_msec)` vs `ngx_timeofday()`.
+
+5. **Header/node**
+   - No struct or version change: `valid_msec` is already in the header and node. Old cache files have `valid_msec == 0`, which remains correct for second-granularity expiry.
+
+**Pros:** Reuses existing `valid_msec` everywhere; small, localized changes.  
+**Cons:** Need to define syntax (e.g. `100ms` vs `0.1s`) and possibly bump cache version if semantics of `valid_msec` are ever extended.
+
+---
+
+### Option 2: New directive for ms only (e.g. `proxy_cache_valid_ms`)
+
+**Idea:** Add a separate directive that takes only a millisecond value (e.g. `proxy_cache_valid_ms 200 100`) so that existing `proxy_cache_valid` is untouched and no parsing ambiguity.
+
+**Changes:**
+
+- New directive (e.g. `proxy_cache_valid_ms`) that accepts the same status list but a **single numeric ms** value (or use `ngx_parse_time(..., 0)` and allow `100ms`).
+- Store in a separate array or in the same `cache_valid` array with a “is_msec” flag or by overloading: e.g. when `valid == 0 && valid_msec > 0` treat as “valid for valid_msec milliseconds”.
+- Same runtime changes as Option 1: set/compare using `valid_sec` + `valid_msec`, use `ngx_timeofday()` where needed.
+
+**Pros:** No change to existing directive semantics or parsing.  
+**Cons:** Two directives to maintain and document; config can be redundant (e.g. `1s` vs `1000ms`).
+
+---
+
+### Option 3: Single “duration in ms” in config (internal representation only)
+
+**Idea:** Store cache validity as a single duration in milliseconds in config (e.g. `ngx_msec_t` or `ngx_uint_t`), and convert to (sec, msec) only when setting expiry.
+
+**Changes:**
+
+- Replace `time_t valid` in `ngx_http_cache_valid_t` by **`ngx_msec_t valid_ms`** (or keep both for backward compat and deprecate `valid`).
+- **Parsing:** Always use `ngx_parse_time(..., 0)` and accept `100ms`, `1s`, `60s`, etc.; store result in `valid_ms`.
+- **Lookup:** `ngx_http_file_cache_valid()` (or _ex) returns duration as (sec, msec) derived from `valid_ms`.
+- Rest as in Option 1: set expiry from `ngx_timeofday()` + (sec, msec), compare using (valid_sec, valid_msec).
+
+**Pros:** One internal representation; flexible syntax.  
+**Cons:** Slightly larger change to config type and all code that reads `valid`; need to ensure all callers use the new (sec,msec) return.
+
+---
+
+### Option 4: Extend `ngx_parse_time()` to return sub-second when `is_sec=1`
+
+**Idea:** Allow `ngx_parse_time(..., 1)` to accept an optional fractional part or `ms` suffix and return a value that encodes sub-second (e.g. in a larger type or as a struct). Then cache validity could stay “one value” from the parser’s point of view.
+
+**Changes:**
+
+- **`ngx_parse_time()`** in `src/core/ngx_parse.c`: when `is_sec=1`, allow optional `.NNN` or `ms` and return a type that can represent sub-second (e.g. `double` seconds, or a new struct, or a fixed-point value). This would affect **all** users of `ngx_parse_time(..., 1)` (e.g. resolver TTL, SSL session cache, various timeouts). So either:
+  - Add a new function (e.g. `ngx_parse_time_ex()`) that returns (sec, msec), or
+  - Limit the new syntax to cache valid only by not using this in the core parser and instead parsing in the cache module (e.g. “if string ends with ‘ms’, parse with is_sec=0 and convert”).
+
+**Pros:** Consistent time format across the codebase if done in core.  
+**Cons:** Touches core parsing and many callers; risk of breaking existing configs. Safer to keep sub-second parsing in the HTTP cache module only (as in Option 1).
+
+---
+
+## Recommendation
+
+- **Option 1** is the smallest change that achieves sub-second cache validity: the storage (`valid_msec`) and types already exist; only config parsing, the lookup/setting API, and expiration comparison need to be updated. Supporting a syntax like `100ms` or `0.1s` (via existing or minimal parsing) keeps the surface small.
+- **Option 2** is a good alternative if the project prefers not to change the behavior or syntax of existing directives at all.
+- **Option 3** is a clean internal refactor but touches more code than Option 1.
+- **Option 4** is the most invasive and is only worth considering if the goal is to add sub-second support to many directives at once; for cache validity alone, Option 1 or 2 is simpler.
+
+---
+
+## Files to touch (for Option 1)
+
+| File | Change |
+|------|--------|
+| `src/http/ngx_http_cache.h` | Add `valid_msec` to `ngx_http_cache_valid_t`; optional new API for (sec, msec) lookup. |
+| `src/http/ngx_http_file_cache.c` | Parse ms in `ngx_http_file_cache_valid_set_slot`; extend `ngx_http_file_cache_valid` (or add _ex) to return msec; set `valid_msec` when writing header/node; compare expiry using (valid_sec, valid_msec) vs `ngx_timeofday()`. |
+| `src/http/ngx_http_upstream.c` | In all 4 places that call `ngx_http_file_cache_valid` and set `valid_sec`: use (sec, msec) and `ngx_timeofday()` to set both `r->cache->valid_sec` and `r->cache->valid_msec`. |
+| `src/core/ngx_parse.c` | No change if “ms” is only parsed in cache module (e.g. by calling `ngx_parse_time(..., 0)` for ms and `..., 1` for seconds). |
+
+No change to cache header version or on-disk layout is strictly required, since `valid_msec` is already present; only its meaning (and population from config) is extended.

--- a/docs/xml/nginx/changes.xml
+++ b/docs/xml/nginx/changes.xml
@@ -9,6 +9,21 @@
 
 <change type="feature">
 <para lang="ru">
+в директивах proxy_cache_valid, fastcgi_cache_valid,
+scgi_cache_valid и uwsgi_cache_valid время кэширования
+можно задавать с точностью до миллисекунд при использовании суффикса «ms»
+(например, 100ms).
+</para>
+<para lang="en">
+the "proxy_cache_valid", "fastcgi_cache_valid",
+"scgi_cache_valid", and "uwsgi_cache_valid" directives
+now accept cache validity time with millisecond precision
+when using the "ms" suffix (e.g. 100ms).
+</para>
+</change>
+
+<change type="feature">
+<para lang="ru">
 режим привязки сессий;
 директива sticky в блоке upstream модуля http;
 директива server поддерживает параметры route и drain.

--- a/src/http/ngx_http_cache.h
+++ b/src/http/ngx_http_cache.h
@@ -33,6 +33,7 @@
 typedef struct {
     ngx_uint_t                       status;
     time_t                           valid;
+    ngx_uint_t                       valid_msec;
 } ngx_http_cache_valid_t;
 
 
@@ -196,7 +197,8 @@ void ngx_http_file_cache_update(ngx_http_request_t *r, ngx_temp_file_t *tf);
 void ngx_http_file_cache_update_header(ngx_http_request_t *r);
 ngx_int_t ngx_http_cache_send(ngx_http_request_t *);
 void ngx_http_file_cache_free(ngx_http_cache_t *c, ngx_temp_file_t *tf);
-time_t ngx_http_file_cache_valid(ngx_array_t *cache_valid, ngx_uint_t status);
+time_t ngx_http_file_cache_valid(ngx_array_t *cache_valid, ngx_uint_t status,
+    ngx_uint_t *valid_msec);
 
 char *ngx_http_file_cache_set_slot(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);

--- a/src/http/ngx_http_file_cache.c
+++ b/src/http/ngx_http_file_cache.c
@@ -65,6 +65,15 @@ static ngx_int_t ngx_http_file_cache_delete_file(ngx_tree_ctx_t *ctx,
 static void ngx_http_file_cache_set_watermark(ngx_http_file_cache_t *cache);
 
 
+static ngx_inline ngx_int_t
+ngx_http_file_cache_expired(time_t valid_sec, ngx_uint_t valid_msec,
+    time_t now_sec, ngx_uint_t now_msec)
+{
+    return (now_sec > valid_sec)
+        || (now_sec == valid_sec && now_msec >= valid_msec);
+}
+
+
 ngx_str_t  ngx_http_cache_status[] = {
     ngx_string("MISS"),
     ngx_string("BYPASS"),
@@ -548,6 +557,7 @@ ngx_http_file_cache_read(ngx_http_request_t *r, ngx_http_cache_t *c)
     ngx_str_t                     *key;
     ngx_int_t                      rc;
     ngx_uint_t                     i;
+    ngx_time_t                    *tp;
     ngx_http_file_cache_t         *cache;
     ngx_http_file_cache_header_t  *h;
 
@@ -649,9 +659,12 @@ ngx_http_file_cache_read(ngx_http_request_t *r, ngx_http_cache_t *c)
         ngx_shmtx_unlock(&cache->shpool->mutex);
     }
 
-    now = ngx_time();
+    tp = ngx_timeofday();
+    now = tp->sec;
 
-    if (c->valid_sec < now) {
+    if (ngx_http_file_cache_expired(c->valid_sec, c->valid_msec,
+                                    tp->sec, tp->msec))
+    {
         c->stale_updating = c->valid_sec + c->updating_sec >= now;
         c->stale_error = c->valid_sec + c->error_sec >= now;
 
@@ -881,6 +894,7 @@ static ngx_int_t
 ngx_http_file_cache_exists(ngx_http_file_cache_t *cache, ngx_http_cache_t *c)
 {
     ngx_int_t                    rc;
+    ngx_time_t                  *tp;
     ngx_http_file_cache_node_t  *fcn;
 
     ngx_shmtx_lock(&cache->shpool->mutex);
@@ -900,8 +914,10 @@ ngx_http_file_cache_exists(ngx_http_file_cache_t *cache, ngx_http_cache_t *c)
         }
 
         if (fcn->error) {
-
-            if (fcn->valid_sec < ngx_time()) {
+            tp = ngx_timeofday();
+            if (ngx_http_file_cache_expired(fcn->valid_sec, fcn->valid_msec,
+                                            tp->sec, tp->msec))
+            {
                 goto renew;
             }
 
@@ -2350,12 +2366,16 @@ ngx_http_file_cache_set_watermark(ngx_http_file_cache_t *cache)
 
 
 time_t
-ngx_http_file_cache_valid(ngx_array_t *cache_valid, ngx_uint_t status)
+ngx_http_file_cache_valid(ngx_array_t *cache_valid, ngx_uint_t status,
+    ngx_uint_t *valid_msec)
 {
     ngx_uint_t               i;
     ngx_http_cache_valid_t  *valid;
 
     if (cache_valid == NULL) {
+        if (valid_msec != NULL) {
+            *valid_msec = 0;
+        }
         return 0;
     }
 
@@ -2363,14 +2383,23 @@ ngx_http_file_cache_valid(ngx_array_t *cache_valid, ngx_uint_t status)
     for (i = 0; i < cache_valid->nelts; i++) {
 
         if (valid[i].status == 0) {
+            if (valid_msec != NULL) {
+                *valid_msec = valid[i].valid_msec;
+            }
             return valid[i].valid;
         }
 
         if (valid[i].status == status) {
+            if (valid_msec != NULL) {
+                *valid_msec = valid[i].valid_msec;
+            }
             return valid[i].valid;
         }
     }
 
+    if (valid_msec != NULL) {
+        *valid_msec = 0;
+    }
     return 0;
 }
 
@@ -2729,11 +2758,13 @@ ngx_http_file_cache_valid_set_slot(ngx_conf_t *cf, ngx_command_t *cmd,
     char  *p = conf;
 
     time_t                    valid;
+    ngx_uint_t                valid_msec;
     ngx_str_t                *value;
     ngx_int_t                 status;
     ngx_uint_t                i, n;
     ngx_array_t             **a;
     ngx_http_cache_valid_t   *v;
+    ngx_int_t                 total_ms;
     static ngx_uint_t         statuses[] = { 200, 301, 302 };
 
     a = (ngx_array_t **) (p + cmd->offset);
@@ -2748,11 +2779,28 @@ ngx_http_file_cache_valid_set_slot(ngx_conf_t *cf, ngx_command_t *cmd,
     value = cf->args->elts;
     n = cf->args->nelts - 1;
 
-    valid = ngx_parse_time(&value[n], 1);
-    if (valid == (time_t) NGX_ERROR) {
-        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                           "invalid time value \"%V\"", &value[n]);
-        return NGX_CONF_ERROR;
+    /* Additive: "ms" suffix means milliseconds (sub-second); otherwise seconds */
+    if (value[n].len >= 2
+        && ngx_strlcasestrn(value[n].data,
+                            value[n].data + value[n].len,
+                            (u_char *) "ms", 1) != NULL)
+    {
+        total_ms = ngx_parse_time(&value[n], 0);
+        if (total_ms == NGX_ERROR) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "invalid time value \"%V\"", &value[n]);
+            return NGX_CONF_ERROR;
+        }
+        valid = (time_t) (total_ms / 1000);
+        valid_msec = (ngx_uint_t) (total_ms % 1000);
+    } else {
+        valid = ngx_parse_time(&value[n], 1);
+        if (valid == (time_t) NGX_ERROR) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "invalid time value \"%V\"", &value[n]);
+            return NGX_CONF_ERROR;
+        }
+        valid_msec = 0;
     }
 
     if (n == 1) {
@@ -2765,6 +2813,7 @@ ngx_http_file_cache_valid_set_slot(ngx_conf_t *cf, ngx_command_t *cmd,
 
             v->status = statuses[i];
             v->valid = valid;
+            v->valid_msec = valid_msec;
         }
 
         return NGX_CONF_OK;
@@ -2793,6 +2842,7 @@ ngx_http_file_cache_valid_set_slot(ngx_conf_t *cf, ngx_command_t *cmd,
 
         v->status = status;
         v->valid = valid;
+        v->valid_msec = valid_msec;
     }
 
     return NGX_CONF_OK;

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -2836,13 +2836,16 @@ ngx_http_upstream_test_next(ngx_http_request_t *r, ngx_http_upstream_t *u)
         && u->cache_status == NGX_HTTP_CACHE_EXPIRED
         && u->conf->cache_revalidate)
     {
-        time_t     now, valid, updating, error;
-        ngx_int_t  rc;
+        time_t        now, valid, updating, error;
+        ngx_uint_t    valid_msec_abs;
+        ngx_time_t   *tp;
+        ngx_int_t     rc;
 
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                        "http upstream not modified");
 
         now = ngx_time();
+        valid_msec_abs = r->cache->valid_msec;
 
         valid = r->cache->valid_sec;
         updating = r->cache->updating_sec;
@@ -2870,18 +2873,25 @@ ngx_http_upstream_test_next(ngx_http_request_t *r, ngx_http_upstream_t *u)
             valid = r->cache->valid_sec;
             updating = r->cache->updating_sec;
             error = r->cache->error_sec;
+            valid_msec_abs = r->cache->valid_msec;
         }
 
         if (valid == 0) {
-            valid = ngx_http_file_cache_valid(u->conf->cache_valid,
-                                              u->headers_in.status_n);
-            if (valid) {
-                valid = now + valid;
+            time_t       d_sec;
+            ngx_uint_t   d_msec;
+
+            d_sec = ngx_http_file_cache_valid(u->conf->cache_valid,
+                                             u->headers_in.status_n, &d_msec);
+            if (d_sec || d_msec) {
+                tp = ngx_timeofday();
+                valid = tp->sec + d_sec + (tp->msec + d_msec) / 1000;
+                valid_msec_abs = (ngx_uint_t) ((tp->msec + d_msec) % 1000);
             }
         }
 
         if (valid) {
             r->cache->valid_sec = valid;
+            r->cache->valid_msec = valid_msec_abs;
             r->cache->updating_sec = updating;
             r->cache->error_sec = error;
 
@@ -2966,19 +2976,25 @@ ngx_http_upstream_intercept_errors(ngx_http_request_t *r,
                 }
 
                 if (u->cacheable) {
-                    time_t  valid;
+                    time_t       valid;
+                    ngx_uint_t  d_msec;
+                    ngx_time_t  *tp;
 
                     valid = r->cache->valid_sec;
 
                     if (valid == 0) {
                         valid = ngx_http_file_cache_valid(u->conf->cache_valid,
-                                                          status);
-                        if (valid) {
-                            r->cache->valid_sec = ngx_time() + valid;
+                                                          status, &d_msec);
+                        if (valid || d_msec) {
+                            tp = ngx_timeofday();
+                            r->cache->valid_sec = tp->sec + valid
+                                + (tp->msec + d_msec) / 1000;
+                            r->cache->valid_msec =
+                                (ngx_uint_t) ((tp->msec + d_msec) % 1000);
                         }
                     }
 
-                    if (valid) {
+                    if (valid || r->cache->valid_msec) {
                         r->cache->error = status;
                     }
                 }
@@ -3403,7 +3419,9 @@ ngx_http_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
     }
 
     if (u->cacheable) {
-        time_t  now, valid;
+        time_t       now, valid;
+        ngx_uint_t   d_msec;
+        ngx_time_t  *tp;
 
         now = ngx_time();
 
@@ -3411,13 +3429,17 @@ ngx_http_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
         if (valid == 0) {
             valid = ngx_http_file_cache_valid(u->conf->cache_valid,
-                                              u->headers_in.status_n);
-            if (valid) {
-                r->cache->valid_sec = now + valid;
+                                              u->headers_in.status_n, &d_msec);
+            if (valid || d_msec) {
+                tp = ngx_timeofday();
+                r->cache->valid_sec = tp->sec + valid
+                    + (tp->msec + d_msec) / 1000;
+                r->cache->valid_msec =
+                    (ngx_uint_t) ((tp->msec + d_msec) % 1000);
             }
         }
 
-        if (valid) {
+        if (valid || r->cache->valid_msec) {
             r->cache->date = now;
             r->cache->body_start = (u_short) (u->buffer.pos - u->buffer.start);
 
@@ -4852,12 +4874,19 @@ ngx_http_upstream_finalize_request(ngx_http_request_t *r,
         if (u->cacheable) {
 
             if (rc == NGX_HTTP_BAD_GATEWAY || rc == NGX_HTTP_GATEWAY_TIME_OUT) {
-                time_t  valid;
+                time_t       valid;
+                ngx_uint_t   d_msec;
+                ngx_time_t  *tp;
 
-                valid = ngx_http_file_cache_valid(u->conf->cache_valid, rc);
+                valid = ngx_http_file_cache_valid(u->conf->cache_valid, rc,
+                                                  &d_msec);
 
-                if (valid) {
-                    r->cache->valid_sec = ngx_time() + valid;
+                if (valid || d_msec) {
+                    tp = ngx_timeofday();
+                    r->cache->valid_sec = tp->sec + valid
+                        + (tp->msec + d_msec) / 1000;
+                    r->cache->valid_msec =
+                        (ngx_uint_t) ((tp->msec + d_msec) % 1000);
                     r->cache->error = rc;
                 }
             }


### PR DESCRIPTION
### Proposed changes:

Adds sub-second cache validity for the proxy (and related) cache: `proxy_cache_valid`, `fastcgi_cache_valid`, `scgi_cache_valid`, and `uwsgi_cache_valid` accept a time value with an optional ms suffix for millisecond precision (e.g. 100ms for a 10 Hz-style TTL).

- **Behavior**: Only values that contain `ms` are treated as milliseconds; all existing time syntax (e.g. 60s, 10m) is unchanged.
- Implementation: Uses the existing `valid_sec `/ `valid_msec` storage and `ngx_timeofday()` for expiry; no cache format or version change.
- **Docs**: Changelog entry in docs/xml/nginx/changes.xml; docs/subsecond-cache-validity-options.md describes the design and testing.
- **Tests**: New contrib test contrib/nginx-tests/proxy_cache_valid_subsecond.t (for use with the nginx-tests repo). .gitignore updated to ignore a local nginx-tests clone.

Fixes ISSUE #1156.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
