### PR TITLE
Proxy: added "proxy_cache_lock_wait_time" directive.

### DIFF
--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -512,7 +512,12 @@ static ngx_command_t  ngx_http_proxy_commands[] = {
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_proxy_loc_conf_t, upstream.cache_lock_age),
       NULL },
-
+    { ngx_string("proxy_cache_lock_wait_time"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_proxy_loc_conf_t, upstream.cache_lock_wait_time),
+      NULL },
     { ngx_string("proxy_cache_revalidate"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
@@ -3582,6 +3587,7 @@ ngx_http_proxy_create_loc_conf(ngx_conf_t *cf)
     conf->upstream.cache_lock = NGX_CONF_UNSET;
     conf->upstream.cache_lock_timeout = NGX_CONF_UNSET_MSEC;
     conf->upstream.cache_lock_age = NGX_CONF_UNSET_MSEC;
+    conf->upstream.cache_lock_wait_time = NGX_CONF_UNSET_MSEC;
     conf->upstream.cache_revalidate = NGX_CONF_UNSET;
     conf->upstream.cache_convert_head = NGX_CONF_UNSET;
     conf->upstream.cache_background_update = NGX_CONF_UNSET;
@@ -3897,6 +3903,9 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_msec_value(conf->upstream.cache_lock_age,
                               prev->upstream.cache_lock_age, 5000);
+
+    ngx_conf_merge_msec_value(conf->upstream.cache_lock_wait_time,
+                              prev->upstream.cache_lock_wait_time, 500);
 
     ngx_conf_merge_value(conf->upstream.cache_revalidate,
                               prev->upstream.cache_revalidate, 0);

--- a/src/http/ngx_http_cache.h
+++ b/src/http/ngx_http_cache.h
@@ -103,6 +103,7 @@ struct ngx_http_cache_s {
     ngx_msec_t                       lock_timeout;
     ngx_msec_t                       lock_age;
     ngx_msec_t                       lock_time;
+    ngx_msec_t                       lock_wait_time;
     ngx_msec_t                       wait_time;
 
     ngx_event_t                      wait_event;

--- a/src/http/ngx_http_file_cache.c
+++ b/src/http/ngx_http_file_cache.c
@@ -452,7 +452,10 @@ ngx_http_file_cache_lock(ngx_http_request_t *r, ngx_http_cache_t *c)
 
     timer = c->wait_time - now;
 
-    ngx_add_timer(&c->wait_event, (timer > 500) ? 500 : timer);
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "http file cache lock timer tm:%M lwt:%M", timer, c->lock_wait_time);
+
+    ngx_add_timer(&c->wait_event, (timer > c->lock_wait_time) ? c->lock_wait_time : timer);
 
     r->main->blocked++;
 
@@ -531,7 +534,7 @@ ngx_http_file_cache_lock_wait(ngx_http_request_t *r, ngx_http_cache_t *c)
     ngx_shmtx_unlock(&cache->shpool->mutex);
 
     if (wait) {
-        ngx_add_timer(&c->wait_event, (timer > 500) ? 500 : timer);
+        ngx_add_timer(&c->wait_event, (timer > c->lock_wait_time) ? c->lock_wait_time : timer);
         return NGX_AGAIN;
     }
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -923,6 +923,7 @@ ngx_http_upstream_cache(ngx_http_request_t *r, ngx_http_upstream_t *u)
         c->lock = u->conf->cache_lock;
         c->lock_timeout = u->conf->cache_lock_timeout;
         c->lock_age = u->conf->cache_lock_age;
+        c->lock_wait_time = u->conf->cache_lock_wait_time;
 
         u->cache_status = NGX_HTTP_CACHE_MISS;
     }

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -219,6 +219,7 @@ typedef struct {
     ngx_flag_t                       cache_lock;
     ngx_msec_t                       cache_lock_timeout;
     ngx_msec_t                       cache_lock_age;
+    ngx_msec_t                       cache_lock_wait_time;
 
     ngx_flag_t                       cache_revalidate;
     ngx_flag_t                       cache_convert_head;


### PR DESCRIPTION
### Proposed changes

  The new directive controls the polling interval when waiting
  for a cache lock to be released by another request.  Previously,
  the wait time was hardcoded to 500ms, which in a worst case scenario adds 500ms latency to requests (see my [blog post ](https://nejc.blog/2024/11/06/nginx-proxy-cache-lock-request-coalescing/) for more info)

  The directive accepts a millisecond value and defaults to 500ms,
  preserving the existing behavior.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
