### PR TITLE
HTTP/3: added overflow checks in QPACK field section prefix.

### DIFF
--- a/src/http/v3/ngx_http_v3_parse.c
+++ b/src/http/v3/ngx_http_v3_parse.c
@@ -437,6 +437,12 @@ ngx_http_v3_parse_field_section_prefix(ngx_connection_t *c,
                 return rc;
             }
 
+            if (st->pint.value > (ngx_uint_t) -1) {
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "client sent too large insert count");
+                return NGX_HTTP_V3_ERR_DECOMPRESSION_FAILED;
+            }
+
             st->insert_count = st->pint.value;
             st->state = sw_delta_base;
             break;
@@ -461,6 +467,12 @@ ngx_http_v3_parse_field_section_prefix(ngx_connection_t *c,
                 return rc;
             }
 
+            if (st->pint.value > (ngx_uint_t) -1) {
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "client sent too large delta base");
+                return NGX_HTTP_V3_ERR_DECOMPRESSION_FAILED;
+            }
+
             st->delta_base = st->pint.value;
             goto done;
         }
@@ -482,6 +494,11 @@ done:
         st->base = st->insert_count - st->delta_base - 1;
 
     } else {
+        if (st->delta_base > (ngx_uint_t) -1 - st->insert_count) {
+            ngx_log_error(NGX_LOG_INFO, c->log, 0, "client sent too large base");
+            return NGX_HTTP_V3_ERR_DECOMPRESSION_FAILED;
+        }
+
         st->base = st->insert_count + st->delta_base;
     }
 


### PR DESCRIPTION
Added bounds checks for insert_count and delta_base values parsed from QPACK field section prefix integers.  The prefix integer parser produces uint64_t values which are assigned to ngx_uint_t fields without validation.  On 32-bit platforms, this truncation can silently wrap a crafted delta_base to a valid dynamic table index, causing incorrect header lookups.

Also added an overflow check for the base computation (insert_count + delta_base), mirroring the existing underflow check in the negative base case.

Test: nginx/nginx-tests#36

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
