### PR TITLE
ProxyCache: Fix the problem of 500 caused by insufficient zone of proxy cache

### DIFF
--- a/src/http/ngx_http_file_cache.c
+++ b/src/http/ngx_http_file_cache.c
@@ -301,11 +301,7 @@ ngx_http_file_cache_open(ngx_http_request_t *r)
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http file cache exists: %i e:%d", rc, c->exists);
 
-    if (rc == NGX_ERROR) {
-        return rc;
-    }
-
-    if (rc == NGX_AGAIN) {
+    if (rc == NGX_AGAIN || rc == NGX_ERROR) {
         return NGX_HTTP_CACHE_SCARCE;
     }
 


### PR DESCRIPTION
### Proposed changes

Use case
In reverse-proxy deployments using proxy_cache (file cache) under high concurrency, it’s common to have many cache misses and therefore many upstream fetches. In this environment it’s also typical that the configured keys_zone is difficult to size correctly: operators generally cannot reliably predict the upstream object size distribution (e.g., how many responses fall into the “small” range such as around “4 kB”-class objects vs. larger ones).

As the workload generates many misses, Nginx needs to allocate a metadata node from the keys_zone slab. When the slab does not have enough free nodes, allocation fails and logs could not allocate node. A key factor is that the forced eviction path (ngx_http_file_cache_forced_expire) may encounter cache nodes with fcn->deleting set; in that case those entries cannot be reclaimed immediately (it effectively waits), so slab space is not freed in time and the subsequent allocation retry still fails. This causes ngx_http_file_cache_exists() to return NGX_ERROR.

With the existing behavior, this NGX_ERROR can be treated as a fatal cache error and bubble up to the request path, resulting in 500 responses and log spam—even though bypassing the file cache and fetching from upstream would produce correct outcomes.

Change detail
In ngx_http_file_cache_open(), when ngx_http_file_cache_exists() returns NGX_ERROR (the keys-zone metadata allocation failure / could not allocate node path), return NGX_HTTP_CACHE_SCARCE instead of propagating the error.

This makes the upstream cache logic treat the request as non-cacheable (cacheable = 0) and bypass the file cache, prioritizing correctness (return upstream response) and avoiding 500 failures caused by temporary cache metadata exhaustion.

Test description
Before: with 5G bandwidth, high miss rate, and many small upstream responses that exhaust keys_zone, the system produces many 500 and logs could not allocate node.
After: under the same workload, only error logs appear, but 500 disappears and requests succeed normally (e.g., 200).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
