### PR TITLE
Proxy: reset control frame counters on HTTP/2 upstream reinit.

### DIFF
--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -944,6 +944,8 @@ ngx_http_proxy_v2_reinit_request(ngx_http_request_t *r)
     ctx->rst = 0;
     ctx->goaway = 0;
     ctx->connection = NULL;
+    ctx->pings = 0;
+    ctx->settings = 0;
     ctx->in = NULL;
     ctx->busy = NULL;
     ctx->out = NULL;


### PR DESCRIPTION
The pings and settings DoS protection counters were not cleared in ngx_http_proxy_v2_reinit_request(), causing them to accumulate across upstream retries.  If the first upstream sent many SETTINGS or PING frames before failing, the carried-over counter could falsely trigger "upstream sent too many settings/ping frames" on the next upstream.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
