### PR TITLE
event: fix grammatical typos in ngx_kqueue_module.c comments

### DIFF
--- a/src/event/modules/ngx_kqueue_module.c
+++ b/src/event/modules/ngx_kqueue_module.c
@@ -92,8 +92,8 @@ static ngx_event_module_t  ngx_kqueue_module_ctx = {
         ngx_kqueue_del_event,              /* delete an event */
         ngx_kqueue_add_event,              /* enable an event */
         ngx_kqueue_del_event,              /* disable an event */
-        NULL,                              /* add an connection */
-        NULL,                              /* delete an connection */
+        NULL,                              /* add a connection */
+        NULL,                              /* delete a connection */
 #ifdef EVFILT_USER
         ngx_kqueue_notify,                 /* trigger a notify */
 #else


### PR DESCRIPTION
Fix grammatical errors in `src/event/modules/ngx_kqueue_module.c`:

- `add an connection` → `add a connection` (line 95)
- `delete an connection` → `delete a connection` (line 96)

Fixes #617