### PR TITLE
Add integer overflow checks to ngx_array_push() and ngx_array_push_n()

### DIFF
--- a/src/core/ngx_array.c
+++ b/src/core/ngx_array.c
@@ -55,6 +55,10 @@ ngx_array_push(ngx_array_t *a)
 
         /* the array is full */
 
+        if (a->nalloc > SIZE_MAX / a->size) {
+            return NULL;
+        }
+
         size = a->size * a->nalloc;
 
         p = a->pool;
@@ -72,6 +76,10 @@ ngx_array_push(ngx_array_t *a)
 
         } else {
             /* allocate a new array */
+
+            if (size > SIZE_MAX / 2) {
+                return NULL;
+            }
 
             new = ngx_palloc(p, 2 * size);
             if (new == NULL) {
@@ -99,6 +107,10 @@ ngx_array_push_n(ngx_array_t *a, ngx_uint_t n)
     ngx_uint_t   nalloc;
     ngx_pool_t  *p;
 
+    if (n > SIZE_MAX / a->size) {
+        return NULL;
+    }
+
     size = n * a->size;
 
     if (a->nelts + n > a->nalloc) {
@@ -121,7 +133,17 @@ ngx_array_push_n(ngx_array_t *a, ngx_uint_t n)
         } else {
             /* allocate a new array */
 
-            nalloc = 2 * ((n >= a->nalloc) ? n : a->nalloc);
+            nalloc = (n >= a->nalloc) ? n : a->nalloc;
+
+            if (nalloc > SIZE_MAX / 2) {
+                return NULL;
+            }
+
+            nalloc *= 2;
+
+            if (nalloc > SIZE_MAX / a->size) {
+                return NULL;
+            }
 
             new = ngx_palloc(p, nalloc * a->size);
             if (new == NULL) {

--- a/src/core/ngx_list.c
+++ b/src/core/ngx_list.c
@@ -44,6 +44,10 @@ ngx_list_push(ngx_list_t *l)
             return NULL;
         }
 
+        if (l->nalloc > SIZE_MAX / l->size) {
+            return NULL;
+        }
+
         last->elts = ngx_palloc(l->pool, l->nalloc * l->size);
         if (last->elts == NULL) {
             return NULL;


### PR DESCRIPTION
`ngx_array_push()` and `ngx_array_push_n()` in `src/core/ngx_array.c` perform unchecked `size_t` arithmetic when growing the array. Multiplications (`a->size * a->nalloc`, `n * a->size`, `nalloc * a->size`) and doublings (`2 * size`, `2 * nalloc`) can overflow, causing `ngx_palloc` to allocate an undersized buffer. The subsequent `ngx_memcpy` then copies old data past the allocation boundary.

This adds overflow checks before each arithmetic operation:

- `a->nalloc > SIZE_MAX / a->size` before `a->size * a->nalloc`
- `size > SIZE_MAX / 2` before `2 * size`
- `n > SIZE_MAX / a->size` before `n * a->size`
- `nalloc > SIZE_MAX / 2` before `nalloc *= 2`
- `nalloc > SIZE_MAX / a->size` before `nalloc * a->size`

On overflow, both functions return `NULL`, consistent with the existing `ngx_palloc` failure handling.