### PR TITLE
Resolver: reject PTR answers with out-of-bounds RDLENGTH

### DIFF
--- a/src/core/ngx_resolver.c
+++ b/src/core/ngx_resolver.c
@@ -3320,6 +3320,10 @@ valid:
 
         i += sizeof(ngx_resolver_an_t);
 
+        if (len > n - i) {
+            goto short_response;
+        }
+
         switch (type) {
 
         case NGX_RESOLVE_PTR:


### PR DESCRIPTION
### Proposed changes

This change makes PTR response parsing a bit stricter by rejecting answers whose declared `RDLENGTH` goes past the remaining DNS packet.

In `ngx_resolver_process_ptr()`, the resolver moves past the answer header and can enter PTR-specific decoding without first checking whether the RR's `RDLENGTH` actually fits in the remaining packet data. In that case, a malformed PTR answer with an oversized `RDLENGTH` but only a compressed name pointer in the available bytes can still be decoded and treated as a successful resolver result instead of being rejected as malformed.

This patch adds a small bounds check before PTR-specific handling so those malformed answers follow the existing `short_response` path.

The change is intentionally kept narrow:
- only `src/core/ngx_resolver.c` is modified
- only `ngx_resolver_process_ptr()` is touched
- behavior for valid PTR answers stays the same

### Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
