### PR TITLE
ci: pin called workflows to full commit SHAs

### DIFF
--- a/.github/workflows/buildbot.yml
+++ b/.github/workflows/buildbot.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   buildbot:
-    uses: nginx/ci-self-hosted/.github/workflows/nginx-buildbot.yml@main
+    uses: nginx/ci-self-hosted/.github/workflows/nginx-buildbot.yml@a18ba87ce844172e745b83b6bcfed902c5bbe039 # main

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   check-pr:
-    uses: nginx/ci-self-hosted/.github/workflows/nginx-check-pr.yml@main
+    uses: nginx/ci-self-hosted/.github/workflows/nginx-check-pr.yml@a18ba87ce844172e745b83b6bcfed902c5bbe039 # main


### PR DESCRIPTION
## Summary

Pin reusable workflow refs from mutable branch names (`@main`) to full commit SHAs to prevent supply-chain attacks.

## Changes

| File | Before | After |
|------|--------|-------|
| `.github/workflows/buildbot.yml` | `nginx/ci-self-hosted/.github/workflows/nginx-buildbot.yml@main` | `@a18ba87ce844172e745b83b6bcfed902c5bbe039 # main` |
| `.github/workflows/check-pr.yml` | `nginx/ci-self-hosted/.github/workflows/nginx-check-pr.yml@main` | `@a18ba87ce844172e745b83b6bcfed902c5bbe039 # main` |

Both are pinned to the current HEAD of `nginx/ci-self-hosted@main` — no behavioral change, only supply-chain hardening.