### PR TITLE
Mail: fixed clearing s->passwd in auth http requests.

### DIFF
--- a/src/mail/ngx_mail_auth_http_module.c
+++ b/src/mail/ngx_mail_auth_http_module.c
@@ -1328,7 +1328,7 @@ ngx_mail_auth_http_create_request(ngx_mail_session_t *s, ngx_pool_t *pool,
         b->last = ngx_cpymem(b->last, "Auth-Salt: ", sizeof("Auth-Salt: ") - 1);
         b->last = ngx_copy(b->last, s->salt.data, s->salt.len);
 
-        s->passwd.data = NULL;
+        ngx_str_null(&s->passwd);
     }
 
     b->last = ngx_cpymem(b->last, "Auth-Protocol: ",


### PR DESCRIPTION
Previously, it was not properly cleared retaining length as part of authenticating with CRAM-MD5 and APOP methods that expect to receive password in auth response.  This resulted in null pointer dereference and worker process crash in subsequent auth attempts with CRAM-MD5.

Reported by Arkadi Vainbrand.
