### PR TITLE
SSL_R_RECORD_LAYER_FAILURE [crit] log level

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -3954,6 +3954,9 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
 #ifdef SSL_R_BAD_ECPOINT
             || n == SSL_R_BAD_ECPOINT                                /*  306 */
 #endif
+#ifdef SSL_R_RECORD_LAYER_FAILURE
+            || n == SSL_R_RECORD_LAYER_FAILURE                       /*  313 */
+#endif
 #ifdef SSL_R_RENEGOTIATE_EXT_TOO_LONG
             || n == SSL_R_RENEGOTIATE_EXT_TOO_LONG                   /*  335 */
             || n == SSL_R_RENEGOTIATION_ENCODING_ERR                 /*  336 */


### PR DESCRIPTION
fixes: https://github.com/nginx/nginx/issues/961
There's a complete description of the problem in the issue.

Authored by https://github.com/goran-lazic-gcore

Also made a minimal tls13 client that reproduces the error reliably:

https://github.com/climagabriel/openssl/blob/368676f96493de363cd96ec6558e5be9fa34f0a5/demos/bio/client-arg.c

It's based on the normal openssl demos minimal https client.
You build it and execute it as: `./client-arg -corrupt -connect 127.0.0.1:443` 

And sure enough:

`2026/03/26 12:13:36 [crit] 190483#190483: *1 SSL_read() failed (SSL: error:0A000119:SSL routines::decryption failed or bad record mac error:0A000139:SSL routines::record layer failure) while waiting for request, client: 127.0.0.1, server: 0.0.0.0:443
`