### PR TITLE
add `nginxconf` file extension to vim syntax detection

### DIFF
--- a/contrib/vim/ftdetect/nginx.vim
+++ b/contrib/vim/ftdetect/nginx.vim
@@ -1,4 +1,5 @@
 au BufRead,BufNewFile *.nginx set ft=nginx
+au BufRead,BufNewFile *.nginxconf set ft=nginx
 au BufRead,BufNewFile */etc/nginx/* set ft=nginx
 au BufRead,BufNewFile */usr/local/nginx/conf/* set ft=nginx
 au BufRead,BufNewFile nginx.conf set ft=nginx


### PR DESCRIPTION
### Proposed changes

The Linguist project - GitHub's syntax highlighter - recognises the extensions 
- `.nginx`
- `.nginxconf`
- `.vhost`
as nginx config files. 
See https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml#L5079

The vim syntax detection configuration for nginx syntax does not detect the nginxconf extension or the vhost extension.
Since the vhost extension is potentially ambiguous, it is probably sensible not to detect it as nginx automatically. But the nginxconf extension should definitely be detected as an nginx configuration file. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
  - [ ] rebase commits to follow contributing guidelines 
- [ ] I have checked that NGINX compiles and runs after adding my changes.
