### PR TITLE
feat(ssl): add $ssl_handshake_rtt variable

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5721,6 +5721,40 @@ ngx_ssl_get_session_reused(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 
 
 ngx_int_t
+ngx_ssl_get_handshake_rtt(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+{
+#if (OPENSSL_VERSION_NUMBER >= 0x30200000L)
+
+    uint64_t  rtt;
+    u_char   *p;
+
+    if (SSL_get_handshake_rtt(c->ssl->connection, &rtt) > 0) {
+        if (pool == NULL) {
+            pool = c->pool;
+        }
+
+        s->data = ngx_pnalloc(pool, NGX_INT64_LEN + 1);
+        if (s->data == NULL) {
+            return NGX_ERROR;
+        }
+
+        p = ngx_sprintf(s->data, "%uL", rtt);
+        *p = '\0';
+        s->len = p - s->data;
+
+        return NGX_OK;
+    }
+
+#endif
+
+    s->len = 0;
+    s->data = (u_char *) "";
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
 ngx_ssl_get_early_data(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 {
     s->len = 0;

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -336,6 +336,8 @@ ngx_int_t ngx_ssl_get_session_id(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_session_reused(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
+ngx_int_t ngx_ssl_get_handshake_rtt(ngx_connection_t *c, ngx_pool_t *pool,
+    ngx_str_t *s);
 ngx_int_t ngx_ssl_get_early_data(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_server_name(ngx_connection_t *c, ngx_pool_t *pool,

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -32,6 +32,8 @@ static int ngx_http_ssl_alpn_select(ngx_ssl_conn_t *ssl_conn,
 
 static ngx_int_t ngx_http_ssl_static_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_ssl_handshake_rtt_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_ssl_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 
@@ -374,6 +376,9 @@ static ngx_http_variable_t  ngx_http_ssl_vars[] = {
     { ngx_string("ssl_session_reused"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_session_reused, NGX_HTTP_VAR_CHANGEABLE, 0 },
 
+    { ngx_string("ssl_handshake_rtt"), NULL, ngx_http_ssl_handshake_rtt_variable,
+      (uintptr_t) ngx_ssl_get_handshake_rtt, NGX_HTTP_VAR_CHANGEABLE, 0 },
+
     { ngx_string("ssl_early_data"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_early_data,
       NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_NOCACHEABLE, 0 },
@@ -556,6 +561,35 @@ ngx_http_ssl_static_variable(ngx_http_request_t *r,
         for (len = 0; v->data[len]; len++) { /* void */ }
 
         v->len = len;
+        v->valid = 1;
+        v->no_cacheable = 0;
+        v->not_found = 0;
+
+        return NGX_OK;
+    }
+
+    v->not_found = 1;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_ssl_handshake_rtt_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    ngx_ssl_variable_handler_pt  handler = (ngx_ssl_variable_handler_pt) data;
+
+    ngx_str_t  s;
+
+    if (r->connection->ssl) {
+
+        if (handler(r->connection, r->pool, &s) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        v->len = s.len;
+        v->data = s.data;
         v->valid = 1;
         v->no_cacheable = 0;
         v->not_found = 0;

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -36,6 +36,8 @@ static int ngx_stream_ssl_certificate(ngx_ssl_conn_t *ssl_conn, void *arg);
 #endif
 static ngx_int_t ngx_stream_ssl_static_variable(ngx_stream_session_t *s,
     ngx_stream_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_stream_ssl_handshake_rtt_variable(ngx_stream_session_t *s,
+    ngx_stream_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_stream_ssl_variable(ngx_stream_session_t *s,
     ngx_stream_variable_value_t *v, uintptr_t data);
 
@@ -372,6 +374,9 @@ static ngx_stream_variable_t  ngx_stream_ssl_vars[] = {
 
     { ngx_string("ssl_session_reused"), NULL, ngx_stream_ssl_variable,
       (uintptr_t) ngx_ssl_get_session_reused, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
+    { ngx_string("ssl_handshake_rtt"), NULL, ngx_stream_ssl_handshake_rtt_variable,
+      (uintptr_t) ngx_ssl_get_handshake_rtt, NGX_STREAM_VAR_CHANGEABLE, 0 },
 
     { ngx_string("ssl_server_name"), NULL, ngx_stream_ssl_variable,
       (uintptr_t) ngx_ssl_get_server_name, NGX_STREAM_VAR_CHANGEABLE, 0 },
@@ -816,6 +821,35 @@ ngx_stream_ssl_static_variable(ngx_stream_session_t *s,
         for (len = 0; v->data[len]; len++) { /* void */ }
 
         v->len = len;
+        v->valid = 1;
+        v->no_cacheable = 0;
+        v->not_found = 0;
+
+        return NGX_OK;
+    }
+
+    v->not_found = 1;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_stream_ssl_handshake_rtt_variable(ngx_stream_session_t *s,
+    ngx_stream_variable_value_t *v, uintptr_t data)
+{
+    ngx_ssl_variable_handler_pt  handler = (ngx_ssl_variable_handler_pt) data;
+
+    ngx_str_t  str;
+
+    if (s->connection->ssl) {
+
+        if (handler(s->connection, s->connection->pool, &str) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        v->len = str.len;
+        v->data = str.data;
         v->valid = 1;
         v->no_cacheable = 0;
         v->not_found = 0;


### PR DESCRIPTION
### Proposed changes

OpenSSL 3.2 added the SSL_get_handshake_rtt function. This addition exposes the data from this function in ngx_http_ssl_module.c, ngx_event_openssl.c and ngx_stream_ssl_module.c so that it can be extracted, utilized and logged within Nginx.

### Notes about implementation

Guards are in place for ensuring OpenSSL 3.2 is installed (assigns empty value if not). On the OpenSSL side if either TLS < 1.2 or RTT can't be calculated internally, then a value of 0 is returned to any caller. In this implementation, it was determined it was better to have an empty value in the ssl-handshake-rtt variable rather than an error value (e.g. 0 or -1).

The variable type is uint64_t, please advise if that should be different.

### Tested systems
Alpine 3.18, Alpine 3.23.3, Debian 12.10, Debian 13, Fedora 40, Kali Linux 2026.1, RedHat Enterprise Linux 10.1, Rocky Linux 8.9/8.10, Rocky Linux 9.3/9.8, Rocky Linux 10.1, Ubuntu 24.04, Ubuntu 25.10, Ubuntu 26.04. 

Note: due to local environmental setup problems Alma Linux 9, Alma Linux 10.1, FreeBSD 10, Windows Server 2019 Standard were attempted, but not tested.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [✅] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [✅] I have added my own regression tests to nginx-tests (PR will follow this one - https://github.com/nginx/nginx-tests/pull/40)
- [✅] I have tested locally and on various distributions (list above)
- [✅] I have checked that NGINX compiles, runs and passes test-suite after adding my changes
   -> Note: currently have 1x failing case for stream_ssl_oscp.t. But as OSCP requires an active TLS certificate this failure was ignored. Please advise if this needs to fully tested locally. 
   -> Side note: I observed recent changes to this file as of 3 days ago, not sure if that affected things or not. See: https://github.com/nginx/nginx-tests/commit/cf90a22921652731302e8a4dc2a88049c723377d 
