### PR TITLE
SSL: fix ssl want x509 lookup

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -2310,6 +2310,21 @@ ngx_ssl_handshake(ngx_connection_t *c)
         return NGX_AGAIN;
     }
 
+    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP) {
+        c->read->handler = ngx_ssl_handshake_handler;
+        c->write->handler = ngx_ssl_handshake_handler;
+
+        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        return NGX_AGAIN;
+    }
+
     err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
 
     c->ssl->no_wait_shutdown = 1;
@@ -2443,6 +2458,21 @@ ngx_ssl_try_early_data(ngx_connection_t *c)
 
     if (sslerr == SSL_ERROR_WANT_WRITE) {
         c->write->ready = 0;
+        c->read->handler = ngx_ssl_handshake_handler;
+        c->write->handler = ngx_ssl_handshake_handler;
+
+        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        return NGX_AGAIN;
+    }
+
+    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP) {
         c->read->handler = ngx_ssl_handshake_handler;
         c->write->handler = ngx_ssl_handshake_handler;
 

--- a/src/event/quic/ngx_event_quic_ssl.c
+++ b/src/event/quic/ngx_event_quic_ssl.c
@@ -719,10 +719,12 @@ ngx_quic_handshake(ngx_connection_t *c)
             return NGX_ERROR;
         }
 
-        if (sslerr != SSL_ERROR_WANT_READ) {
-            ngx_ssl_connection_error(c, sslerr, 0, "SSL_do_handshake() failed");
-            return NGX_ERROR;
+        if (sslerr == SSL_ERROR_WANT_READ || sslerr == SSL_ERROR_WANT_X509_LOOKUP) {
+            return NGX_OK;
         }
+
+        ngx_ssl_connection_error(c, sslerr, 0, "SSL_do_handshake() failed");
+        return NGX_ERROR;
     }
 
     if (qc->error) {


### PR DESCRIPTION
### Proposed changes

## Description
Handle SSL_ERROR_WANT_X509_LOOKUP during TLS handshake to fix connection
failures when using ssl_verify_client with TLS 1.3.

## Problem
When a TLS 1.3 session expires and a full handshake is required with client
certificate verification enabled, OpenSSL may return SSL_ERROR_WANT_X509_LOOKUP
(error code 6) from SSL_do_handshake(). This error was not handled, causing
nginx to terminate the connection.

## Solution
Added handling for SSL_ERROR_WANT_X509_LOOKUP similar to SSL_ERROR_WANT_READ,
allowing the handshake to be retried.

## Changes
- `src/event/ngx_event_openssl.c`: Handle SSL_ERROR_WANT_X509_LOOKUP in
  ngx_ssl_handshake() and ngx_ssl_try_early_data()
- `src/event/quic/ngx_event_quic_ssl.c`: Handle SSL_ERROR_WANT_X509_LOOKUP
  in QUIC handshake

## Testing
- Built and tested on macOS and Linux

## Related Issue
Fixes #1202 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
