### PR TITLE
Fix resource leak in ngx_event_acceptex() error paths

### DIFF
--- a/src/event/ngx_event_acceptex.c
+++ b/src/event/ngx_event_acceptex.c
@@ -41,7 +41,7 @@ ngx_event_acceptex(ngx_event_t *rev)
         ngx_log_error(NGX_LOG_CRIT, c->log, ngx_socket_errno,
                       "setsockopt(SO_UPDATE_ACCEPT_CONTEXT) failed for %V",
                       &c->addr_text);
-        /* TODO: close socket */
+        ngx_close_posted_connection(c);
         return;
     }
 
@@ -63,7 +63,7 @@ ngx_event_acceptex(ngx_event_t *rev)
     if (ls->addr_ntop) {
         c->addr_text.data = ngx_pnalloc(c->pool, ls->addr_text_max_len);
         if (c->addr_text.data == NULL) {
-            /* TODO: close socket */
+            ngx_close_posted_connection(c);
             return;
         }
 
@@ -71,7 +71,7 @@ ngx_event_acceptex(ngx_event_t *rev)
                                          c->addr_text.data,
                                          ls->addr_text_max_len, 0);
         if (c->addr_text.len == 0) {
-            /* TODO: close socket */
+            ngx_close_posted_connection(c);
             return;
         }
     }


### PR DESCRIPTION
## Summary
- Fix resource leak when AcceptEx completes but subsequent processing fails
- Replace TODO comments with actual calls to `ngx_close_posted_connection()`

## Problem
When `AcceptEx()` completes successfully but later operations fail, the accepted socket was not closed, leading to resource leaks. This occurred in 3 error paths:

1. `setsockopt(SO_UPDATE_ACCEPT_CONTEXT)` failure
2. `ngx_pnalloc()` failure for `addr_text` 
3. `ngx_sock_ntop()` failure returning 0 length

## Solution
Replace `/* TODO: close socket */` comments with actual cleanup calls to `ngx_close_posted_connection()`, which properly:
- Frees the connection structure via `ngx_free_connection()`
- Closes the socket
- Destroys the connection pool

This matches the error handling pattern used elsewhere in `ngx_event_post_acceptex()`.

## Test plan
- [ ] Code review: The fix follows existing patterns in the codebase
- [ ] Static analysis: No new warnings introduced
- [ ] Manual testing: Requires Windows environment with IOCP

**Note:** This is Windows-specific code (IOCP/AcceptEx). Testing requires a Windows build environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)