### PR TITLE
added #ifndef guards to SIGNAL macro definitions..

### DIFF
--- a/src/core/ngx_config.h
+++ b/src/core/ngx_config.h
@@ -56,18 +56,44 @@
 
 #define ngx_random               random
 
-/* TODO: #ifndef */
+/* TODO: #ifndef
+   Done..
+ */
+#ifndef NGX_SHUTDOWN_SIGNAL
 #define NGX_SHUTDOWN_SIGNAL      QUIT
+#endif
+
+#ifndef NGX_TERMINATE_SIGNAL
 #define NGX_TERMINATE_SIGNAL     TERM
+#endif
+
+#ifndef NGX_NOACCEPT_SIGNAL
 #define NGX_NOACCEPT_SIGNAL      WINCH
+#endif
+
+#ifndef NGX_RECONFIGURE_SIGNAL
 #define NGX_RECONFIGURE_SIGNAL   HUP
+#endif
 
 #if (NGX_LINUXTHREADS)
+
+#ifndef NGX_REOPEN_SIGNAL
 #define NGX_REOPEN_SIGNAL        INFO
+#endif
+
+#ifndef NGX_CHANGEBIN_SIGNAL
 #define NGX_CHANGEBIN_SIGNAL     XCPU
+#endif
+
 #else
+
+#ifndef NGX_REOPEN_SIGNAL
 #define NGX_REOPEN_SIGNAL        USR1
+#endif
+
+#ifndef NGX_CHANGEBIN_SIGNAL
 #define NGX_CHANGEBIN_SIGNAL     USR2
+#endif
 #endif
 
 #define ngx_cdecl


### PR DESCRIPTION
wrap NGX_* signal macros with #ifndef to prevent redefine warnings and improve portability.

### Description

Wrap NGX_* signal macros with #ifndef guards to prevent redefinition warnings and improve portability.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.