### PR TITLE
GH: add a workflow to check for the 'version bump' commit

### DIFF
--- a/.github/workflows/check-version-bump.yaml
+++ b/.github/workflows/check-version-bump.yaml
@@ -1,0 +1,23 @@
+name: Check Version Bump
+
+on:
+  pull_request:
+    types: [ opened, synchronize ]
+
+jobs:
+  check-version-bump:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        fetch-depth: 0
+
+    - name: Check git log
+      run: |
+        echo "## Check for 'Version bump' commit" >${GITHUB_STEP_SUMMARY}
+        subj=$(git log --format=%s $(git describe --abbrev=0 --tags).. | tail -1)
+        if ! expr "$subj" : 'Version bump' >/dev/null
+        then
+          echo "❌ No 'Version bump' commit immediately after release tag" | tee -a ${GITHUB_STEP_SUMMARY}
+          exit 2
+        fi

--- a/src/core/nginx.h
+++ b/src/core/nginx.h
@@ -9,8 +9,8 @@
 #define _NGINX_H_INCLUDED_
 
 
-#define nginx_version      1029008
-#define NGINX_VERSION      "1.29.8"
+#define nginx_version      1031000
+#define NGINX_VERSION      "1.31.0"
 #define NGINX_VER          "nginx/" NGINX_VERSION
 
 #ifdef NGX_BUILD


### PR DESCRIPTION
```
GH: add a workflow to check for the 'version bump' commit

This checks pull-requests to make sure the 'Version bump' commit is
immediately after the last release commit/tag.

The check includes the commits in the pull-request, so if a pull-request
is adding this commit it will accept it and also if there are other
commits in the pull-request, as long as the 'Version bump' commit is
first.
```