### PR TITLE
Removed CLOCK_MONOTONIC_FAST support.

### DIFF
--- a/src/core/ngx_times.c
+++ b/src/core/ngx_times.c
@@ -198,11 +198,7 @@ ngx_monotonic_time(time_t sec, ngx_uint_t msec)
 #if (NGX_HAVE_CLOCK_MONOTONIC)
     struct timespec  ts;
 
-#if defined(CLOCK_MONOTONIC_FAST)
-    clock_gettime(CLOCK_MONOTONIC_FAST, &ts);
-#else
     clock_gettime(CLOCK_MONOTONIC, &ts);
-#endif
 
     sec = ts.tv_sec;
     msec = ts.tv_nsec / 1000000;


### PR DESCRIPTION
### Proposed changes
CLOCK_MONOTONIC_FAST, like CLOCK_MONOTONIC_COARSE, has low accuracy. It shows noticeable timing variation for short intervals, which is visible in metrics like $upstream_response_time for fast upstream responses. This change complements the work started in commit f29d7ade5. In addition to the reasons described in f29d7ade5, CLOCK_MONOTONIC performance is good enough on modern hardware with a TSC timecounter, especially when it is available via a shared page as on FreeBSD since version 10.0 (see git commits 869fd80fd449 and aea810386d8e for details).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
