### PR TITLE
fix $request_port / $is_request_port being empty if auth_request is used

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -2446,6 +2446,8 @@ ngx_http_subrequest(ngx_http_request_t *r,
     sr->method = NGX_HTTP_GET;
     sr->http_version = r->http_version;
 
+    sr->port = r->port;
+
     sr->request_line = r->request_line;
     sr->uri = *uri;
 


### PR DESCRIPTION
This was reported to me in https://github.com/ZoeyVid/NPMplus/discussions/3034 and this patch seems to fix it in my tests. #1247

### Proposed changes

If auth_request is configured then $request_port / $is_request_port are always empty.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
