### PR TITLE
isolate atomic fields in shared memory structs to reduce false sharing

### DIFF
--- a/src/http/ngx_http_upstream_round_robin.h
+++ b/src/http/ngx_http_upstream_round_robin.h
@@ -80,7 +80,7 @@ struct ngx_http_upstream_rr_peer_s {
 #if (NGX_HTTP_UPSTREAM_ZONE)
     unsigned                        zombie:1;
 
-    ngx_atomic_t                    lock;
+    ngx_atomic_t                    lock __attribute__((aligned(64)));
     ngx_uint_t                      refs;
     ngx_http_upstream_host_t       *host;
 #endif


### PR DESCRIPTION
align lock/rwlock/atomic fields to cache line boundaries in three shared
memory structs accessed concurrently by all worker processes:
 
1. `ngx_http_upstream_rr_peer_s.lock` : spinlock shared a cache line with
   `current_weight`/`effective_weight`/`conns`. Workers spinning on the lock
   invalidated these fields for the lock holder.
 
2. `ngx_http_upstream_rr_peers_s.rwlock` : rwlock shared cache line 0 with
   `number`/`shpool`. 
 
3. `ngx_http_file_cache_sh_t.cold` : atomics (`cold`/`loading`) shared a
   cache line with mutex-guarded `queue` tail. Workers updating `size` under
   mutex invalidated the line for lock free readers of `cold`/`loading`.
 
this is approximately 48B per upstream peer, 96B per peer group, 72B per cache zone which are 
shared memory singletons or small arrays, effectively negligible.
 
Found via static analysis of struct layout relative to cache line boundaries.
