### PR TITLE
Switch to ngx_current_msec for $request_time tracking

### DIFF
--- a/src/http/modules/ngx_http_log_module.c
+++ b/src/http/modules/ngx_http_log_module.c
@@ -838,13 +838,9 @@ static u_char *
 ngx_http_log_request_time(ngx_http_request_t *r, u_char *buf,
     ngx_http_log_op_t *op)
 {
-    ngx_time_t      *tp;
-    ngx_msec_int_t   ms;
+    ngx_msec_int_t  ms;
 
-    tp = ngx_timeofday();
-
-    ms = (ngx_msec_int_t)
-             ((tp->sec - r->start_sec) * 1000 + (tp->msec - r->start_msec));
+    ms = (ngx_msec_int_t) (ngx_current_msec - r->start_time);
     ms = ngx_max(ms, 0);
 
     return ngx_sprintf(buf, "%T.%03M", (time_t) ms / 1000, ms % 1000);

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -2368,7 +2368,6 @@ ngx_http_subrequest(ngx_http_request_t *r,
     ngx_str_t *uri, ngx_str_t *args, ngx_http_request_t **psr,
     ngx_http_post_subrequest_t *ps, ngx_uint_t flags)
 {
-    ngx_time_t                    *tp;
     ngx_connection_t              *c;
     ngx_http_request_t            *sr;
     ngx_http_core_srv_conf_t      *cscf;
@@ -2522,9 +2521,7 @@ ngx_http_subrequest(ngx_http_request_t *r,
     sr->uri_changes = NGX_HTTP_MAX_URI_CHANGES + 1;
     sr->subrequests = r->subrequests - 1;
 
-    tp = ngx_timeofday();
-    sr->start_sec = tp->sec;
-    sr->start_msec = tp->msec;
+    sr->start_time = ngx_current_msec;
 
     r->main->count++;
 

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -565,7 +565,6 @@ static ngx_http_request_t *
 ngx_http_alloc_request(ngx_connection_t *c)
 {
     ngx_pool_t                 *pool;
-    ngx_time_t                 *tp;
     ngx_http_request_t         *r;
     ngx_http_connection_t      *hc;
     ngx_http_core_srv_conf_t   *cscf;
@@ -640,9 +639,7 @@ ngx_http_alloc_request(ngx_connection_t *c)
     r->main = r;
     r->count = 1;
 
-    tp = ngx_timeofday();
-    r->start_sec = tp->sec;
-    r->start_msec = tp->msec;
+    r->start_time = ngx_current_msec;
 
     r->method = NGX_HTTP_UNKNOWN;
     r->http_version = NGX_HTTP_VERSION_10;

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -412,8 +412,7 @@ struct ngx_http_request_s {
     ngx_http_request_body_t          *request_body;
 
     time_t                            lingering_time;
-    time_t                            start_sec;
-    ngx_msec_t                        start_msec;
+    ngx_msec_t                        start_time;
 
     ngx_uint_t                        method;
     ngx_uint_t                        http_version;

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -2270,7 +2270,6 @@ ngx_http_variable_request_time(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data)
 {
     u_char          *p;
-    ngx_time_t      *tp;
     ngx_msec_int_t   ms;
 
     p = ngx_pnalloc(r->pool, NGX_TIME_T_LEN + 4);
@@ -2278,10 +2277,7 @@ ngx_http_variable_request_time(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    tp = ngx_timeofday();
-
-    ms = (ngx_msec_int_t)
-             ((tp->sec - r->start_sec) * 1000 + (tp->msec - r->start_msec));
+    ms = (ngx_msec_int_t) (ngx_current_msec - r->start_time);
     ms = ngx_max(ms, 0);
 
     v->len = ngx_sprintf(p, "%T.%03M", (time_t) ms / 1000, ms % 1000) - p;

--- a/src/http/ngx_http_write_filter_module.c
+++ b/src/http/ngx_http_write_filter_module.c
@@ -268,7 +268,8 @@ ngx_http_write_filter(ngx_http_request_t *r, ngx_chain_t *in)
             r->limit_rate_after_set = 1;
         }
 
-        limit = (off_t) r->limit_rate * (ngx_time() - r->start_sec + 1)
+        limit = (off_t) r->limit_rate
+                * (ngx_current_msec / 1000 - r->start_time / 1000 + 1)
                 - (c->sent - r->limit_rate_after);
 
         if (limit <= 0) {

--- a/src/stream/ngx_stream.h
+++ b/src/stream/ngx_stream.h
@@ -264,8 +264,7 @@ struct ngx_stream_session_s {
     ngx_connection_t              *connection;
 
     off_t                          received;
-    time_t                         start_sec;
-    ngx_msec_t                     start_msec;
+    ngx_msec_t                     start_time;
 
     ngx_log_handler_pt             log_handler;
 

--- a/src/stream/ngx_stream_handler.c
+++ b/src/stream/ngx_stream_handler.c
@@ -23,7 +23,6 @@ ngx_stream_init_connection(ngx_connection_t *c)
     u_char                        text[NGX_SOCKADDR_STRLEN];
     size_t                        len;
     ngx_uint_t                    i;
-    ngx_time_t                   *tp;
     ngx_event_t                  *rev;
     struct sockaddr              *sa;
     ngx_stream_port_t            *port;
@@ -173,9 +172,7 @@ ngx_stream_init_connection(ngx_connection_t *c)
         return;
     }
 
-    tp = ngx_timeofday();
-    s->start_sec = tp->sec;
-    s->start_msec = tp->msec;
+    s->start_time = ngx_current_msec;
 
     rev = c->read;
     rev->handler = ngx_stream_session_handler;

--- a/src/stream/ngx_stream_variables.c
+++ b/src/stream/ngx_stream_variables.c
@@ -776,7 +776,6 @@ ngx_stream_variable_session_time(ngx_stream_session_t *s,
     ngx_stream_variable_value_t *v, uintptr_t data)
 {
     u_char          *p;
-    ngx_time_t      *tp;
     ngx_msec_int_t   ms;
 
     p = ngx_pnalloc(s->connection->pool, NGX_TIME_T_LEN + 4);
@@ -784,10 +783,7 @@ ngx_stream_variable_session_time(ngx_stream_session_t *s,
         return NGX_ERROR;
     }
 
-    tp = ngx_timeofday();
-
-    ms = (ngx_msec_int_t)
-             ((tp->sec - s->start_sec) * 1000 + (tp->msec - s->start_msec));
+    ms = (ngx_msec_int_t) (ngx_current_msec - s->start_time);
     ms = ngx_max(ms, 0);
 
     v->len = ngx_sprintf(p, "%T.%03M", (time_t) ms / 1000, ms % 1000) - p;


### PR DESCRIPTION
```
Switch to ngx_current_msec for $request_time tracking#1254

This ensures that $request_time (and $session_time in stream) is not
affected by system time changes on platforms with monotonic time
available.

Also, it is now tracked similarly to $upstream_response_time, and there
should be no unexpected differences as previously observed with
clock_gettime(CLOCK_MONOTONIC_COARSE), see f29d7ade5 ("Removed
CLOCK_MONOTONIC_COARSE support.").

[ This required a slight tweak to the limit calculation in
  ngx_http_write_filter() due to r->start_sec being no more. Maxim has a
  preceding commit which significantly changes this calculation as part
  of a larger change in 9378:dbc717370186 ("Changed limit_rate algorithm
  to leaky bucket."). Also tweaked commit message to refer to git commit
  rather than mercurial. ]

Closes: https://github.com/nginx/nginx/issues/1235
Origin: <https://freenginx.org/hg/nginx/rev/2edfdf15f9b4>
Co-authored-by: Andrew Clayton <a.clayton@nginx.com>
Signed-off-by: Andrew Clayton <a.clayton@nginx.com>
```