### PR TITLE
conf/mime.types: add mjs extension for JavaScript modules

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -5,7 +5,7 @@ types {
     text/xml                                         xml;
     image/gif                                        gif;
     image/jpeg                                       jpeg jpg;
-    application/javascript                           js;
+    application/javascript                           js mjs;
     application/atom+xml                             atom;
     application/rss+xml                              rss;
 


### PR DESCRIPTION
ES modules use the .mjs extension as defined by Node.js and now widely used across the JavaScript ecosystem. Without this mapping, nginx serves .mjs files as application/octet-stream, causing browsers to refuse to execute them as JavaScript modules with the error:

"Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of application/octet-stream."

This affects any nginx user serving ES module JavaScript files, including users of Nextcloud's ExApp framework and any application using native ES modules.

### Proposed changes

ES modules use the .mjs extension as defined by Node.js and now widely used across the JavaScript ecosystem. Without this mapping, nginx serves .mjs files as application/octet-stream, causing browsers to refuse to execute them as JavaScript modules with the error: "Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of application/octet-stream."

This affects any nginx user serving ES module JavaScript files, including users of Nextcloud's ExApp framework and any application using native ES modules.
### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [X ] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [X ] I have checked that NGINX compiles and runs after adding my changes.
