### PR TITLE
Charset: fix buffer over-read in recode_from_utf8().

### DIFF
--- a/src/http/modules/ngx_http_charset_filter_module.c
+++ b/src/http/modules/ngx_http_charset_filter_module.c
@@ -689,7 +689,6 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
     u_char        c, *p, *src, *dst, *saved, **table;
     uint32_t      n;
     ngx_buf_t    *b;
-    ngx_uint_t    i;
     ngx_chain_t  *out, *cl, **ll;
 
     src = buf->pos;
@@ -783,18 +782,12 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pool->log, 0,
                    "http charset utf saved: %z", ctx->saved_len);
 
-    p = src;
-
-    for (i = ctx->saved_len; i < NGX_UTF_LEN; i++) {
-        ctx->saved[i] = *p++;
-
-        if (p == buf->last) {
-            break;
-        }
-    }
+    len = ngx_min(NGX_UTF_LEN - ctx->saved_len, (size_t) (buf->last - src));
+    ngx_memcpy(&ctx->saved[ctx->saved_len], src, len);
+    len += ctx->saved_len;
 
     saved = ctx->saved;
-    n = ngx_utf8_decode(&saved, i);
+    n = ngx_utf8_decode(&saved, len);
 
     c = '\0';
 
@@ -810,7 +803,7 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
 
         /* incomplete UTF-8 symbol */
 
-        if (i < NGX_UTF_LEN) {
+        if (len < NGX_UTF_LEN) {
             out = ngx_http_charset_get_buf(pool, ctx);
             if (out == NULL) {
                 return NULL;
@@ -823,8 +816,7 @@ ngx_http_charset_recode_from_utf8(ngx_pool_t *pool, ngx_buf_t *buf,
             b->sync = 1;
             b->shadow = buf;
 
-            ngx_memcpy(&ctx->saved[ctx->saved_len], src, i);
-            ctx->saved_len += i;
+            ctx->saved_len = len;
 
             return out;
         }


### PR DESCRIPTION
When a multi-byte UTF-8 character was split across 3+ single-byte buffers, the saved bytes continuation path had two related bugs:

ngx_utf8_decode() was called with the last saved-array index instead of the byte count, causing it to report "incomplete" even when the sequence was already complete.

The subsequent ngx_memcpy() used that same index as the copy length, reading past the input buffer boundary.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
