### PR TITLE
SSL: log SSL_R_RECORD_LAYER_FAILURE at info level

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -3966,6 +3966,9 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
 #ifdef SSL_R_BAD_ECPOINT
             || n == SSL_R_BAD_ECPOINT                                /*  306 */
 #endif
+#ifdef SSL_R_RECORD_LAYER_FAILURE
+            || n == SSL_R_RECORD_LAYER_FAILURE                       /*  313 */
+#endif
 #ifdef SSL_R_RENEGOTIATE_EXT_TOO_LONG
             || n == SSL_R_RENEGOTIATE_EXT_TOO_LONG                   /*  335 */
             || n == SSL_R_RENEGOTIATION_ENCODING_ERR                 /*  336 */


### PR DESCRIPTION
### Proposed changes

Fixes #961

With modern OpenSSL and TLSv1.3, when a client sends a bad record MAC,
OpenSSL pushes two errors onto the error stack:

1. `SSL_R_DECRYPTION_FAILED_OR_BAD_RECORD_MAC` (281) — the actual error
2. `SSL_R_RECORD_LAYER_FAILURE` (313) — a wrapper pushed on top

Since `ngx_ssl_connection_error()` uses `ERR_peek_last_error()`, it reads
the **last** error pushed — which is `SSL_R_RECORD_LAYER_FAILURE` (313).
This code is not in the allowlist, so it falls through to the default
`NGX_LOG_CRIT` level instead of `NGX_LOG_INFO`.

The result: high-traffic servers running TLSv1.3 with modern OpenSSL get
flooded with `[crit]` log entries for normal client-side disconnects:

```
[crit] SSL_read() failed (SSL: error:0A000119:SSL routines::decryption
failed or bad record mac error:0A000139:SSL routines::record layer failure)
```

The fix adds `SSL_R_RECORD_LAYER_FAILURE` to the list of errors demoted
to the `info` log level for client connections, guarded by `#ifdef` to
maintain compatibility with older OpenSSL versions that may not define it.

### Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.