### PR TITLE
Restrict duplicate TE headers in HTTP/2 and HTTP/3.

### DIFF
--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3849,7 +3849,8 @@ ngx_http_v2_run_request(ngx_http_request_t *r)
     }
 
     if (r->headers_in.te
-        && (r->headers_in.te->value.len != 8
+        && (r->headers_in.te->next
+            || r->headers_in.te->value.len != 8
             || ngx_strncasecmp(r->headers_in.te->value.data,
                                (u_char *) "trailers", 8) != 0))
     {

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -1050,7 +1050,8 @@ ngx_http_v3_process_request_header(ngx_http_request_t *r)
     }
 
     if (r->headers_in.te
-        && (r->headers_in.te->value.len != 8
+        && (r->headers_in.te->next
+            || r->headers_in.te->value.len != 8
             || ngx_strncasecmp(r->headers_in.te->value.data,
                                (u_char *) "trailers", 8) != 0))
     {


### PR DESCRIPTION
Following d3a76322cf7a, this change rejects requests which have multiple TE headers.

Reported-by: geeknik <geeknik@protonmail.ch>
