### PR TITLE
Win32: recycle failed AcceptEx connections

### DIFF
--- a/src/event/ngx_event_acceptex.c
+++ b/src/event/ngx_event_acceptex.c
@@ -11,6 +11,7 @@
 
 
 static void ngx_close_posted_connection(ngx_connection_t *c);
+static void ngx_event_acceptex_recycle(ngx_listening_t *ls, ngx_connection_t *c);
 
 
 void
@@ -29,6 +30,7 @@ ngx_event_acceptex(ngx_event_t *rev)
     if (rev->ovlp.error) {
         ngx_log_error(NGX_LOG_CRIT, c->log, rev->ovlp.error,
                       "AcceptEx() %V failed", &ls->addr_text);
+        ngx_event_acceptex_recycle(ls, c);
         return;
     }
 
@@ -41,7 +43,7 @@ ngx_event_acceptex(ngx_event_t *rev)
         ngx_log_error(NGX_LOG_CRIT, c->log, ngx_socket_errno,
                       "setsockopt(SO_UPDATE_ACCEPT_CONTEXT) failed for %V",
                       &c->addr_text);
-        /* TODO: close socket */
+        ngx_event_acceptex_recycle(ls, c);
         return;
     }
 
@@ -63,7 +65,7 @@ ngx_event_acceptex(ngx_event_t *rev)
     if (ls->addr_ntop) {
         c->addr_text.data = ngx_pnalloc(c->pool, ls->addr_text_max_len);
         if (c->addr_text.data == NULL) {
-            /* TODO: close socket */
+            ngx_event_acceptex_recycle(ls, c);
             return;
         }
 
@@ -71,7 +73,7 @@ ngx_event_acceptex(ngx_event_t *rev)
                                          c->addr_text.data,
                                          ls->addr_text_max_len, 0);
         if (c->addr_text.len == 0) {
-            /* TODO: close socket */
+            ngx_event_acceptex_recycle(ls, c);
             return;
         }
     }
@@ -198,6 +200,15 @@ ngx_event_post_acceptex(ngx_listening_t *ls, ngx_uint_t n)
     }
 
     return NGX_OK;
+}
+
+
+static void
+ngx_event_acceptex_recycle(ngx_listening_t *ls, ngx_connection_t *c)
+{
+    ngx_close_posted_connection(c);
+
+    (void) ngx_event_post_acceptex(ls, 1);
 }
 
 


### PR DESCRIPTION
### Proposed changes

`ngx_event_acceptex()` had several error exits that logged and returned without closing the accepted connection or reposting a replacement `AcceptEx` request. On Win32, repeated failures in these paths could leak connection resources and reduce listener capacity over time.

This change introduces a small recycle helper that closes the failed posted connection and reposts a replacement `AcceptEx` request.

The helper is now used for:
- overlapped `AcceptEx` completion errors
- `SO_UPDATE_ACCEPT_CONTEXT` failures
- address text allocation failures
- `ngx_sock_ntop()` failures

This keeps the listener accepting new connections even when these edge-case failures occur.

Windows compile validation is expected from CI/buildbot. Runtime verification of the `AcceptEx` failure path has not been performed locally.

### Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [ ] I have checked that NGINX compiles and runs after adding my changes.
