### PR TITLE
Style.

### DIFF
--- a/src/http/modules/ngx_http_upstream_zone_module.c
+++ b/src/http/modules/ngx_http_upstream_zone_module.c
@@ -863,7 +863,7 @@ ngx_http_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
 
 again:
 
-    for (peerp = &peers->peer; *peerp; /* void */ ) {
+    for (peerp = &peers->peer; *peerp; /* void */) {
         peer = *peerp;
 
         if (peer->host != host) {

--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -467,7 +467,7 @@ ngx_http_script_compile(ngx_http_script_compile_t *sc)
         return NGX_ERROR;
     }
 
-    for (i = 0; i < sc->source->len; /* void */ ) {
+    for (i = 0; i < sc->source->len; /* void */) {
 
         name.len = 0;
 

--- a/src/stream/ngx_stream_script.c
+++ b/src/stream/ngx_stream_script.c
@@ -371,7 +371,7 @@ ngx_stream_script_compile(ngx_stream_script_compile_t *sc)
         return NGX_ERROR;
     }
 
-    for (i = 0; i < sc->source->len; /* void */ ) {
+    for (i = 0; i < sc->source->len; /* void */) {
 
         name.len = 0;
 

--- a/src/stream/ngx_stream_upstream_zone_module.c
+++ b/src/stream/ngx_stream_upstream_zone_module.c
@@ -838,7 +838,7 @@ ngx_stream_upstream_zone_resolve_handler(ngx_resolver_ctx_t *ctx)
 
 again:
 
-    for (peerp = &peers->peer; *peerp; /* void */ ) {
+    for (peerp = &peers->peer; *peerp; /* void */) {
         peer = *peerp;
 
         if (peer->host != host) {


### PR DESCRIPTION
### Proposed changes

While working on https://github.com/nginx/nginx/pull/1261, I noticed discrepancies in the `/* void */` style for omitted expressions in for-loop statements.
This changes brings the consistency to what's is documented in the [DevGuide](https://nginx.org/en/docs/dev/development_guide.html) examples.

Also supported by the actual distribution:

```
$ fgrep -r 'for (' src | egrep ' void \*/)' 
src/core/ngx_output_chain.c:    for (cl = ctx->out; cl && cl != chain; /* void */) {
src/stream/ngx_stream_write_filter_module.c:            for (cl = *out; cl; /* void */) {
src/stream/ngx_stream_write_filter_module.c:    for (cl = *out; cl && cl != chain; /* void */) {
src/http/ngx_http_write_filter_module.c:            for (cl = r->out; cl; /* void */) {
src/http/ngx_http_write_filter_module.c:    for (cl = r->out; cl && cl != chain; /* void */) {
src/http/ngx_http_request_body.c:    for (cl = rb->bufs; cl; /* void */) {
src/http/ngx_http_request.c:            for (cl = hc->busy; cl; /* void */) {
src/http/ngx_http_request.c:        for (cl = hc->free; cl; /* void */) {
src/http/ngx_http_request.c:        for (cl = hc->busy; cl; /* void */) {
src/http/modules/ngx_http_dav_module.c:        for (i = 0; i < r->uri.len; /* void */) {
src/http/modules/ngx_http_gzip_filter_module.c:    for (cl = ctx->copied; cl; /* void */) {
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
