### PR TITLE
Fix README OpenSSL warning block rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ sudo apt install libpcre3-dev zlib1g-dev
 > [!WARNING]
 > This is the minimal set of dependency libraries needed to build NGINX with rewriting and gzip capabilities. Other dependencies may be required if you choose to build NGINX with additional modules. Monitor the output of the `configure` command discussed in the following sections for information on which modules may be missing. For example, if you plan to use SSL certificates to encrypt traffic with TLS, you'll need to install the OpenSSL library. To do so, issue the following command.
 
->```bash
->sudo apt install libssl-dev
+> ```bash
+> sudo apt install libssl-dev
+> ```
 
 ## Cloning the NGINX GitHub repository
 Using your preferred method, clone the NGINX repository into your development directory. See [Cloning a GitHub Repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) for additional help.


### PR DESCRIPTION

**Repo:** nginx/nginx (⭐ 25000)
**Type:** docs
**Files changed:** 1
**Lines:** +3/-2

## What
This change fixes the quoted OpenSSL installation example in `README.md` by restoring the missing closing code fence and aligning the blockquote fence formatting with the surrounding Markdown style.

## Why
The broken fenced block causes the README's build instructions to render incorrectly after the OpenSSL warning section, which makes the source-build documentation harder to read and follow. Fixing the fence restores correct Markdown rendering without changing any product behavior.

## Testing
Verified the exact README section locally after the edit and confirmed the committed diff is limited to the malformed Markdown block. No code tests were needed because this is a documentation-only change.

## Risk
Low / Documentation-only change in a single file with no runtime impact.
