### PR TITLE
Realip: support variables in the real_ip_header directive

### DIFF
--- a/src/http/modules/ngx_http_realip_module.c
+++ b/src/http/modules/ngx_http_realip_module.c
@@ -10,18 +10,20 @@
 #include <ngx_http.h>
 
 
-#define NGX_HTTP_REALIP_XREALIP  0
-#define NGX_HTTP_REALIP_XFWD     1
-#define NGX_HTTP_REALIP_HEADER   2
-#define NGX_HTTP_REALIP_PROXY    3
+#define NGX_HTTP_REALIP_XREALIP     0
+#define NGX_HTTP_REALIP_XFWD        1
+#define NGX_HTTP_REALIP_HEADER      2
+#define NGX_HTTP_REALIP_PROXY       3
+#define NGX_HTTP_REALIP_EXPRESSION  4
 
 
 typedef struct {
-    ngx_array_t       *from;     /* array of ngx_cidr_t */
-    ngx_uint_t         type;
-    ngx_uint_t         hash;
-    ngx_str_t          header;
-    ngx_flag_t         recursive;
+    ngx_array_t               *from;     /* array of ngx_cidr_t */
+    ngx_uint_t                 type;
+    ngx_uint_t                 hash;
+    ngx_str_t                  header;
+    ngx_http_complex_value_t  *addresses;
+    ngx_flag_t                 recursive;
 } ngx_http_realip_loc_conf_t;
 
 
@@ -131,7 +133,7 @@ ngx_http_realip_handler(ngx_http_request_t *r)
 {
     u_char                      *p;
     size_t                       len;
-    ngx_str_t                   *value;
+    ngx_str_t                   *value, addrs_value;
     ngx_uint_t                   i, hash;
     ngx_addr_t                   addr;
     ngx_list_part_t             *part;
@@ -184,6 +186,23 @@ ngx_http_realip_handler(ngx_http_request_t *r)
         }
 
         value = &r->connection->proxy_protocol->src_addr;
+        xfwd = NULL;
+
+        break;
+
+    case NGX_HTTP_REALIP_EXPRESSION:
+
+        if (ngx_http_complex_value(r, rlcf->addresses, &addrs_value)
+            != NGX_OK)
+        {
+            return NGX_DECLINED;
+        }
+
+        if (addrs_value.len == 0) {
+            return NGX_DECLINED;
+        }
+
+        value = &addrs_value;
         xfwd = NULL;
 
         break;
@@ -418,7 +437,9 @@ ngx_http_realip(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
     ngx_http_realip_loc_conf_t *rlcf = conf;
 
-    ngx_str_t  *value;
+    ngx_str_t                         *value;
+    ngx_http_complex_value_t           cv;
+    ngx_http_compile_complex_value_t   ccv;
 
     if (rlcf->type != NGX_CONF_UNSET_UINT) {
         return "is duplicate";
@@ -438,6 +459,29 @@ ngx_http_realip(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (ngx_strcmp(value[1].data, "proxy_protocol") == 0) {
         rlcf->type = NGX_HTTP_REALIP_PROXY;
+        return NGX_CONF_OK;
+    }
+
+    ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
+
+    ccv.cf = cf;
+    ccv.value = &value[1];
+    ccv.complex_value = &cv;
+
+    if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (cv.lengths != NULL) {
+        rlcf->addresses = ngx_palloc(cf->pool,
+                                     sizeof(ngx_http_complex_value_t));
+        if (rlcf->addresses == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        *rlcf->addresses = cv;
+        rlcf->type = NGX_HTTP_REALIP_EXPRESSION;
+
         return NGX_CONF_OK;
     }
 
@@ -465,6 +509,7 @@ ngx_http_realip_create_loc_conf(ngx_conf_t *cf)
      *     conf->from = NULL;
      *     conf->hash = 0;
      *     conf->header = { 0, NULL };
+     *     conf->addresses = NULL;
      */
 
     conf->type = NGX_CONF_UNSET_UINT;
@@ -490,6 +535,10 @@ ngx_http_realip_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     if (conf->header.len == 0) {
         conf->hash = prev->hash;
         conf->header = prev->header;
+    }
+
+    if (conf->addresses == NULL) {
+        conf->addresses = prev->addresses;
     }
 
     return NGX_CONF_OK;


### PR DESCRIPTION
### Proposed changes

Extend the `real_ip_header` directive to support variables in its
value. When the argument contains at least one variable, it is
interpreted as the value from which to extract the real IP rather
than as a plain header name.

Use case: fetching the real IP from more than one source, e.g.
running nginx behind PROXY protocol and wanting to trust a real IP
header from clients. In that case, you can use a config like:

    map $http_x_forwarded_for $real_ip_src {
        ""       $proxy_protocol_addr;
        default  "$http_x_forwarded_for,$proxy_protocol_addr";
    }

    real_ip_header $real_ip_src;
    include trusted_real_ips;
    real_ip_recursive on;

This option has been requested before, see:

* https://trac.nginx.org/nginx/ticket/2350 — in the comments,
  Maxim Dounin suggests teaching http_real_ip to read variables
* https://github.com/kubernetes/ingress-nginx/issues/11623

If you're interested in this PR, I can also offer to add the tests:
https://github.com/nginx/nginx-tests/compare/master...CthulhuDen:nginx-tests:http-real-ip-variables

This is a new iteration of https://github.com/nginx/nginx/pull/1288
because Github doesn't allow me to re-open the old PR after force-push.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
