### PR TITLE
Dav: Added path validation for COPY and MOVE operations

### DIFF
--- a/src/http/modules/ngx_http_dav_module.c
+++ b/src/http/modules/ngx_http_dav_module.c
@@ -733,6 +733,35 @@ overwrite_done:
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http copy to: \"%s\"", copy.path.data);
 
+    len = path.len - 1;
+
+    if (len > 0 && path.data[len - 1] == '/') {
+        len--;
+    }
+
+    if (len == copy.path.len
+        && ngx_strncmp(path.data, copy.path.data, len) == 0)
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "both URI \"%V\" and \"Destination\" URI \"%V\" "
+                      "point to the same location",
+                      &r->uri, &dest->value);
+        return NGX_HTTP_FORBIDDEN;
+    }
+
+    if (slash
+        && ngx_strncmp(path.data, copy.path.data,
+                       ngx_min(len, copy.path.len)) == 0
+        && (len < copy.path.len
+            ? copy.path.data[len] == '/'
+            : path.data[copy.path.len] == '/'))
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "\"%V\" could not be %Ved to collection \"%V\"",
+                      &r->uri, &r->method_name, &dest->value);
+        return NGX_HTTP_FORBIDDEN;
+    }
+
     if (ngx_link_info(copy.path.data, &fi) == NGX_FILE_ERROR) {
         err = ngx_errno;
 


### PR DESCRIPTION
The COPY and MOVE handler did not validate whether the resolved source and destination filesystem paths referred to the same resource or to a parent-child relationship between collections.

When a COPY request had the Destination header pointing to the same resource, ngx_copy_file() opened the destination with O_TRUNC before reading the source, destroying the file content and resulting in a zero-length file.  A MOVE to the same path could similarly remove the source before completing the operation.

When a collection was copied or moved into its own subtree, the recursive walk could produce unbounded nesting or corrupt the directory structure.

Fix: after resolving both paths and stripping trailing slashes, compare them for equality and return 403 (Forbidden) if they match. Additionally, when the destination is a collection, check whether either path is a prefix of the other separated by "/" and reject such requests with 403 as well.'

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR's description or commit message.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have checked that NGINX compiles and runs after adding my changes.
