### PR TITLE
Configure: fix gcc version detection in some corner cases

### DIFF
--- a/auto/cc/name
+++ b/auto/cc/name
@@ -57,7 +57,7 @@ elif `$CC -v 2>&1 | grep 'gcc version' >/dev/null 2>&1`; then
     NGX_CC_NAME=gcc
     echo " + using GNU C compiler"
 
-    NGX_CC_VER=`$CC -v 2>&1 | sed -n -e 's/^.*gcc version \(.*\)/\1/p'`
+    NGX_CC_VER=`$CC -v 2>&1 | sed -n -e 's/^gcc version \(.*\)/\1/p'`
     echo " + gcc version: $NGX_CC_VER"
 
     have=NGX_COMPILER value="\"gcc $NGX_CC_VER\"" . auto/define


### PR DESCRIPTION
```
Configure: fix gcc version detection in some corner cases

If the "gcc version ... " string appeared within "Configured with:", it
was picked up rather than the real gcc version string. This might then
break the configure scripts due to a malformed NGX_COMPILER macro.

The simple fix is to look for "gcc version ... " at the start of the
line, rather than anywhere within.

GCC versions going back to at least 1.27 (checked via godbolt.org) all
have "gcc version ... " at the start of the line.

Suggested-by: Aleksei Bavshin <a.bavshin@nginx.com>
Fixes: c15717285 ("nginx-0.1.25-RELEASE import")
Closes: https://github.com/nginx/nginx/issues/1278
```