### PR TITLE
Updating NGINX logos to 2026 brand guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/9335b488-ffcc-4157-8364-2370a0b70ad0">
-  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/3a7eeb08-1133-47f5-859c-fad4f5a6a013">
+  <source media="(prefers-color-scheme: dark)" srcset="https://nginx.org/img/nginx_logo_dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://nginx.org/img/nginx_logo.svg">
   <img alt="NGINX Banner">
 </picture>
 


### PR DESCRIPTION
## Problem

NGINX brand guidelines updated. New logos need to be applied. README.md refers to an S3 location for the logo image files. Needs to change to nginx.org

## Solution

Updating nginx project logos with 2026 update - NGINX Sponsored by F5.
Aligning to latest F5 brand guidelines.
Linking to image files hosted on nginx.org.

## Testing

Light and dark mode both tested.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)
