### PR TITLE
Cache: warn when proxy_cache_min_uses exceeds the uses bitfield range.

### DIFF
--- a/src/http/modules/ngx_http_fastcgi_module.c
+++ b/src/http/modules/ngx_http_fastcgi_module.c
@@ -3166,6 +3166,15 @@ ngx_http_fastcgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         return NGX_CONF_ERROR;
     }
 
+    if (conf->upstream.cache_min_uses != NGX_CONF_UNSET_UINT
+        && conf->upstream.cache_min_uses > 1023)
+    {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "\"fastcgi_cache_min_uses\" value %ui exceeds 1023 "
+                           "and effectively disables caching",
+                           conf->upstream.cache_min_uses);
+    }
+
     ngx_conf_merge_uint_value(conf->upstream.cache_min_uses,
                               prev->upstream.cache_min_uses, 1);
 

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -3849,6 +3849,15 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         return NGX_CONF_ERROR;
     }
 
+    if (conf->upstream.cache_min_uses != NGX_CONF_UNSET_UINT
+        && conf->upstream.cache_min_uses > 1023)
+    {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "\"proxy_cache_min_uses\" value %ui exceeds 1023 "
+                           "and effectively disables caching",
+                           conf->upstream.cache_min_uses);
+    }
+
     ngx_conf_merge_uint_value(conf->upstream.cache_min_uses,
                               prev->upstream.cache_min_uses, 1);
 

--- a/src/http/modules/ngx_http_scgi_module.c
+++ b/src/http/modules/ngx_http_scgi_module.c
@@ -1579,6 +1579,15 @@ ngx_http_scgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         return NGX_CONF_ERROR;
     }
 
+    if (conf->upstream.cache_min_uses != NGX_CONF_UNSET_UINT
+        && conf->upstream.cache_min_uses > 1023)
+    {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "\"scgi_cache_min_uses\" value %ui exceeds 1023 "
+                           "and effectively disables caching",
+                           conf->upstream.cache_min_uses);
+    }
+
     ngx_conf_merge_uint_value(conf->upstream.cache_min_uses,
                               prev->upstream.cache_min_uses, 1);
 

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -1839,6 +1839,15 @@ ngx_http_uwsgi_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         return NGX_CONF_ERROR;
     }
 
+    if (conf->upstream.cache_min_uses != NGX_CONF_UNSET_UINT
+        && conf->upstream.cache_min_uses > 1023)
+    {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "\"uwsgi_cache_min_uses\" value %ui exceeds 1023 "
+                           "and effectively disables caching",
+                           conf->upstream.cache_min_uses);
+    }
+
     ngx_conf_merge_uint_value(conf->upstream.cache_min_uses,
                               prev->upstream.cache_min_uses, 1);
 


### PR DESCRIPTION
## Problem

The "uses" counter on ngx_http_cache_node_t is a 10-bit field, so once "{proxy,fastcgi,uwsgi,scgi}_cache_min_uses" is configured at 1024 or greater the threshold can never be reached and caching is silently disabled.  Emit a config-time warning at the point where the directive is set so the misconfiguration is visible without code reading.

## Solution

Emit a config time warning 


## Testing

- [x] Manual Testing


## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)