### PR TITLE
Proxy: fix keepalive for HTTP/2 when no body is specified

### DIFF
--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -910,6 +910,8 @@ ngx_http_proxy_v2_create_request(ngx_http_request_t *r)
             f = (ngx_http_proxy_v2_frame_t *) headers_frame;
             f->flags |= NGX_HTTP_V2_END_STREAM_FLAG;
         }
+
+        b->last_buf = 1;
     }
 
     u->output.output_filter = ngx_http_proxy_v2_body_output_filter;


### PR DESCRIPTION
Previously, when an HTTP/2 request consisted of only the header buffer, the b->last_buf flag was not set.  This prevented ctx->output_closed from being set after processing this buffer.  This prevented u->keepalive from being set on upstream connection closure.  This prevented the connection from being stored in the keepalive cache.