### PR TITLE
SSL: ssl_sigalgs option

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -1842,6 +1842,24 @@ ngx_ssl_ecdh_curve(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *name)
 
 
 ngx_int_t
+ngx_ssl_sigalgs(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *sigalgs)
+{
+    if (sigalgs->len == 0) {
+        return NGX_OK;
+    }
+
+    if (SSL_CTX_set1_sigalgs_list(ssl->ctx, (char *) sigalgs->data) == 0) {
+        ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0,
+                      "SSL_CTX_set1_sigalgs_list(\"%V\") failed",
+                      sigalgs);
+        return NGX_ERROR;
+    }
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
 ngx_ssl_early_data(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_uint_t enable)
 {
     if (!enable) {

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -279,6 +279,7 @@ ngx_int_t ngx_ssl_dhparam(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *file);
 ngx_int_t ngx_ssl_ech_files(ngx_conf_t *cf, ngx_ssl_t *ssl,
     ngx_array_t *filename);
 ngx_int_t ngx_ssl_ecdh_curve(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *name);
+ngx_int_t ngx_ssl_sigalgs(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *sigalgs);
 ngx_int_t ngx_ssl_early_data(ngx_conf_t *cf, ngx_ssl_t *ssl,
     ngx_uint_t enable);
 ngx_int_t ngx_ssl_conf_commands(ngx_conf_t *cf, ngx_ssl_t *ssl,

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -152,6 +152,13 @@ static ngx_command_t  ngx_http_ssl_commands[] = {
       offsetof(ngx_http_ssl_srv_conf_t, ecdh_curve),
       NULL },
 
+    { ngx_string("ssl_sigalgs"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_ssl_srv_conf_t, sigalgs),
+      NULL },
+
     { ngx_string("ssl_protocols"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_1MORE,
       ngx_conf_set_bitmask_slot,
@@ -637,6 +644,7 @@ ngx_http_ssl_create_srv_conf(ngx_conf_t *cf)
      *     sscf->certificate_values = NULL;
      *     sscf->dhparam = { 0, NULL };
      *     sscf->ecdh_curve = { 0, NULL };
+     *     sscf->sigalgs = { 0, NULL };
      *     sscf->client_certificate = { 0, NULL };
      *     sscf->trusted_certificate = { 0, NULL };
      *     sscf->crl = { 0, NULL };
@@ -723,6 +731,8 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_str_value(conf->ecdh_curve, prev->ecdh_curve,
                          NGX_DEFAULT_ECDH_CURVE);
+
+    ngx_conf_merge_str_value(conf->sigalgs, prev->sigalgs, "");
 
     ngx_conf_merge_str_value(conf->ciphers, prev->ciphers, NGX_DEFAULT_CIPHERS);
 
@@ -902,6 +912,10 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     }
 
     if (ngx_ssl_ecdh_curve(cf, &conf->ssl, &conf->ecdh_curve) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (ngx_ssl_sigalgs(cf, &conf->ssl, &conf->sigalgs) != NGX_OK) {
         return NGX_CONF_ERROR;
     }
 

--- a/src/http/modules/ngx_http_ssl_module.h
+++ b/src/http/modules/ngx_http_ssl_module.h
@@ -43,6 +43,7 @@ typedef struct {
 
     ngx_str_t                       dhparam;
     ngx_str_t                       ecdh_curve;
+    ngx_str_t                       sigalgs;
     ngx_str_t                       client_certificate;
     ngx_str_t                       trusted_certificate;
     ngx_str_t                       crl;

--- a/src/mail/ngx_mail_ssl_module.c
+++ b/src/mail/ngx_mail_ssl_module.c
@@ -118,6 +118,13 @@ static ngx_command_t  ngx_mail_ssl_commands[] = {
       offsetof(ngx_mail_ssl_conf_t, ecdh_curve),
       NULL },
 
+    { ngx_string("ssl_sigalgs"),
+      NGX_MAIL_MAIN_CONF|NGX_MAIL_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_MAIL_SRV_CONF_OFFSET,
+      offsetof(ngx_mail_ssl_conf_t, sigalgs),
+      NULL },
+
     { ngx_string("ssl_protocols"),
       NGX_MAIL_MAIN_CONF|NGX_MAIL_SRV_CONF|NGX_CONF_1MORE,
       ngx_conf_set_bitmask_slot,
@@ -308,6 +315,7 @@ ngx_mail_ssl_create_conf(ngx_conf_t *cf)
      *     scf->protocols = 0;
      *     scf->dhparam = { 0, NULL };
      *     scf->ecdh_curve = { 0, NULL };
+     *     scf->sigalgs = { 0, NULL };
      *     scf->client_certificate = { 0, NULL };
      *     scf->trusted_certificate = { 0, NULL };
      *     scf->crl = { 0, NULL };
@@ -370,6 +378,8 @@ ngx_mail_ssl_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_str_value(conf->ecdh_curve, prev->ecdh_curve,
                          NGX_DEFAULT_ECDH_CURVE);
+
+    ngx_conf_merge_str_value(conf->sigalgs, prev->sigalgs, "");
 
     ngx_conf_merge_str_value(conf->client_certificate,
                          prev->client_certificate, "");
@@ -502,6 +512,10 @@ ngx_mail_ssl_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     }
 
     if (ngx_ssl_ecdh_curve(cf, &conf->ssl, &conf->ecdh_curve) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (ngx_ssl_sigalgs(cf, &conf->ssl, &conf->sigalgs) != NGX_OK) {
         return NGX_CONF_ERROR;
     }
 

--- a/src/mail/ngx_mail_ssl_module.h
+++ b/src/mail/ngx_mail_ssl_module.h
@@ -41,6 +41,7 @@ typedef struct {
 
     ngx_str_t        dhparam;
     ngx_str_t        ecdh_curve;
+    ngx_str_t        sigalgs;
     ngx_str_t        client_certificate;
     ngx_str_t        trusted_certificate;
     ngx_str_t        crl;

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -161,6 +161,13 @@ static ngx_command_t  ngx_stream_ssl_commands[] = {
       offsetof(ngx_stream_ssl_srv_conf_t, ecdh_curve),
       NULL },
 
+    { ngx_string("ssl_sigalgs"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_ssl_srv_conf_t, sigalgs),
+      NULL },
+
     { ngx_string("ssl_protocols"),
       NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_1MORE,
       ngx_conf_set_bitmask_slot,
@@ -897,6 +904,7 @@ ngx_stream_ssl_create_srv_conf(ngx_conf_t *cf)
      *     sscf->certificate_values = NULL;
      *     sscf->dhparam = { 0, NULL };
      *     sscf->ecdh_curve = { 0, NULL };
+     *     sscf->sigalgs = { 0, NULL };
      *     sscf->client_certificate = { 0, NULL };
      *     sscf->trusted_certificate = { 0, NULL };
      *     sscf->crl = { 0, NULL };
@@ -983,6 +991,8 @@ ngx_stream_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_str_value(conf->ecdh_curve, prev->ecdh_curve,
                          NGX_DEFAULT_ECDH_CURVE);
+
+    ngx_conf_merge_str_value(conf->sigalgs, prev->sigalgs, "");
 
     ngx_conf_merge_str_value(conf->ciphers, prev->ciphers, NGX_DEFAULT_CIPHERS);
 
@@ -1156,6 +1166,10 @@ ngx_stream_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     }
 
     if (ngx_ssl_ecdh_curve(cf, &conf->ssl, &conf->ecdh_curve) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    if (ngx_ssl_sigalgs(cf, &conf->ssl, &conf->sigalgs) != NGX_OK) {
         return NGX_CONF_ERROR;
     }
 

--- a/src/stream/ngx_stream_ssl_module.h
+++ b/src/stream/ngx_stream_ssl_module.h
@@ -42,6 +42,7 @@ typedef struct {
 
     ngx_str_t         dhparam;
     ngx_str_t         ecdh_curve;
+    ngx_str_t         sigalgs;
     ngx_str_t         client_certificate;
     ngx_str_t         trusted_certificate;
     ngx_str_t         crl;


### PR DESCRIPTION
## Problem

For compliance reasons, some systems are required to not use deprecated SHA-1 hashing method. When using OpenSSL, these algorithms should be possible to set by `ssl_conf_command` option, but this option is not available at least when using BoringSSl.

## Solution

Add new option `ssl_sigalgs` that will make possible to set supported signature algorithm.

## Testing

If you will agree to merge this, I can add functional tests.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes


