### PR TITLE
Split clients: improved calculation of range boundaries

### DIFF
--- a/src/http/modules/ngx_http_split_clients_module.c
+++ b/src/http/modules/ngx_http_split_clients_module.c
@@ -182,6 +182,11 @@ ngx_conf_split_clients_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     for (i = 0; i < ctx->parts.nelts; i++) {
         sum = part[i].percent ? sum + part[i].percent : 10000;
+
+        if (sum == 10000) {
+            part[i].percent = 0;
+        }
+
         if (sum > 10000) {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                "percent total is greater than 100%%");

--- a/src/stream/ngx_stream_split_clients_module.c
+++ b/src/stream/ngx_stream_split_clients_module.c
@@ -180,6 +180,11 @@ ngx_conf_split_clients_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     for (i = 0; i < ctx->parts.nelts; i++) {
         sum = part[i].percent ? sum + part[i].percent : 10000;
+
+        if (sum == 10000) {
+            part[i].percent = 0;
+        }
+
         if (sum > 10000) {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                "percent total is greater than 100%%");


### PR DESCRIPTION
## Problem

If the last variant was given an explicit percentage to reach 100%, it did not cover hash values on the range boundary or due to accumulating rounding error. 

## Solution

Now this corresponds to the configuration with "*".

## Testing

- [x] Manual Testing

Now it should work the same.

```
    split_clients $foo $bar {
        50%  one;
        50%  two;
    }

    split_clients $foo $bar {
        50%  one;
        *    two;
    }
```

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)
