### PR TITLE
Request body: reject client_body_buffer_size 0.

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -90,12 +90,17 @@ static char *ngx_http_disable_symlinks(ngx_conf_t *cf, ngx_command_t *cmd,
 
 static char *ngx_http_core_lowat_check(ngx_conf_t *cf, void *post, void *data);
 static char *ngx_http_core_pool_size(ngx_conf_t *cf, void *post, void *data);
+static char *ngx_http_core_client_body_buffer_size(ngx_conf_t *cf, void *post,
+    void *data);
 
 static ngx_conf_post_t  ngx_http_core_lowat_post =
     { ngx_http_core_lowat_check };
 
 static ngx_conf_post_handler_pt  ngx_http_core_pool_size_p =
     ngx_http_core_pool_size;
+
+static ngx_conf_post_t  ngx_http_core_client_body_buffer_size_post =
+    { ngx_http_core_client_body_buffer_size };
 
 
 static ngx_conf_enum_t  ngx_http_core_request_body_in_file[] = {
@@ -364,7 +369,7 @@ static ngx_command_t  ngx_http_core_commands[] = {
       ngx_conf_set_size_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_core_loc_conf_t, client_body_buffer_size),
-      NULL },
+      &ngx_http_core_client_body_buffer_size_post },
 
     { ngx_string("client_body_timeout"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
@@ -5455,6 +5460,22 @@ ngx_http_core_pool_size(ngx_conf_t *cf, void *post, void *data)
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                            "the pool size must be a multiple of %uz",
                            NGX_POOL_ALIGNMENT);
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+static char *
+ngx_http_core_client_body_buffer_size(ngx_conf_t *cf, void *post, void *data)
+{
+    size_t *sp = data;
+
+    if (*sp == 0) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "the client body buffer size cannot be zero");
+
         return NGX_CONF_ERROR;
     }
 


### PR DESCRIPTION
## Problem

A zero value for `client_body_buffer_size` causes `ngx_http_do_read_client_request_body()` to spin in userspace without calling `recv()`: the inner loop hits `size == 0` and breaks, and the outer `for(;;)` re-enters as long as `c->read->ready` is true and `rb->rest > 0`.

### Regression scope

- Introduced in `67d160bf25e02` — "Request body: reading body buffering in filters." (2021-08-29).
- First released in nginx 1.21.2 (2021-08-31).
- Still present on `master` / 1.30.0.

Prior to `67d160bf25e02`, `c->recv` was called even with `size == 0`, which led to `NGX_HTTP_BAD_REQUEST` instead of spinning (the exact return value depending on the transport).

The directive itself has no meaningful interpretation at zero: it sets the buffer size for reading the request body, and the read path needs a non-zero capacity to receive body data via `recv()`.

### References

- trac ticket #2548 (open, same root cause): https://trac.nginx.org/nginx/ticket/2548
- See also (incident in the wild with nginx 1.21.6): https://github.com/kubernetes/ingress-nginx/issues/10992

## Solution

Reject `client_body_buffer_size 0` at configuration parse time with `NGX_LOG_EMERG`, using the `ngx_conf_post_t` post-validator pattern. This mirrors the convention used by `http2_chunk_size` (`src/http/v2/ngx_http_v2_module.c`).

## Testing

- `nginx -t` with `client_body_buffer_size 0;` (and `0k`) at `http`, `server`, or `location` scope emits `[emerg] the client body buffer size cannot be zero` and exits 1.
- Existing valid values (`1`, `8k`, default) continue to parse without errors (`nginx -t` successful).
- `./auto/configure && make` succeeds without warnings.

Tests: nginx/nginx-tests#51 (https://github.com/nginx/nginx-tests/pull/51)

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards

## Release Notes

Configurations with `client_body_buffer_size 0` are now rejected at startup, avoiding a potential busy-loop on HTTP/1.x request body reads.