### PR TITLE
Fix the set-creation-date.yaml workflow

### DIFF
--- a/.github/workflows/set-creation-date.yaml
+++ b/.github/workflows/set-creation-date.yaml
@@ -53,7 +53,7 @@ jobs:
             }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER >project_data.json
 
           echo 'PROJECT_ID='$(jq -r '.data.organization.projectV2.id' project_data.json) >>$GITHUB_ENV
-          echo 'DATE_FIELD_ID='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Created at") | .id' project_data.json) >>$GITHUB_ENV
+          echo 'DATE_FIELD_ID='$(jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Created At") | .id' project_data.json) >>$GITHUB_ENV
 
       # Needed to get the item's Global ID
       - name: Add item to project

--- a/src/core/nginx.h
+++ b/src/core/nginx.h
@@ -9,8 +9,8 @@
 #define _NGINX_H_INCLUDED_
 
 
-#define nginx_version      1031000
-#define NGINX_VERSION      "1.31.0"
+#define nginx_version      1031001
+#define NGINX_VERSION      "1.31.1"
 #define NGINX_VER          "nginx/" NGINX_VERSION
 
 #ifdef NGX_BUILD


### PR DESCRIPTION
- **Version bump**

1.31.1

- **GH: fix set-creation-date.yaml workflow**

The 'Created at' field is 'Created At'
