### PR TITLE
HTTP error 495, https certificate error: "400 {The =>} SSL certificate error"

### DIFF
--- a/src/http/ngx_http_special_response.c
+++ b/src/http/ngx_http_special_response.c
@@ -261,11 +261,11 @@ CRLF
 
 static char ngx_http_error_495_page[] =
 "<html>" CRLF
-"<head><title>400 The SSL certificate error</title></head>"
+"<head><title>400 SSL certificate error</title></head>"
 CRLF
 "<body>" CRLF
 "<center><h1>400 Bad Request</h1></center>" CRLF
-"<center>The SSL certificate error</center>" CRLF
+"<center>SSL certificate error</center>" CRLF
 ;
 
 


### PR DESCRIPTION
## Problem

```
<html>
<head><title>400 The SSL certificate error</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<center>The SSL certificate error</center>
<hr><center>nginx</center>
</body>
</html>
```

## Solution

per 
```c
    ngx_string(ngx_http_error_495_page), /* 495, https certificate error */
```
this is supposed to be "SSL certificate error", not an unfilled placeholder (which is how me and a coworker read it).

## Testing

None.

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

> For 400 responses generated by the internal nginx "495, https certificate error" error, the error label is "SSL certificate error" instead of "The SSL certificate error".