### PR TITLE
Mail error path fixes

### DIFF
--- a/src/mail/ngx_mail_imap_handler.c
+++ b/src/mail/ngx_mail_imap_handler.c
@@ -48,6 +48,7 @@ ngx_mail_imap_init_session(ngx_mail_session_t *s, ngx_connection_t *c)
 
     if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
         ngx_mail_close_connection(c);
+        return;
     }
 
     ngx_mail_send(c->write);

--- a/src/mail/ngx_mail_pop3_handler.c
+++ b/src/mail/ngx_mail_pop3_handler.c
@@ -69,6 +69,7 @@ ngx_mail_pop3_init_session(ngx_mail_session_t *s, ngx_connection_t *c)
 
     if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
         ngx_mail_close_connection(c);
+        return;
     }
 
     ngx_mail_send(c->write);

--- a/src/mail/ngx_mail_proxy_module.c
+++ b/src/mail/ngx_mail_proxy_module.c
@@ -894,6 +894,7 @@ ngx_mail_proxy_write_handler(ngx_event_t *wev)
 
     if (ngx_handle_write_event(wev, 0) != NGX_OK) {
         ngx_mail_proxy_internal_server_error(s);
+        return;
     }
 
     if (c->read->ready) {

--- a/src/mail/ngx_mail_smtp_handler.c
+++ b/src/mail/ngx_mail_smtp_handler.c
@@ -340,6 +340,7 @@ ngx_mail_smtp_greeting(ngx_mail_session_t *s, ngx_connection_t *c)
 
     if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
         ngx_mail_close_connection(c);
+        return;
     }
 
     if (c->read->ready) {

--- a/src/mail/ngx_mail_smtp_handler.c
+++ b/src/mail/ngx_mail_smtp_handler.c
@@ -348,8 +348,8 @@ ngx_mail_smtp_greeting(ngx_mail_session_t *s, ngx_connection_t *c)
     }
 
     if (sscf->greeting_delay) {
-         c->read->handler = ngx_mail_smtp_invalid_pipelining;
-         return;
+        c->read->handler = ngx_mail_smtp_invalid_pipelining;
+        return;
     }
 
     c->read->handler = ngx_mail_smtp_init_protocol;


### PR DESCRIPTION
Previously, when `ngx_handle_read_event()` or `ngx_handle_write_event()` returned an error while handling an SMTP, POP3 or IMAP session, the released session memory could be accessed after handling the error.

It should be noticed here that the above mentioned error is unlikely.