### PR TITLE
SSL: add $ssl_sigalgs variable

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5670,6 +5670,104 @@ ngx_ssl_get_sigalg(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 
 
 ngx_int_t
+ngx_ssl_get_sigalgs(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+{
+#if (OPENSSL_VERSION_NUMBER >= 0x40000000L)
+
+    int            n, i;
+    size_t         len;
+    u_char        *p;
+    const char    *name;
+    unsigned int   codepoint;
+
+    n = SSL_get0_sigalg(c->ssl->connection, -1, NULL, NULL);
+
+    if (n <= 0) {
+        s->len = 0;
+        return NGX_OK;
+    }
+
+    len = 0;
+
+    for (i = 0; i < n; i++) {
+        SSL_get0_sigalg(c->ssl->connection, i, &codepoint, &name);
+        len += name ? ngx_strlen(name) : sizeof("0x0000") - 1;
+        len += sizeof(":") - 1;
+    }
+
+    s->data = ngx_pnalloc(pool, len);
+    if (s->data == NULL) {
+        return NGX_ERROR;
+    }
+
+    p = s->data;
+
+    for (i = 0; i < n; i++) {
+        SSL_get0_sigalg(c->ssl->connection, i, &codepoint, &name);
+
+        if (name) {
+            p = ngx_cpymem(p, name, ngx_strlen(name));
+
+        } else {
+            p = ngx_sprintf(p, "0x%04xd", codepoint);
+        }
+
+        *p++ = ':';
+    }
+
+    p--;
+
+    s->len = p - s->data;
+
+#elif defined SSL_CTRL_SET_SIGALGS
+
+    /*
+     * SSL_get_sigalgs() is only available in OpenSSL 1.0.2+,
+     * but uses a different naming, so emit raw codes
+     */
+
+    int             n, i;
+    size_t          len;
+    u_char         *p;
+    unsigned char   rsig, rhash;
+
+    n = SSL_get_sigalgs(c->ssl->connection, -1, NULL, NULL, NULL, NULL, NULL);
+
+    if (n <= 0) {
+        s->len = 0;
+        return NGX_OK;
+    }
+
+    len = n * (sizeof("0x0000") - 1 + sizeof(":") - 1);
+
+    s->data = ngx_pnalloc(pool, len);
+    if (s->data == NULL) {
+        return NGX_ERROR;
+    }
+
+    p = s->data;
+
+    for (i = 0; i < n; i++) {
+        SSL_get_sigalgs(c->ssl->connection, i, NULL, NULL, NULL, &rsig, &rhash);
+        p = ngx_sprintf(p, "0x%04xd", rhash << 8 | rsig);
+        *p++ = ':';
+    }
+
+    p--;
+
+    s->len = p - s->data;
+
+#else
+
+    s->len = 0;
+
+#endif
+
+    return NGX_OK;
+}
+
+
+ngx_int_t
 ngx_ssl_get_session_id(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 {
     u_char        *buf;

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -337,6 +337,8 @@ ngx_int_t ngx_ssl_get_curves(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_sigalg(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
+ngx_int_t ngx_ssl_get_sigalgs(ngx_connection_t *c, ngx_pool_t *pool,
+    ngx_str_t *s);
 ngx_int_t ngx_ssl_get_session_id(ngx_connection_t *c, ngx_pool_t *pool,
     ngx_str_t *s);
 ngx_int_t ngx_ssl_get_session_reused(ngx_connection_t *c, ngx_pool_t *pool,

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -368,6 +368,9 @@ static ngx_http_variable_t  ngx_http_ssl_vars[] = {
     { ngx_string("ssl_sigalg"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_sigalg, NGX_HTTP_VAR_CHANGEABLE, 0 },
 
+    { ngx_string("ssl_sigalgs"), NULL, ngx_http_ssl_variable,
+      (uintptr_t) ngx_ssl_get_sigalgs, NGX_HTTP_VAR_CHANGEABLE, 0 },
+
     { ngx_string("ssl_session_id"), NULL, ngx_http_ssl_variable,
       (uintptr_t) ngx_ssl_get_session_id, NGX_HTTP_VAR_CHANGEABLE, 0 },
 

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -367,6 +367,9 @@ static ngx_stream_variable_t  ngx_stream_ssl_vars[] = {
     { ngx_string("ssl_sigalg"), NULL, ngx_stream_ssl_variable,
       (uintptr_t) ngx_ssl_get_sigalg, NGX_STREAM_VAR_CHANGEABLE, 0 },
 
+    { ngx_string("ssl_sigalgs"), NULL, ngx_stream_ssl_variable,
+      (uintptr_t) ngx_ssl_get_sigalgs, NGX_STREAM_VAR_CHANGEABLE, 0 },
+
     { ngx_string("ssl_session_id"), NULL, ngx_stream_ssl_variable,
       (uintptr_t) ngx_ssl_get_session_id, NGX_STREAM_VAR_CHANGEABLE, 0 },
 


### PR DESCRIPTION
  SSL: add $ssl_sigalgs variable

  Adds $ssl_sigalgs (plural) to complement the existing $ssl_sigalg (singular) variable, in direct analogy  to how $ssl_ciphers/$ssl_cipher and $ssl_curves/$ssl_curve relate to each other.

  What it does

  $ssl_sigalgs lists all signature algorithms advertised by the client in the supported_signature_algorithms
  extension of its ClientHello message, colon-separated. This gives access  to the full set of algorithms the
  client is willing to accept for verifying the server certificate,  rather than only the one actually negotiated.

  Implementation

  The implementation uses a tiered API approach depending on the OpenSSL version:

  OpenSSL 4.0+ — uses the new SSL_get0_sigalg(), which returns proper TLS scheme names and a numeric
  codepoint for each advertised algorithm. Named entries appear as their canonical TLS scheme name (e.g.
  rsa_pkcs1_sha256, ecdsa_secp256r1_sha256); entries with no registered name fall back to 0xHHHH hex.

  Example on a modern client (OpenSSL 4.0+):
  rsa_pkcs1_sha256:rsa_pss_rsae_sha256:ecdsa_secp256r1_sha256:ed25519

  OpenSSL 1.0.2–3.x — uses SSL_get_sigalgs(). This API is designed for TLS 1.2 and maps TLS
  SignatureScheme codes to X.509 OIDs via OBJ_nid2sn(), but that mapping is not injective: distinct TLS
  1.3 codes such as ecdsa_secp256r1_sha256 (0x0403) and ecdsa_brainpoolP256r1tls13_sha256 (0x081a) both
  resolve to "ecdsa-with-SHA256", producing duplicates in the list. To avoid this ambiguity, raw TLS
  SignatureScheme codes are reported unconditionally on this path.

  Example on a modern client (OpenSSL 1.0.2–3.x):
  0x0403:0x0503:0x0603:0x0807:0x0808:0x0804:0x0805:0x0806:0x0401:0x0501:0x0601

  OpenSSL < 1.0.2 and BoringSSL — the variable is present but always empty. OpenSSL before 1.0.2 predates
  TLS 1.2 and has no signature algorithm negotiation. BoringSSL does not expose SSL_get_sigalgs().

  Compatibility

  The variable is registered in both the HTTP and stream SSL modules. On OpenSSL 0.9.8 (the minimum nginx
  supports) the variable compiles cleanly and returns an empty string.

  Use cases

  - TLS fingerprinting and client identification (JA3-style logging)
  - Security policy enforcement — block or warn on clients that don't advertise modern sigalgs
  - Routing or access decisions based on client cryptographic capabilities


  Closes: #1354

   Release Notes

  Documentation need to be provided for new variable.
