### PR TITLE
HTTP/2: log failures in the synchronous request body reader

### DIFF
--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -4009,7 +4009,9 @@ ngx_http_v2_read_request_body(ngx_http_request_t *r)
 
     if (rb->buf == NULL) {
         stream->skip_data = 1;
-        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "http2 cannot allocate request body buffer");
+        return NGX_HTTP_INSUFFICIENT_STORAGE;
     }
 
     buf = stream->preread;
@@ -4064,6 +4066,8 @@ ngx_http_v2_read_request_body(ngx_http_request_t *r)
             == NGX_ERROR)
         {
             stream->skip_data = 1;
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "http2 failed to send WINDOW_UPDATE");
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
 
@@ -4072,6 +4076,8 @@ ngx_http_v2_read_request_body(ngx_http_request_t *r)
         if (!h2c->blocked) {
             if (ngx_http_v2_send_output_queue(h2c) == NGX_ERROR) {
                 stream->skip_data = 1;
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "http2 failed to send output queue");
                 return NGX_HTTP_INTERNAL_SERVER_ERROR;
             }
         }


### PR DESCRIPTION
## Problem

`ngx_http_v2_read_request_body()` in `src/http/v2/ngx_http_v2.c` has three
failure paths that return 500 silently — nothing is written to the error
log at any level:

1. Request body buffer allocation fails (`rb->buf == NULL`).
2. `ngx_http_v2_send_window_update()` returns `NGX_ERROR`.
3. `ngx_http_v2_send_output_queue()` returns `NGX_ERROR`.

The dominant trigger in production is paths 2/3: a client sends
`RST_STREAM(CANCEL)` on an HTTP/2 POST that has already entered
`proxy_pass`. The stream is reset, the next `WINDOW_UPDATE` or output
flush on the connection fails, and the function returns 500. The access
log records `status=500 bytes_sent=0` with no matching `error_log` entry,
so operators cannot correlate the 500s to a cause — and the silent paths
do not expose anything even after raising the `error_log` level.

The buffer allocation path (1) is rarer (memory pressure / pool
exhaustion) but exhibits the same silent failure.

## Solution

Two changes, all confined to `ngx_http_v2_read_request_body()`:

1. Emit `NGX_LOG_ERR` before each of the three returns. `NGX_LOG_ERR`
   matches the visibility of the 500 already in the access log —
   operators see the cause at the default `error_log` level without
   raising verbosity. The messages identify which step failed:

   - `"http2 cannot allocate request body buffer"`
   - `"http2 failed to send WINDOW_UPDATE"`
   - `"http2 failed to flush output queue"`

2. Change the buffer-allocation path to return
   `NGX_HTTP_INSUFFICIENT_STORAGE` (507) instead of
   `NGX_HTTP_INTERNAL_SERVER_ERROR` (500). A failed body-buffer
   allocation is closer in nature to the `ENOSPC` handling in
   `ngx_http_dav_module` than to a generic internal error; 507 is the
   better fit. The other two paths still return 500 — they reflect
   stream/connection state, not resource exhaustion.

No new APIs, no behavior change on the success path, no new
configuration directives.

## Testing

Reproduced paths 2/3 manually against a build with the patch applied and
a baseline build without.

**nginx config**

```nginx
http {
    server {
        listen 443 ssl http2;
        server_name example.com;

        ssl_certificate     /path/to/cert.pem;
        ssl_certificate_key /path/to/key.pem;

        location /upload {
            proxy_pass http://127.0.0.1:8080;
            client_max_body_size 16m;
        }
    }
}
```

**Python client** (requires `pip install h2`)

```python
#!/usr/bin/env python3

import socket, ssl, sys, time
import h2.connection, h2.config, h2.events
from h2.errors import ErrorCodes

HOST = sys.argv[1] if len(sys.argv) > 1 else 'example.com'
PATH = sys.argv[2] if len(sys.argv) > 2 else '/some-post-endpoint'
N    = int(sys.argv[3]) if len(sys.argv) > 3 else 200
PORT = 443

ctx = ssl.create_default_context()
ctx.check_hostname = False
ctx.verify_mode = ssl.CERT_NONE
ctx.set_alpn_protocols(['h2'])

TIMINGS_MS = [0, 1, 7, 50, 300]
for delay_ms in TIMINGS_MS:
    for i in range(N // len(TIMINGS_MS)):
        try:
            sock = socket.create_connection((HOST, PORT), timeout=5)
            ssock = ctx.wrap_socket(sock, server_hostname=HOST)
            conn = h2.connection.H2Connection(
                config=h2.config.H2Configuration(client_side=True))
            conn.initiate_connection()
            ssock.sendall(conn.data_to_send())

            headers = [
                (':method', 'POST'),
                (':path', PATH),
                (':authority', HOST),
                (':scheme', 'https'),
                ('content-type', 'application/json'),
                ('content-length', '7'),
                ('user-agent', 'h2-rst-repro/0.1'),
            ]
            sid = conn.get_next_available_stream_id()
            conn.send_headers(sid, headers, end_stream=False)
            conn.send_data(sid, b'{"x":1}', end_stream=False)
            ssock.sendall(conn.data_to_send())

            if delay_ms > 0:
                time.sleep(delay_ms / 1000.0)

            conn.reset_stream(sid, error_code=ErrorCodes.CANCEL)
            ssock.sendall(conn.data_to_send())
            ssock.close()
        except Exception as e:
            print(f"[delay={delay_ms}ms i={i}] err: {e}", file=sys.stderr)

    print(f"sent {N//len(TIMINGS_MS)} RST_STREAM with delay={delay_ms}ms")


```

> python3 repro_h2_read_body.py example.com / 200

**Verification**

1. Build nginx without the patch, run the client, inspect logs:
   `access.log` shows a 500; `error.log` is empty at the default level.
2. Apply the patch, rebuild, repeat: `access.log` still shows a 500;
   `error.log` now contains an explanatory line at the default level.

Path 1 (buffer allocation failure) is reproducible only under memory
pressure / pool exhaustion and is not covered by an automated test; the
log statement is symmetric with the other two paths and follows the
existing pattern for allocation-failure logging elsewhere in nginx.

- [x] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #ISSUE_NUMBER

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

HTTP/2 POST requests that fail inside `ngx_http_v2_read_request_body()` —
most commonly when the client cancels the stream after `proxy_pass` has
begun forwarding — now produce an explicit `error_log` entry instead of
returning 500 silently. Buffer-allocation failures on the same path now
return `507 Insufficient Storage` instead of `500 Internal Server Error`.