### PR TITLE
Geo: validate binary range bases before relocation.

### DIFF
--- a/src/http/modules/ngx_http_geo_module.c
+++ b/src/http/modules/ngx_http_geo_module.c
@@ -106,6 +106,13 @@ static char *ngx_http_geo_include(ngx_conf_t *cf, ngx_http_geo_conf_ctx_t *ctx,
     ngx_str_t *name);
 static ngx_int_t ngx_http_geo_include_binary_base(ngx_conf_t *cf,
     ngx_http_geo_conf_ctx_t *ctx, ngx_str_t *name);
+static ngx_int_t ngx_http_geo_validate_binary_base(ngx_conf_t *cf,
+    ngx_http_geo_conf_ctx_t *ctx, ngx_str_t *name, u_char *base, size_t size,
+    uint32_t *crc32, ngx_http_geo_range_t ***ranges);
+static void ngx_http_geo_relocate_binary_base(u_char *base, size_t size,
+    ngx_http_geo_range_t **ranges);
+static ngx_int_t ngx_http_geo_binary_search_offset(ngx_array_t *offsets,
+    uintptr_t offset);
 static void ngx_http_geo_create_binary_base(ngx_http_geo_conf_ctx_t *ctx);
 static u_char *ngx_http_geo_copy_values(u_char *base, u_char *p,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
@@ -1420,18 +1427,17 @@ ngx_http_geo_include_binary_base(ngx_conf_t *cf, ngx_http_geo_conf_ctx_t *ctx,
     ngx_str_t *name)
 {
     u_char                     *base, ch;
+    off_t                       file_size;
     time_t                      mtime;
-    size_t                      size, len;
+    size_t                      size;
     ssize_t                     n;
     uint32_t                    crc32;
     ngx_err_t                   err;
     ngx_int_t                   rc;
-    ngx_uint_t                  i;
     ngx_file_t                  file;
     ngx_file_info_t             fi;
-    ngx_http_geo_range_t       *range, **ranges;
+    ngx_http_geo_range_t      **ranges;
     ngx_http_geo_header_t      *header;
-    ngx_http_variable_value_t  *vv;
 
     ngx_memzero(&file, sizeof(ngx_file_t));
     file.name = *name;
@@ -1470,13 +1476,31 @@ ngx_http_geo_include_binary_base(ngx_conf_t *cf, ngx_http_geo_conf_ctx_t *ctx,
         goto failed;
     }
 
-    size = (size_t) ngx_file_size(&fi);
+    if (!ngx_is_file(&fi)) {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "binary geo range base \"%s\" is not a file",
+                           name->data);
+        goto failed;
+    }
+
+    file_size = ngx_file_size(&fi);
+
+    if (file_size < (off_t) sizeof(ngx_http_geo_header_t)
+        || file_size > (off_t) NGX_MAX_SIZE_T_VALUE)
+    {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+             "incompatible binary geo range base \"%s\"", name->data);
+        goto failed;
+    }
+
+    size = (size_t) file_size;
     mtime = ngx_file_mtime(&fi);
 
     ch = name->data[name->len - 4];
     name->data[name->len - 4] = '\0';
 
     if (ngx_file_info(name->data, &fi) == NGX_FILE_ERROR) {
+        name->data[name->len - 4] = ch;
         ngx_conf_log_error(NGX_LOG_CRIT, cf, ngx_errno,
                            ngx_file_info_n " \"%s\" failed", name->data);
         goto failed;
@@ -1512,57 +1536,32 @@ ngx_http_geo_include_binary_base(ngx_conf_t *cf, ngx_http_geo_conf_ctx_t *ctx,
 
     header = (ngx_http_geo_header_t *) base;
 
-    if (size < 16 || ngx_memcmp(&ngx_http_geo_header, header, 12) != 0) {
+    if (ngx_memcmp(&ngx_http_geo_header, header,
+                   sizeof(ngx_http_geo_header_t) - sizeof(uint32_t))
+        != 0)
+    {
         ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
              "incompatible binary geo range base \"%s\"", name->data);
         goto failed;
     }
 
-    ngx_crc32_init(crc32);
-
-    vv = (ngx_http_variable_value_t *) (base + sizeof(ngx_http_geo_header_t));
-
-    while (vv->data) {
-        len = ngx_align(sizeof(ngx_http_variable_value_t) + vv->len,
-                        sizeof(void *));
-        ngx_crc32_update(&crc32, (u_char *) vv, len);
-        vv->data += (size_t) base;
-        vv = (ngx_http_variable_value_t *) ((u_char *) vv + len);
-    }
-    ngx_crc32_update(&crc32, (u_char *) vv, sizeof(ngx_http_variable_value_t));
-    vv++;
-
-    ranges = (ngx_http_geo_range_t **) vv;
-
-    for (i = 0; i < 0x10000; i++) {
-        ngx_crc32_update(&crc32, (u_char *) &ranges[i], sizeof(void *));
-        if (ranges[i]) {
-            ranges[i] = (ngx_http_geo_range_t *)
-                            ((u_char *) ranges[i] + (size_t) base);
-        }
+    rc = ngx_http_geo_validate_binary_base(cf, ctx, name, base, size, &crc32,
+                                           &ranges);
+    if (rc == NGX_ERROR) {
+        goto done;
     }
 
-    range = (ngx_http_geo_range_t *) &ranges[0x10000];
-
-    while ((u_char *) range < base + size) {
-        while (range->value) {
-            ngx_crc32_update(&crc32, (u_char *) range,
-                             sizeof(ngx_http_geo_range_t));
-            range->value = (ngx_http_variable_value_t *)
-                               ((u_char *) range->value + (size_t) base);
-            range++;
-        }
-        ngx_crc32_update(&crc32, (u_char *) range, sizeof(void *));
-        range = (ngx_http_geo_range_t *) ((u_char *) range + sizeof(void *));
+    if (rc != NGX_OK) {
+        goto failed;
     }
-
-    ngx_crc32_final(crc32);
 
     if (crc32 != header->crc32) {
         ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
                   "CRC32 mismatch in binary geo range base \"%s\"", name->data);
         goto failed;
     }
+
+    ngx_http_geo_relocate_binary_base(base, size, ranges);
 
     ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0,
                        "using binary geo range base \"%s\"", name->data);
@@ -1586,6 +1585,285 @@ done:
     }
 
     return rc;
+}
+
+
+static ngx_int_t
+ngx_http_geo_validate_binary_base(ngx_conf_t *cf,
+    ngx_http_geo_conf_ctx_t *ctx, ngx_str_t *name, u_char *base, size_t size,
+    uint32_t *crc32, ngx_http_geo_range_t ***ranges)
+{
+    u_char                     *last, *p, *next, *range_base;
+    size_t                      len, table_size;
+    uintptr_t                   data, offset;
+    uintptr_t                  *entry;
+    ngx_uint_t                  i, n;
+    u_short                     previous;
+    ngx_array_t                *values, *range_starts;
+    ngx_http_geo_range_t       *range, **rs;
+    ngx_http_variable_value_t  *vv;
+
+    last = base + size;
+    p = base + sizeof(ngx_http_geo_header_t);
+
+    values = ngx_array_create(ctx->temp_pool, 16, sizeof(uintptr_t));
+    if (values == NULL) {
+        return NGX_ERROR;
+    }
+
+    range_starts = ngx_array_create(ctx->temp_pool, 1024,
+                                    sizeof(uintptr_t));
+    if (range_starts == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_crc32_init(*crc32);
+
+    for ( ;; ) {
+        if ((uintptr_t) p % sizeof(void *) != 0
+            || (size_t) (last - p) < sizeof(ngx_http_variable_value_t))
+        {
+            goto invalid;
+        }
+
+        vv = (ngx_http_variable_value_t *) p;
+
+        if (vv->data == NULL) {
+            if (vv->len || vv->valid || vv->no_cacheable
+                || vv->not_found || vv->escape)
+            {
+                goto invalid;
+            }
+
+            ngx_crc32_update(crc32, p, sizeof(ngx_http_variable_value_t));
+            p += sizeof(ngx_http_variable_value_t);
+            break;
+        }
+
+        if (vv->valid != 1 || vv->no_cacheable || vv->not_found
+            || vv->escape)
+        {
+            goto invalid;
+        }
+
+        if (vv->len > (size_t) (last - p)
+                      - sizeof(ngx_http_variable_value_t))
+        {
+            goto invalid;
+        }
+
+        data = (uintptr_t) vv->data;
+        offset = (uintptr_t) (p + sizeof(ngx_http_variable_value_t) - base);
+
+        if (data != offset) {
+            goto invalid;
+        }
+
+        next = ngx_align_ptr(p + sizeof(ngx_http_variable_value_t) + vv->len,
+                             sizeof(void *));
+        if (next > last) {
+            goto invalid;
+        }
+
+        entry = ngx_array_push(values);
+        if (entry == NULL) {
+            return NGX_ERROR;
+        }
+
+        *entry = (uintptr_t) (p - base);
+
+        len = (size_t) (next - p);
+        ngx_crc32_update(crc32, p, len);
+
+        p = next;
+    }
+
+    table_size = 0x10000 * sizeof(ngx_http_geo_range_t *);
+
+    if ((uintptr_t) p % sizeof(void *) != 0
+        || (size_t) (last - p) < table_size)
+    {
+        goto invalid;
+    }
+
+    rs = (ngx_http_geo_range_t **) p;
+    *ranges = rs;
+    range_base = p + table_size;
+
+    for (i = 0; i < 0x10000; i++) {
+        ngx_crc32_update(crc32, (u_char *) &rs[i], sizeof(void *));
+
+        offset = (uintptr_t) rs[i];
+
+        if (offset == 0) {
+            continue;
+        }
+
+        if (offset < (uintptr_t) (range_base - base)
+            || offset > size - sizeof(void *)
+            || offset % sizeof(void *) != 0)
+        {
+            goto invalid;
+        }
+    }
+
+    p = range_base;
+
+    while (p < last) {
+        if ((uintptr_t) p % sizeof(void *) != 0) {
+            goto invalid;
+        }
+
+        entry = ngx_array_push(range_starts);
+        if (entry == NULL) {
+            return NGX_ERROR;
+        }
+
+        *entry = (uintptr_t) (p - base);
+
+        n = 0;
+        previous = 0;
+
+        for ( ;; ) {
+            if ((size_t) (last - p) < sizeof(void *)) {
+                goto invalid;
+            }
+
+            range = (ngx_http_geo_range_t *) p;
+
+            if (range->value == NULL) {
+                if (n == 0) {
+                    goto invalid;
+                }
+
+                ngx_crc32_update(crc32, p, sizeof(void *));
+                p += sizeof(void *);
+                break;
+            }
+
+            if ((size_t) (last - p) < sizeof(ngx_http_geo_range_t)) {
+                goto invalid;
+            }
+
+            offset = (uintptr_t) range->value;
+
+            if (ngx_http_geo_binary_search_offset(values, offset) != NGX_OK) {
+                goto invalid;
+            }
+
+            if (range->start > range->end
+                || (n != 0 && range->start <= previous))
+            {
+                goto invalid;
+            }
+
+            previous = range->end;
+
+            ngx_crc32_update(crc32, p, sizeof(ngx_http_geo_range_t));
+            p += sizeof(ngx_http_geo_range_t);
+            n++;
+        }
+    }
+
+    if (p != last) {
+        goto invalid;
+    }
+
+    for (i = 0; i < 0x10000; i++) {
+        offset = (uintptr_t) rs[i];
+
+        if (offset == 0) {
+            continue;
+        }
+
+        if (ngx_http_geo_binary_search_offset(range_starts, offset)
+            != NGX_OK)
+        {
+            goto invalid;
+        }
+    }
+
+    ngx_crc32_final(*crc32);
+
+    return NGX_OK;
+
+invalid:
+
+    ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                       "invalid binary geo range base \"%s\"", name->data);
+
+    return NGX_DECLINED;
+}
+
+
+static void
+ngx_http_geo_relocate_binary_base(u_char *base, size_t size,
+    ngx_http_geo_range_t **ranges)
+{
+    u_char                     *last;
+    size_t                      len;
+    ngx_uint_t                  i;
+    ngx_http_geo_range_t       *range;
+    ngx_http_variable_value_t  *vv;
+
+    last = base + size;
+
+    vv = (ngx_http_variable_value_t *) (base + sizeof(ngx_http_geo_header_t));
+
+    while (vv->data) {
+        len = ngx_align(sizeof(ngx_http_variable_value_t) + vv->len,
+                        sizeof(void *));
+        vv->data = (u_char *) ((uintptr_t) vv->data + (uintptr_t) base);
+        vv = (ngx_http_variable_value_t *) ((u_char *) vv + len);
+    }
+
+    for (i = 0; i < 0x10000; i++) {
+        if (ranges[i]) {
+            ranges[i] = (ngx_http_geo_range_t *)
+                            ((uintptr_t) ranges[i] + (uintptr_t) base);
+        }
+    }
+
+    range = (ngx_http_geo_range_t *) &ranges[0x10000];
+
+    while ((u_char *) range < last) {
+        while (range->value) {
+            range->value = (ngx_http_variable_value_t *)
+                               ((uintptr_t) range->value + (uintptr_t) base);
+            range++;
+        }
+
+        range = (ngx_http_geo_range_t *) ((u_char *) range + sizeof(void *));
+    }
+}
+
+
+static ngx_int_t
+ngx_http_geo_binary_search_offset(ngx_array_t *offsets, uintptr_t offset)
+{
+    ngx_uint_t   i, left, right;
+    uintptr_t   *elts;
+
+    elts = offsets->elts;
+    left = 0;
+    right = offsets->nelts;
+
+    while (left < right) {
+        i = left + (right - left) / 2;
+
+        if (offset == elts[i]) {
+            return NGX_OK;
+        }
+
+        if (offset < elts[i]) {
+            right = i;
+
+        } else {
+            left = i + 1;
+        }
+    }
+
+    return NGX_DECLINED;
 }
 
 

--- a/src/stream/ngx_stream_geo_module.c
+++ b/src/stream/ngx_stream_geo_module.c
@@ -100,6 +100,13 @@ static char *ngx_stream_geo_include(ngx_conf_t *cf,
     ngx_stream_geo_conf_ctx_t *ctx, ngx_str_t *name);
 static ngx_int_t ngx_stream_geo_include_binary_base(ngx_conf_t *cf,
     ngx_stream_geo_conf_ctx_t *ctx, ngx_str_t *name);
+static ngx_int_t ngx_stream_geo_validate_binary_base(ngx_conf_t *cf,
+    ngx_stream_geo_conf_ctx_t *ctx, ngx_str_t *name, u_char *base,
+    size_t size, uint32_t *crc32, ngx_stream_geo_range_t ***ranges);
+static void ngx_stream_geo_relocate_binary_base(u_char *base, size_t size,
+    ngx_stream_geo_range_t **ranges);
+static ngx_int_t ngx_stream_geo_binary_search_offset(ngx_array_t *offsets,
+    uintptr_t offset);
 static void ngx_stream_geo_create_binary_base(ngx_stream_geo_conf_ctx_t *ctx);
 static u_char *ngx_stream_geo_copy_values(u_char *base, u_char *p,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
@@ -1346,18 +1353,17 @@ ngx_stream_geo_include_binary_base(ngx_conf_t *cf,
     ngx_stream_geo_conf_ctx_t *ctx, ngx_str_t *name)
 {
     u_char                       *base, ch;
+    off_t                         file_size;
     time_t                        mtime;
-    size_t                        size, len;
+    size_t                        size;
     ssize_t                       n;
     uint32_t                      crc32;
     ngx_err_t                     err;
     ngx_int_t                     rc;
-    ngx_uint_t                    i;
     ngx_file_t                    file;
     ngx_file_info_t               fi;
-    ngx_stream_geo_range_t       *range, **ranges;
+    ngx_stream_geo_range_t      **ranges;
     ngx_stream_geo_header_t      *header;
-    ngx_stream_variable_value_t  *vv;
 
     ngx_memzero(&file, sizeof(ngx_file_t));
     file.name = *name;
@@ -1396,13 +1402,31 @@ ngx_stream_geo_include_binary_base(ngx_conf_t *cf,
         goto failed;
     }
 
-    size = (size_t) ngx_file_size(&fi);
+    if (!ngx_is_file(&fi)) {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "binary geo range base \"%s\" is not a file",
+                           name->data);
+        goto failed;
+    }
+
+    file_size = ngx_file_size(&fi);
+
+    if (file_size < (off_t) sizeof(ngx_stream_geo_header_t)
+        || file_size > (off_t) NGX_MAX_SIZE_T_VALUE)
+    {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+             "incompatible binary geo range base \"%s\"", name->data);
+        goto failed;
+    }
+
+    size = (size_t) file_size;
     mtime = ngx_file_mtime(&fi);
 
     ch = name->data[name->len - 4];
     name->data[name->len - 4] = '\0';
 
     if (ngx_file_info(name->data, &fi) == NGX_FILE_ERROR) {
+        name->data[name->len - 4] = ch;
         ngx_conf_log_error(NGX_LOG_CRIT, cf, ngx_errno,
                            ngx_file_info_n " \"%s\" failed", name->data);
         goto failed;
@@ -1438,59 +1462,32 @@ ngx_stream_geo_include_binary_base(ngx_conf_t *cf,
 
     header = (ngx_stream_geo_header_t *) base;
 
-    if (size < 16 || ngx_memcmp(&ngx_stream_geo_header, header, 12) != 0) {
+    if (ngx_memcmp(&ngx_stream_geo_header, header,
+                   sizeof(ngx_stream_geo_header_t) - sizeof(uint32_t))
+        != 0)
+    {
         ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
              "incompatible binary geo range base \"%s\"", name->data);
         goto failed;
     }
 
-    ngx_crc32_init(crc32);
-
-    vv = (ngx_stream_variable_value_t *)
-            (base + sizeof(ngx_stream_geo_header_t));
-
-    while (vv->data) {
-        len = ngx_align(sizeof(ngx_stream_variable_value_t) + vv->len,
-                        sizeof(void *));
-        ngx_crc32_update(&crc32, (u_char *) vv, len);
-        vv->data += (size_t) base;
-        vv = (ngx_stream_variable_value_t *) ((u_char *) vv + len);
-    }
-    ngx_crc32_update(&crc32, (u_char *) vv,
-                     sizeof(ngx_stream_variable_value_t));
-    vv++;
-
-    ranges = (ngx_stream_geo_range_t **) vv;
-
-    for (i = 0; i < 0x10000; i++) {
-        ngx_crc32_update(&crc32, (u_char *) &ranges[i], sizeof(void *));
-        if (ranges[i]) {
-            ranges[i] = (ngx_stream_geo_range_t *)
-                            ((u_char *) ranges[i] + (size_t) base);
-        }
+    rc = ngx_stream_geo_validate_binary_base(cf, ctx, name, base, size, &crc32,
+                                             &ranges);
+    if (rc == NGX_ERROR) {
+        goto done;
     }
 
-    range = (ngx_stream_geo_range_t *) &ranges[0x10000];
-
-    while ((u_char *) range < base + size) {
-        while (range->value) {
-            ngx_crc32_update(&crc32, (u_char *) range,
-                             sizeof(ngx_stream_geo_range_t));
-            range->value = (ngx_stream_variable_value_t *)
-                               ((u_char *) range->value + (size_t) base);
-            range++;
-        }
-        ngx_crc32_update(&crc32, (u_char *) range, sizeof(void *));
-        range = (ngx_stream_geo_range_t *) ((u_char *) range + sizeof(void *));
+    if (rc != NGX_OK) {
+        goto failed;
     }
-
-    ngx_crc32_final(crc32);
 
     if (crc32 != header->crc32) {
         ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
                   "CRC32 mismatch in binary geo range base \"%s\"", name->data);
         goto failed;
     }
+
+    ngx_stream_geo_relocate_binary_base(base, size, ranges);
 
     ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0,
                        "using binary geo range base \"%s\"", name->data);
@@ -1514,6 +1511,288 @@ done:
     }
 
     return rc;
+}
+
+
+static ngx_int_t
+ngx_stream_geo_validate_binary_base(ngx_conf_t *cf,
+    ngx_stream_geo_conf_ctx_t *ctx, ngx_str_t *name, u_char *base,
+    size_t size, uint32_t *crc32, ngx_stream_geo_range_t ***ranges)
+{
+    u_char                       *last, *p, *next, *range_base;
+    size_t                        len, table_size;
+    uintptr_t                     data, offset;
+    uintptr_t                    *entry;
+    ngx_uint_t                    i, n;
+    u_short                       previous;
+    ngx_array_t                  *values, *range_starts;
+    ngx_stream_geo_range_t       *range, **rs;
+    ngx_stream_variable_value_t  *vv;
+
+    last = base + size;
+    p = base + sizeof(ngx_stream_geo_header_t);
+
+    values = ngx_array_create(ctx->temp_pool, 16, sizeof(uintptr_t));
+    if (values == NULL) {
+        return NGX_ERROR;
+    }
+
+    range_starts = ngx_array_create(ctx->temp_pool, 1024,
+                                    sizeof(uintptr_t));
+    if (range_starts == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_crc32_init(*crc32);
+
+    for ( ;; ) {
+        if ((uintptr_t) p % sizeof(void *) != 0
+            || (size_t) (last - p) < sizeof(ngx_stream_variable_value_t))
+        {
+            goto invalid;
+        }
+
+        vv = (ngx_stream_variable_value_t *) p;
+
+        if (vv->data == NULL) {
+            if (vv->len || vv->valid || vv->no_cacheable
+                || vv->not_found || vv->escape)
+            {
+                goto invalid;
+            }
+
+            ngx_crc32_update(crc32, p, sizeof(ngx_stream_variable_value_t));
+            p += sizeof(ngx_stream_variable_value_t);
+            break;
+        }
+
+        if (vv->valid != 1 || vv->no_cacheable || vv->not_found
+            || vv->escape)
+        {
+            goto invalid;
+        }
+
+        if (vv->len > (size_t) (last - p)
+                      - sizeof(ngx_stream_variable_value_t))
+        {
+            goto invalid;
+        }
+
+        data = (uintptr_t) vv->data;
+        offset = (uintptr_t) (p + sizeof(ngx_stream_variable_value_t) - base);
+
+        if (data != offset) {
+            goto invalid;
+        }
+
+        next = ngx_align_ptr(p + sizeof(ngx_stream_variable_value_t) + vv->len,
+                             sizeof(void *));
+        if (next > last) {
+            goto invalid;
+        }
+
+        entry = ngx_array_push(values);
+        if (entry == NULL) {
+            return NGX_ERROR;
+        }
+
+        *entry = (uintptr_t) (p - base);
+
+        len = (size_t) (next - p);
+        ngx_crc32_update(crc32, p, len);
+
+        p = next;
+    }
+
+    table_size = 0x10000 * sizeof(ngx_stream_geo_range_t *);
+
+    if ((uintptr_t) p % sizeof(void *) != 0
+        || (size_t) (last - p) < table_size)
+    {
+        goto invalid;
+    }
+
+    rs = (ngx_stream_geo_range_t **) p;
+    *ranges = rs;
+    range_base = p + table_size;
+
+    for (i = 0; i < 0x10000; i++) {
+        ngx_crc32_update(crc32, (u_char *) &rs[i], sizeof(void *));
+
+        offset = (uintptr_t) rs[i];
+
+        if (offset == 0) {
+            continue;
+        }
+
+        if (offset < (uintptr_t) (range_base - base)
+            || offset > size - sizeof(void *)
+            || offset % sizeof(void *) != 0)
+        {
+            goto invalid;
+        }
+    }
+
+    p = range_base;
+
+    while (p < last) {
+        if ((uintptr_t) p % sizeof(void *) != 0) {
+            goto invalid;
+        }
+
+        entry = ngx_array_push(range_starts);
+        if (entry == NULL) {
+            return NGX_ERROR;
+        }
+
+        *entry = (uintptr_t) (p - base);
+
+        n = 0;
+        previous = 0;
+
+        for ( ;; ) {
+            if ((size_t) (last - p) < sizeof(void *)) {
+                goto invalid;
+            }
+
+            range = (ngx_stream_geo_range_t *) p;
+
+            if (range->value == NULL) {
+                if (n == 0) {
+                    goto invalid;
+                }
+
+                ngx_crc32_update(crc32, p, sizeof(void *));
+                p += sizeof(void *);
+                break;
+            }
+
+            if ((size_t) (last - p) < sizeof(ngx_stream_geo_range_t)) {
+                goto invalid;
+            }
+
+            offset = (uintptr_t) range->value;
+
+            if (ngx_stream_geo_binary_search_offset(values, offset)
+                != NGX_OK)
+            {
+                goto invalid;
+            }
+
+            if (range->start > range->end
+                || (n != 0 && range->start <= previous))
+            {
+                goto invalid;
+            }
+
+            previous = range->end;
+
+            ngx_crc32_update(crc32, p, sizeof(ngx_stream_geo_range_t));
+            p += sizeof(ngx_stream_geo_range_t);
+            n++;
+        }
+    }
+
+    if (p != last) {
+        goto invalid;
+    }
+
+    for (i = 0; i < 0x10000; i++) {
+        offset = (uintptr_t) rs[i];
+
+        if (offset == 0) {
+            continue;
+        }
+
+        if (ngx_stream_geo_binary_search_offset(range_starts, offset)
+            != NGX_OK)
+        {
+            goto invalid;
+        }
+    }
+
+    ngx_crc32_final(*crc32);
+
+    return NGX_OK;
+
+invalid:
+
+    ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                       "invalid binary geo range base \"%s\"", name->data);
+
+    return NGX_DECLINED;
+}
+
+
+static void
+ngx_stream_geo_relocate_binary_base(u_char *base, size_t size,
+    ngx_stream_geo_range_t **ranges)
+{
+    u_char                       *last;
+    size_t                        len;
+    ngx_uint_t                    i;
+    ngx_stream_geo_range_t       *range;
+    ngx_stream_variable_value_t  *vv;
+
+    last = base + size;
+
+    vv = (ngx_stream_variable_value_t *)
+            (base + sizeof(ngx_stream_geo_header_t));
+
+    while (vv->data) {
+        len = ngx_align(sizeof(ngx_stream_variable_value_t) + vv->len,
+                        sizeof(void *));
+        vv->data = (u_char *) ((uintptr_t) vv->data + (uintptr_t) base);
+        vv = (ngx_stream_variable_value_t *) ((u_char *) vv + len);
+    }
+
+    for (i = 0; i < 0x10000; i++) {
+        if (ranges[i]) {
+            ranges[i] = (ngx_stream_geo_range_t *)
+                            ((uintptr_t) ranges[i] + (uintptr_t) base);
+        }
+    }
+
+    range = (ngx_stream_geo_range_t *) &ranges[0x10000];
+
+    while ((u_char *) range < last) {
+        while (range->value) {
+            range->value = (ngx_stream_variable_value_t *)
+                               ((uintptr_t) range->value + (uintptr_t) base);
+            range++;
+        }
+
+        range = (ngx_stream_geo_range_t *) ((u_char *) range + sizeof(void *));
+    }
+}
+
+
+static ngx_int_t
+ngx_stream_geo_binary_search_offset(ngx_array_t *offsets, uintptr_t offset)
+{
+    ngx_uint_t   i, left, right;
+    uintptr_t   *elts;
+
+    elts = offsets->elts;
+    left = 0;
+    right = offsets->nelts;
+
+    while (left < right) {
+        i = left + (right - left) / 2;
+
+        if (offset == elts[i]) {
+            return NGX_OK;
+        }
+
+        if (offset < elts[i]) {
+            right = i;
+
+        } else {
+            left = i + 1;
+        }
+    }
+
+    return NGX_DECLINED;
 }
 
 


### PR DESCRIPTION
# Geo Binary Base Validation

Malformed geo range base files were previously walked before the CRC
check completed. During that pass, offsets from the file were converted
to process pointers before target records were validated.

Validate the binary layout first: file type and size, value records,
range table offsets, range arrays, ordering, and CRC. Only then relocate
offsets to pointers. Invalid bases now fall back to the text include path
without out-of-bounds reads.

Apply the same checks to the HTTP and Stream geo modules.

## Problem

Binary geo range base files are loaded from disk and contain offsets into
serialized value records, a range pointer table, and range arrays. The old
loader validated the header and later checked CRC, but it walked the file
and converted serialized offsets to process pointers before proving that
all referenced records were inside the file and properly aligned.

A malformed or corrupted `.bin` file could therefore make configuration
loading read beyond the binary base buffer or create invalid pointers
before the loader had enough information to reject the file.

## Solution

Validate the binary base layout before any relocation is performed.

The new validation pass checks:

- the `.bin` path is a regular file and has a sane size;
- the binary header matches the expected magic, version, pointer size, and
  byte order;
- value records are aligned, complete, and point to their own string data;
- range table entries are aligned and point into the range data section;
- range arrays are non-empty, complete, ordered, and non-overlapping;
- range value offsets refer to known validated value records;
- range table entries point to validated range array starts;
- CRC matches after the complete structure check.

Only after these checks pass does the loader relocate file offsets to
process pointers. Invalid binary bases keep the existing recovery behavior:
NGINX logs a warning and falls back to parsing the text include file.

The same validation and relocation sequence is applied to both
`ngx_http_geo_module` and `ngx_stream_geo_module`.

## Testing

Tested on Ubuntu 24.04 with:

```sh
./auto/configure --with-stream --with-debug
make -j$(nproc)
```

Functional nginx-tests:

```sh
TEST_NGINX_BINARY=/path/to/nginx/objs/nginx \
TEST_NGINX_UNSAFE=1 \
prove geo_binary.t stream_geo_binary.t
```

Result: PASS, 2 files, 8 tests.

Geo regression nginx-tests:

```sh
TEST_NGINX_BINARY=/path/to/nginx/objs/nginx \
prove geo.t geo_ipv6.t geo_unix.t geo_volatile.t \
      stream_geo.t stream_geo_ipv6.t stream_geo_unix.t
```

Result: PASS, 7 files, 77 tests.

Full nginx-tests run with the same build:

```sh
TEST_NGINX_BINARY=/path/to/nginx/objs/nginx prove .
```

Result: PASS, 490 files, 2999 tests.

Manual negative test:

- generated a valid `base.conf.bin` from a large `geo` ranges include;
- corrupted the first non-empty range table offset in the binary base;
- ran `nginx -t`;
- confirmed NGINX logged `invalid binary geo range base` and successfully
  fell back to the text include file without crashing.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1321 

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

Geo range binary base loading now validates serialized offsets and range
metadata before relocating them to process pointers. Corrupted or malformed
binary bases are rejected safely and fall back to the text include file.