### PR TITLE
HTTP: fix custom error_page for 413 with HTTP/2 and HTTP/3

### DIFF
--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -3008,9 +3008,15 @@ ngx_http_set_write_handler(ngx_http_request_t *r)
 
     r->http_state = NGX_HTTP_WRITING_REQUEST_STATE;
 
-    r->read_event_handler = r->discard_body ?
-                                ngx_http_discarded_request_body_handler:
-                                ngx_http_test_reading;
+    r->read_event_handler =
+#if (NGX_HTTP_V2)
+        r->stream ? ngx_http_test_reading :
+#endif
+#if (NGX_HTTP_V3)
+        r->connection->quic ? ngx_http_test_reading :
+#endif
+        r->discard_body ? ngx_http_discarded_request_body_handler :
+                          ngx_http_test_reading;
     r->write_event_handler = ngx_http_writer;
 
     wev = r->connection->write;

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -642,12 +642,14 @@ ngx_http_discard_request_body(ngx_http_request_t *r)
 #if (NGX_HTTP_V2)
     if (r->stream) {
         r->stream->skip_data = 1;
+        r->discard_body = 1;
         return NGX_OK;
     }
 #endif
 
 #if (NGX_HTTP_V3)
     if (r->http_version == NGX_HTTP_VERSION_30) {
+        r->discard_body = 1;
         return NGX_OK;
     }
 #endif


### PR DESCRIPTION
## Problem

When `client_max_body_size` is exceeded on an HTTP/2 or HTTP/3 request, NGINX returns the built-in `413` error page instead of the custom page configured via:

```nginx
error_page 413 /custom.html;
````

HTTP/1.1 works correctly.

Root cause:

* `ngx_http_discard_request_body()` for HTTP/2 sets `stream->skip_data = 1` but leaves `r->discard_body = 0`
* HTTP/3 returns immediately without setting any discard flag

The early body-size check in `ngx_http_core_find_config_phase()` uses `!r->discard_body` to avoid re-evaluating body limits during internal redirects.

Because the flag is never set for HTTP/2 and HTTP/3, the check runs again during the `error_page` redirect, detects `r >error_page = 1` (no further redirects allowed), and falls back to the built-in `413` response instead of serving the configured custom page.

---

## Solution

Set `r->discard_body = 1` in the HTTP/2 and HTTP/3 paths of `ngx_http_discard_request_body()`, matching existing HTTP/1 behaviour.

This prevents `ngx_http_core_find_config_phase()` from re-evaluating the body size limit during the second phase run triggered by the `error_page` redirect.

Since `r->discard_body` may now be set for HTTP/2 and HTTP/3 requests, `ngx_http_set_write_handler()` is additionally guarded to always use `ngx_http_test_reading()` for these protocols.

`ngx_http_discarded_request_body_handler()` must not be used there:

* For HTTP/2, the fake connection shares the real socket `recv`
* For HTTP/3, the QUIC stream `recv` callback would be invoked incorrectly

---

## Testing

* [x] Manual testing
* [x] Functional testing using `nginx-tests`

### Test Results

```text
h2_request_body.t              : 51/51 passed
h2_request_body_extra.t        : 52/52 passed
h2_request_body_preread.t      : 11/11 passed
proxy_h2_body_discard.t        : 7/7 passed
body.t                         : 17/17 passed
body_chunked.t                 : 20/20 passed
autoindex.t                    : 18/18 passed
autoindex_format.t             : 39/39 passed
```

HTTP/3 body tests were skipped because the `cryptx` module was unavailable.

Build verified clean under GCC 13 with:

```bash
-Wall -Wpointer-arith -Werror
```

**Closes:** #1356

---

## Checklist

* [x] Read the CONTRIBUTING guidelines
* [ ] Added tests where applicable
* [x] All existing tests pass
* [x] Updated documentation where necessary
* [x] Branch rebased on latest `master`
* [x] PR targets `master` from fork
* [x] Commit message follows NGINX standards

---

## Release Notes

`error_page` handling for HTTP `413` now works correctly for HTTP/2 and HTTP/3 requests, matching existing HTTP/1.1 behaviour.

No configuration changes are required.

