### PR TITLE
HTTP: make $remote_user directly settable by auth modules

### DIFF
--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -566,6 +566,7 @@ struct ngx_http_request_s {
     unsigned                          main_filter_need_in_memory:1;
     unsigned                          filter_need_in_memory:1;
     unsigned                          filter_need_temporary:1;
+    unsigned                          remote_user_set:1;
     unsigned                          preserve_body:1;
     unsigned                          allow_ranges:1;
     unsigned                          subrequest_ranges:1;

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -1804,6 +1804,15 @@ ngx_http_variable_remote_user(ngx_http_request_t *r,
 {
     ngx_int_t  rc;
 
+    if (r->remote_user_set) {
+        v->len = r->headers_in.user.len;
+        v->valid = 1;
+        v->no_cacheable = 0;
+        v->not_found = 0;
+        v->data = r->headers_in.user.data;
+        return NGX_OK;
+    }
+
     rc = ngx_http_auth_basic_user(r);
 
     if (rc == NGX_DECLINED) {


### PR DESCRIPTION
## Problem

Currently, modules like [spnego-http-auth-nginx-module](https://github.com/stnoonan/spnego-http-auth-nginx-module) have to resort to using a fake `Basic <base64(user:bogus_password)>` Authorization header just to make `$remote_user` readable downstream.

## Solution

Add a `remote_user_set` flag to `ngx_http_request_t`. When an auth module (e.g. SPNEGO) sets `$remote_user` directly by writing to `r->headers_in.user` and raising the flag, the `get_handler` (i.e. `ngx_http_variable_remote_user()`) returns that value without calling `ngx_http_auth_basic_user()`. I did not include a `set_handler` since that would kind of go against the purpose of `$remote_user`.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing (with a simple one-line change to `spnego-http-auth-nginx-module`)
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** `N/A`

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary (I did not find any place that needed to be updated, happy to make changes if I missed something)
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

This change should only affect module developers.