### PR TITLE
Rewrite: harden escape flags control

### DIFF
--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -1183,6 +1183,7 @@ ngx_http_script_regex_start_code(ngx_http_script_engine_t *e)
         return;
     }
 
+    e->is_args = 0;
     e->quote = code->redirect;
 
     e->pos = e->buf.data;
@@ -1769,6 +1770,7 @@ ngx_http_script_complex_value_code(ngx_http_script_engine_t *e)
     le.ip = code->lengths->elts;
     le.line = e->line;
     le.request = e->request;
+    le.is_args = e->is_args;
     le.quote = e->quote;
 
     for (len = 0; *(uintptr_t *) le.ip; len += lcode(&le)) {


### PR DESCRIPTION
Following 2046b45aa0c6, this change introduces better control of memory allocation flags for escaped values.  Notably:

- The code->redirect flag is now taken into account when allocating rewrite buffer in absence of variables and duplicate captures. Previously only the code->uri flag was used, which could potentially lead to buffer overflow if code->redirect was set, but code->uri was not.  Currently this does not happen.

- The e->is_args flag is now explicitly reset on rewrite start. If the flag was set prior to rewrite start, then buffer overflow could happen, see 2046b45aa0c6.  Currently this does not happen.

- The le->is_args flag value is now copied from e->is_args when calculating complex value length for "if" and "set" directives. If e->is_args was set, but le->is_args was not, then buffer overflow could happen, see 2046b45aa0c6.  Currently this does not happen.
