### PR TITLE
Proxy: fixed HTTP/2 upstream with revalidated cache send

### DIFF
--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -160,6 +160,7 @@ static ngx_http_proxy_v2_ctx_t *
     ngx_http_proxy_v2_get_ctx(ngx_http_request_t *r);
 static ngx_int_t ngx_http_proxy_v2_get_connection_data(ngx_http_request_t *r,
     ngx_http_proxy_v2_ctx_t *ctx, ngx_peer_connection_t *pc);
+static ngx_inline ngx_int_t ngx_http_proxy_v2_cached(ngx_http_request_t *r);
 static void ngx_http_proxy_v2_cleanup(void *data);
 
 static void ngx_http_proxy_v2_abort_request(ngx_http_request_t *r);
@@ -1406,7 +1407,7 @@ ngx_http_proxy_v2_process_header(ngx_http_request_t *r)
 
         /* frame payload */
 
-        if (u->peer.connection) {
+        if (!ngx_http_proxy_v2_cached(r)) {
 
             if (ctx->type == NGX_HTTP_V2_RST_STREAM_FRAME) {
                 rc = ngx_http_proxy_v2_parse_rst_stream(r, ctx, b);
@@ -4069,9 +4070,7 @@ ngx_http_proxy_v2_get_connection_data(ngx_http_request_t *r,
     ngx_connection_t    *c;
     ngx_pool_cleanup_t  *cln;
 
-    c = pc->connection;
-
-    if (c == NULL) {
+    if (ngx_http_proxy_v2_cached(r)) {
         ctx->connection = ngx_palloc(r->pool, sizeof(ngx_http_proxy_v2_conn_t));
         if (ctx->connection == NULL) {
             return NGX_ERROR;
@@ -4081,6 +4080,8 @@ ngx_http_proxy_v2_get_connection_data(ngx_http_request_t *r,
 
         goto done;
     }
+
+    c = pc->connection;
 
     if (pc->cached) {
 
@@ -4134,6 +4135,17 @@ done:
     ctx->connection->last_stream_id = 1;
 
     return NGX_OK;
+}
+
+
+static ngx_inline ngx_int_t
+ngx_http_proxy_v2_cached(ngx_http_request_t *r)
+{
+#if (NGX_HTTP_CACHE)
+    return r->cached;
+#else
+    return 0;
+#endif
 }
 
 


### PR DESCRIPTION
Previously, a revalidated cached response could fail on a cached keepalive connection with "upstream sent frame for unknown stream" error followed by "cache file contains invalid header".

This happened because after a 304 response nginx parsed the cached response while the upstream peer connection was still attached to the request.  The HTTP/2 proxy code treated cached frames as frames from that live connection, and could assign a real stream id instead of treating the cached response as having no real stream.

The fix is to treat cached response parsing as cache-only regardless of the current upstream peer connection: set the stream id to 0 and skip live upstream control-frame handling while r->cached is set.

Closes: https://github.com/nginx/nginx/issues/1318

## Problem

Briefly describe the issue or feature being addressed.

## Solution

Explain your approach and any important design decisions.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [ ] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #ISSUE\_NUMBER

## Checklist

Before submitting this PR, please confirm:

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [ ] I have updated documentation where necessary
- [ ] My branch is rebased on the latest master
- [ ] This PR targets the master branch from my fork
- [ ] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
