### PR TITLE
QUIC: add NGX_BPF_DEBUGMSG to enable bpf debug messages

### DIFF
--- a/src/event/quic/bpf/ngx_quic_reuseport_helper.c
+++ b/src/event/quic/bpf/ngx_quic_reuseport_helper.c
@@ -14,7 +14,7 @@
 #endif
 
 
-#if defined(LICENSE_GPL)
+#if defined(LICENSE_GPL) && defined(NGX_BPF_DEBUGMSG)
 
 /*
  * To see debug:


### PR DESCRIPTION
When LICENSE_GPL is defined, the logs of quic could flush trace_pipe while trace_pipe is used for other bpf tools.

In order to clarify the check, add NGX_BPF_DEBUGMSG as an explicit opt-in for bpf debug messages. Both LICENSE_GPL and NGX_BPF_DEBUGMSG must be defined to enable them: the former ensures the GPL-only bpf_trace_printk helper is permitted, the latter makes the intent explicit.

To enable bpf debug messages:

    make LICENSE=GPL CFLAGS="-O2 -Wall -DNGX_BPF_DEBUGMSG"

## Problem

The logs of quic could flush trace_pipe while trace_pipe is used for other bpf tools.

## Solution

Add NGX_BPF_DEBUGMSG as an explicit opt-in for bpf debug messages.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [ ] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

~~**Closes:** #ISSUE\_NUMBER~~

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

This change only affects users who care about the BPF logs for quic when they select GPL as LICENSE.
