### PR TITLE
HTTP/1.x: Strip leading and trailing tabs from header values

### DIFF
--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -1027,6 +1027,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_space_before_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 break;
             case CR:
                 r->header_start = p;
@@ -1051,6 +1052,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 r->header_end = p;
                 state = sw_space_after_value;
                 break;
@@ -1071,6 +1073,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_space_after_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 break;
             case CR:
                 state = sw_almost_done;


### PR DESCRIPTION
This is required by RFC9112, which includes HTAB in HWS.

## Problem

NGINX didn’t strip leading and trailing HTAB from HTTP/1.x field values, violationg RFC9112.

This is part of #187.

## Solution

Strip them.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [ ] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** No issue as this is an incomplete fix.

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [ ] <del>All existing tests pass</del> Two TLS-related tests fail on my machine, but the failures are unrelated.
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

NGINX now correctly strips leading and trailing SP and HTAB from HTTP/1.x header values.  Previously, only leading and trailing SP was stripped.