### PR TITLE
Support multi-line HTTP field values in configuration

### DIFF
--- a/src/http/modules/ngx_http_headers_filter_module.c
+++ b/src/http/modules/ngx_http_headers_filter_module.c
@@ -851,6 +851,10 @@ ngx_http_headers_add(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     value = cf->args->elts;
 
+    if (ngx_conf_convert_obs_fold_to_sp(cf, value, value + 2) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
     headers = (ngx_array_t **) ((char *) hcf + cmd->offset);
 
     if (*headers == NULL) {

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -108,6 +108,8 @@ static char *ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf,
 static ngx_int_t ngx_http_proxy_init_headers(ngx_conf_t *cf,
     ngx_http_proxy_loc_conf_t *conf, ngx_http_proxy_headers_t *headers,
     ngx_keyval_t *default_headers);
+static char *ngx_http_proxy_set_header(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
 
 static char *ngx_http_proxy_pass(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
@@ -321,7 +323,7 @@ static ngx_command_t  ngx_http_proxy_commands[] = {
 
     { ngx_string("proxy_set_header"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE2,
-      ngx_conf_set_keyval_slot,
+      ngx_http_proxy_set_header,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_proxy_loc_conf_t, headers_source),
       NULL },
@@ -4118,6 +4120,21 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     return NGX_CONF_OK;
 }
 
+static char *
+ngx_http_proxy_set_header(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    char              *rc;
+    ngx_str_t         *value;
+
+    value = cf->args->elts;
+
+    if (ngx_conf_convert_obs_fold_to_sp(cf, value, value + 2) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    rc = ngx_conf_set_keyval_slot(cf, cmd, conf);
+    return rc;
+}
 
 static ngx_int_t
 ngx_http_proxy_init_headers(ngx_conf_t *cf, ngx_http_proxy_loc_conf_t *conf,

--- a/src/http/ngx_http.c
+++ b/src/http/ngx_http.c
@@ -2198,3 +2198,94 @@ ngx_http_set_default_types(ngx_conf_t *cf, ngx_array_t **types,
 
     return NGX_OK;
 }
+
+
+ngx_int_t
+ngx_conf_convert_obs_fold_to_sp(ngx_conf_t *cf,
+    const ngx_str_t *cmd_name, ngx_str_t *value)
+{
+    size_t  out_cursor = 0, cursor = 0, end, original_end;
+    u_char  *ptr, ch;
+
+#define ISSPACE(c) ((c) == ' ' || (c) == '\t')
+    end = original_end = value->len;
+    ptr = value->data;
+
+    /*
+     * Strip leading spaces and tabs, to ensure that none are ever
+     * present in the output.
+     */
+    while (cursor < end && ISSPACE(ptr[cursor])) {
+        cursor++;
+    }
+
+    /*
+     * Invariant 1: if out_cursor == 0 then !ISSPACE(ch).
+     * Invariant 2: out_cursor never has anything that is invalid in an HTTP
+     *              field value.
+     * Invariant 3: !ISSPACE(out_cursor[0])
+     *
+     * At loop start, out_cursor == 0,
+     * but cursor == end || !ISSPACE(ptr[cursor])
+     * so invariant 1 will hold if the loop is entered at all.
+     */
+    for ( /* void */; cursor < end; ++cursor) {
+        ch = ptr[cursor];
+
+        if (ch != CR && ch != LF) {
+            /* Enforce invariant 2. */
+            if (ch < 0x20 ? ch != '\t' : ch == 0x7F) {
+                /* Not valid for an HTTP field value and not obs-fold. */
+                goto fail;
+            }
+            /* Since invariant 1 holds, invariant 3 will not be broken. */
+            ptr[out_cursor++] = ch;
+            continue;
+        }
+
+        if (ch == CR) {
+            if (end - cursor < 3 || ptr[cursor + 1] != LF) {
+                goto fail;
+            }
+            cursor++;
+        }
+        cursor++;
+
+        /* Check that obs-fold syntax is upheld. */
+        if (cursor >= end || !ISSPACE(ptr[cursor])) {
+            goto fail;
+        }
+
+        /* Obs-fold is a single SP, so skip all following HWS. */
+        do {
+            cursor++;
+        } while (cursor < end && ISSPACE(ptr[cursor]));
+
+        /* Loop will increment cursor again, so decrement it. */
+        cursor--;
+
+        /* Obs-fold includes all HWS in the previous line. Strip it. */
+        while (out_cursor > 0 && ISSPACE(ptr[out_cursor - 1])) {
+            out_cursor--;
+        }
+
+        /* Do not add leading whitespace. */
+        if (out_cursor > 0) {
+            ptr[out_cursor++] = ' ';
+        }
+    }
+
+    while (out_cursor > 0 && ISSPACE(ptr[out_cursor - 1])) {
+        out_cursor--;
+    }
+
+    if (out_cursor < original_end) {
+        memset(ptr + out_cursor, '\0', (size_t)(original_end - out_cursor));
+    }
+    value->len = out_cursor;
+    return NGX_OK;
+fail:
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                       "%V: Invalid HTTP field value", (ngx_str_t *)cmd_name);
+    return NGX_ERROR;
+}

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -122,6 +122,11 @@ void ngx_http_split_args(ngx_http_request_t *r, ngx_str_t *uri,
 ngx_int_t ngx_http_parse_chunked(ngx_http_request_t *r, ngx_buf_t *b,
     ngx_http_chunked_t *ctx, ngx_uint_t keep_trailers);
 
+/** Check if the field value is valid for an HTTP field name-value
+ * pair.  Leading and trailing ' ' and '\t' are stripped from the field value
+ * before the value is checked.  The value is updated in-place. */
+ngx_int_t ngx_conf_convert_obs_fold_to_sp(ngx_conf_t *cf,
+    const ngx_str_t *cmd_name, ngx_str_t *value);
 
 ngx_http_request_t *ngx_http_create_request(ngx_connection_t *c);
 ngx_int_t ngx_http_process_request_uri(ngx_http_request_t *r);


### PR DESCRIPTION
Convert obs-fold to a single space and then strip leading and trailing whitespace.  This also rejects invalid field values.

After this change, it is possible to extend HTTP field values across multiple lines.  This can make configuration significantly easier to read.  The syntax is compatible with prior (buggy) configurations that relied on upstream or downstream code supporting HTTP obs-fold.

## Problem

It is not possible to use multiple lines for an HTTP/1.x field value.  There are workarounds some might use that result in quasi-valid (using obs-fold) HTTP/1.x being returned, but break with HTTP/2 and HTTP/3.

## Solution

Perform obs-fold processing and leading/trailing whitespace removal during configuration parsing.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [ ] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1405

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
