### PR TITLE
Core: Make ngx_memcpy and ngx_copymem safe with null pointers

### DIFF
--- a/src/core/ngx_string.c
+++ b/src/core/ngx_string.c
@@ -2124,6 +2124,10 @@ ngx_memcpy(void *dst, const void *src, size_t n)
         ngx_debug_point();
     }
 
+    if (n == 0) {
+        return dst;
+    }
+
     return memcpy(dst, src, n);
 }
 

--- a/src/core/ngx_string.h
+++ b/src/core/ngx_string.h
@@ -103,8 +103,19 @@ void *ngx_memcpy(void *dst, const void *src, size_t n);
  * gcc3 compiles memcpy(d, s, 4) to the inline "mov"es.
  * icc8 compile memcpy(d, s, 4) to the inline "mov"es or XMM moves.
  */
-#define ngx_memcpy(dst, src, n)   (void) memcpy(dst, src, n)
-#define ngx_cpymem(dst, src, n)   (((u_char *) memcpy(dst, src, n)) + (n))
+static inline void
+ngx_memcpy(void *restrict dst, const void *restrict src, size_t n)
+{
+    if (n != 0) {
+        (void) memcpy(dst, src, n);
+    }
+}
+
+static inline u_char *
+ngx_cpymem(void *restrict dst, const void *restrict src, size_t n)
+{
+    return n != 0 ? (u_char *) memcpy(dst, src, n) + n : (u_char *) dst;
+}
 
 #endif
 


### PR DESCRIPTION
## Problem

In many C standards versions, memcpy() with a NULL pointer argument is undefined behavior, even if the size is 0.

## Solution

Avoid the memcpy if the size is 0.

## Testing

- [ ] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** No issue.  This is trivial

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass that pass before the change.
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

No impact.
