### PR TITLE
http_proxy: Initialize fields of newly-allocated chain links to NULL

### DIFF
--- a/src/core/ngx_buf.c
+++ b/src/core/ngx_buf.c
@@ -56,7 +56,7 @@ ngx_alloc_chain_link(ngx_pool_t *pool)
         return cl;
     }
 
-    cl = ngx_palloc(pool, sizeof(ngx_chain_t));
+    cl = ngx_pcalloc(pool, sizeof(ngx_chain_t));
     if (cl == NULL) {
         return NULL;
     }


### PR DESCRIPTION

## Problem

The proxy code currently never returns early while generating headers.  However, subsequent PRs will add checks to ensure that CRLF injection cannot occur.  These checks can fail and cause early returns.  The early return would leave a list without a NULL terminator, causing a crash.

## Solution

Zero-initialize chain links so that the list is always NULL-terminated, even without explicit initialization.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [ ] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #ISSUE\_NUMBER

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass that pass on my machine.
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
