### PR TITLE
Fix 1xx response handling

### DIFF
--- a/src/http/modules/ngx_http_fastcgi_module.c
+++ b/src/http/modules/ngx_http_fastcgi_module.c
@@ -2049,10 +2049,10 @@ ngx_http_fastcgi_process_header(ngx_http_request_t *r)
 
                     status = ngx_atoi(status_line->data, 3);
 
-                    if (status == NGX_ERROR) {
+                    if (status < NGX_HTTP_OK || status > 599) {
                         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                                      "upstream sent invalid status \"%V\"",
-                                      status_line);
+                                      "upstream sent invalid or unsupported "
+                                      "status \"%V\"", status_line);
                         return NGX_HTTP_UPSTREAM_INVALID_HEADER;
                     }
 

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -1873,7 +1873,8 @@ ngx_http_grpc_process_header(ngx_http_request_t *r)
                         return NGX_HTTP_UPSTREAM_INVALID_HEADER;
                     }
 
-                    if (status < NGX_HTTP_OK && status != NGX_HTTP_EARLY_HINTS)
+                    if ((status < NGX_HTTP_OK && status != NGX_HTTP_EARLY_HINTS)
+                        || status > 599)
                     {
                         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                                       "upstream sent unexpected :status \"%V\"",

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -1992,7 +1992,8 @@ ngx_http_grpc_filter_init(void *data)
     r = ctx->request;
     u = r->upstream;
 
-    if (u->headers_in.status_n == NGX_HTTP_NO_CONTENT
+    if (u->headers_in.status_n < NGX_HTTP_OK
+        || u->headers_in.status_n == NGX_HTTP_NO_CONTENT
         || u->headers_in.status_n == NGX_HTTP_NOT_MODIFIED
         || r->method == NGX_HTTP_HEAD)
     {

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -1808,11 +1808,20 @@ ngx_http_proxy_process_status_line(ngx_http_request_t *r)
                    "http proxy status %ui \"%V\"",
                    u->headers_in.status_n, &u->headers_in.status_line);
 
+    if (ctx->status.code == NGX_HTTP_SWITCHING_PROTOCOLS
+        && !r->headers_in.upgrade)
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "upstream sent 101 Switching Protocols, "
+                      "but client didn't send Upgrade header");
+        return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+    }
+
     if (ctx->status.http_version < NGX_HTTP_VERSION_11) {
 
-        if (ctx->status.code == NGX_HTTP_EARLY_HINTS) {
+        if (ctx->status.code < NGX_HTTP_OK) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                          "upstream sent HTTP/1.0 response with early hints");
+                          "upstream sent HTTP/1.0 response with 1xx status");
             return NGX_HTTP_UPSTREAM_INVALID_HEADER;
         }
 
@@ -1838,14 +1847,15 @@ ngx_http_proxy_process_header(ngx_http_request_t *r)
     umcf = ngx_http_get_module_main_conf(r, ngx_http_upstream_module);
 
     for ( ;; ) {
+        u = r->upstream;
 
-        rc = ngx_http_parse_header_line(r, &r->upstream->buffer, 1);
+        rc = ngx_http_parse_header_line(r, &u->buffer, 1);
 
         if (rc == NGX_OK) {
 
             /* a header line has been parsed successfully */
 
-            h = ngx_list_push(&r->upstream->headers_in.headers);
+            h = ngx_list_push(&u->headers_in.headers);
             if (h == NULL) {
                 return NGX_ERROR;
             }
@@ -1881,7 +1891,9 @@ ngx_http_proxy_process_header(ngx_http_request_t *r)
                            "http proxy header: \"%V: %V\"",
                            &h->key, &h->value);
 
-            if (r->upstream->headers_in.status_n == NGX_HTTP_EARLY_HINTS) {
+            if (u->headers_in.status_n < NGX_HTTP_OK
+                && u->headers_in.status_n != NGX_HTTP_SWITCHING_PROTOCOLS)
+            {
                 continue;
             }
 
@@ -1908,14 +1920,19 @@ ngx_http_proxy_process_header(ngx_http_request_t *r)
 
             ctx = ngx_http_get_module_ctx(r, ngx_http_proxy_module);
 
-            if (r->upstream->headers_in.status_n == NGX_HTTP_EARLY_HINTS) {
+            if (u->headers_in.status_n < NGX_HTTP_OK
+                && u->headers_in.status_n != NGX_HTTP_SWITCHING_PROTOCOLS)
+            {
+                /* These responses never have a body. */
+                u->headers_in.chunked = 0;
+                u->headers_in.content_length_n = -1;
+
                 ctx->status.code = 0;
                 ctx->status.count = 0;
                 ctx->status.start = NULL;
                 ctx->status.end = NULL;
 
-                r->upstream->process_header =
-                                            ngx_http_proxy_process_status_line;
+                u->process_header = ngx_http_proxy_process_status_line;
                 r->state = 0;
                 return NGX_HTTP_UPSTREAM_EARLY_HINTS;
             }
@@ -1954,9 +1971,24 @@ ngx_http_proxy_process_header(ngx_http_request_t *r)
                 h->next = NULL;
             }
 
-            /* clear content length if response is chunked */
+            if (u->headers_in.status_n == NGX_HTTP_SWITCHING_PROTOCOLS)
+            {
+                if (!u->headers_in.upgrade) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent 101 Switching Protocols "
+                                  "response without Upgrade header");
+                    return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+                }
 
-            u = r->upstream;
+                u->upgrade = 1;
+                u->keepalive = 0;
+                /* These responses never have a body. */
+                u->headers_in.chunked = 0;
+                u->headers_in.content_length_n = -1;
+                return NGX_OK;
+            }
+
+            /* clear content length if response is chunked */
 
             if (u->headers_in.chunked) {
                 u->headers_in.content_length_n = -1;
@@ -1974,14 +2006,6 @@ ngx_http_proxy_process_header(ngx_http_request_t *r)
                     && u->headers_in.content_length_n == 0))
             {
                 u->keepalive = !u->headers_in.connection_close;
-            }
-
-            if (u->headers_in.status_n == NGX_HTTP_SWITCHING_PROTOCOLS) {
-                u->keepalive = 0;
-
-                if (r->headers_in.upgrade) {
-                    u->upgrade = 1;
-                }
             }
 
             return NGX_OK;
@@ -2021,6 +2045,13 @@ ngx_http_proxy_input_filter_init(void *data)
                    "http proxy filter init s:%ui h:%d c:%d l:%O",
                    u->headers_in.status_n, ctx->head, u->headers_in.chunked,
                    u->headers_in.content_length_n);
+
+    if (u->headers_in.status_n < NGX_HTTP_OK) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                      "internal error: ngx_http_proxy_input_filter_init "
+                      "called on 1xx response");
+        return NGX_ERROR;
+    }
 
     /* as per RFC2616, 4.4 Message Length */
 

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -1629,7 +1629,8 @@ ngx_http_proxy_v2_filter_init(void *data)
         return NGX_ERROR;
     }
 
-    if (u->headers_in.status_n == NGX_HTTP_NO_CONTENT
+    if (u->headers_in.status_n < NGX_HTTP_OK
+        || u->headers_in.status_n == NGX_HTTP_NO_CONTENT
         || u->headers_in.status_n == NGX_HTTP_NOT_MODIFIED
         || ctx->ctx.head)
     {

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -1510,7 +1510,8 @@ ngx_http_proxy_v2_process_header(ngx_http_request_t *r)
                         return NGX_HTTP_UPSTREAM_INVALID_HEADER;
                     }
 
-                    if (status < NGX_HTTP_OK && status != NGX_HTTP_EARLY_HINTS)
+                    if ((status < NGX_HTTP_OK && status != NGX_HTTP_EARLY_HINTS)
+                        || status > 599)
                     {
                         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                                       "upstream sent unexpected :status \"%V\"",

--- a/src/http/modules/ngx_http_scgi_module.c
+++ b/src/http/modules/ngx_http_scgi_module.c
@@ -1220,6 +1220,17 @@ ngx_http_scgi_input_filter_init(void *data)
                    "http scgi filter init s:%ui l:%O",
                    u->headers_in.status_n, u->headers_in.content_length_n);
 
+    /* We don't support 1xx responses. */
+    if (u->headers_in.status_n < NGX_HTTP_OK
+        || u->headers_in.status_n > 599)
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "upstream sent response with invalid or "
+                      "unsupported status %ui",
+                      u->headers_in.status_n);
+        return NGX_ERROR;
+    }
+
     if (u->headers_in.status_n == NGX_HTTP_NO_CONTENT
         || u->headers_in.status_n == NGX_HTTP_NOT_MODIFIED)
     {

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -1459,6 +1459,17 @@ ngx_http_uwsgi_input_filter_init(void *data)
                    "http uwsgi filter init s:%ui l:%O",
                    u->headers_in.status_n, u->headers_in.content_length_n);
 
+    /* We don't support 1xx responses. */
+    if (u->headers_in.status_n < NGX_HTTP_OK
+        || u->headers_in.status_n > 599)
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "upstream sent response with invalid or "
+                      "unsupported status %ui",
+                      u->headers_in.status_n);
+        return NGX_ERROR;
+    }
+
     if (u->headers_in.status_n == NGX_HTTP_NO_CONTENT
         || u->headers_in.status_n == NGX_HTTP_NOT_MODIFIED)
     {

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1810,6 +1810,15 @@ ngx_http_send_response(ngx_http_request_t *r, ngx_uint_t status,
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
+    /*
+     * Anything less than 100 or greater than 599 is invalid.
+     * 1xx responses need to be followed by another response
+     * and this code doesn't support that.
+     */
+    if (status < NGX_HTTP_OK || status > 599) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
     if (status == NGX_HTTP_MOVED_PERMANENTLY
         || status == NGX_HTTP_MOVED_TEMPORARILY
         || status == NGX_HTTP_SEE_OTHER

--- a/src/http/ngx_http_header_filter_module.c
+++ b/src/http/ngx_http_header_filter_module.c
@@ -183,6 +183,22 @@ ngx_http_header_filter(ngx_http_request_t *r)
         return NGX_OK;
     }
 
+    if (r->headers_out.status < NGX_HTTP_OK || r->headers_out.status > 599)
+    {
+        if (r->headers_out.status != NGX_HTTP_SWITCHING_PROTOCOLS) {
+            /*
+             * We shouldn't be here.  Either the status is bad (bug),
+             * or this is a non-101 1xx response (which should use the
+             * early hints filter instead).
+             */
+            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                          "%ui response made it to header filter",
+                          r->headers_out.status);
+            return NGX_ERROR;
+        }
+    }
+
+
     if (r->http_version < NGX_HTTP_VERSION_10) {
         return NGX_OK;
     }

--- a/src/http/ngx_http_header_filter_module.c
+++ b/src/http/ngx_http_header_filter_module.c
@@ -196,6 +196,20 @@ ngx_http_header_filter(ngx_http_request_t *r)
                           r->headers_out.status);
             return NGX_ERROR;
         }
+
+        if (!r->upstream->upgrade
+            || !r->upstream->headers_in.upgrade
+            || r->http_version != NGX_HTTP_VERSION_11)
+        {
+            /*
+             * This is a 101 Switching Protocols response,
+             * but it wasn't properly upgraded or is otherwise
+             * invalid. This is a bug.
+             */
+            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                          "101 response not properly upgraded");
+            return NGX_ERROR;
+        }
     }
 
 

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -1825,6 +1825,9 @@ ngx_http_parse_status_line(ngx_http_request_t *r, ngx_buf_t *b,
                 break;
             case LF:
                 goto done;
+            default:
+                if (ch < 0x20 || ch == 0x7F)
+                    return NGX_ERROR;
             }
             break;
 

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -1823,6 +1823,10 @@ ngx_http_parse_status_line(ngx_http_request_t *r, ngx_buf_t *b,
             status->code = status->code * 10 + (ch - '0');
 
             if (++status->count == 3) {
+                if (status->code < 100 || status->code > 599) {
+                    return NGX_ERROR;
+                }
+
                 state = sw_space_after_status;
                 status->start = p - 2;
             }

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -748,16 +748,14 @@ ngx_http_parse_request_line(ngx_http_request_t *r, ngx_buf_t *b)
 
         /* first digit of major HTTP version */
         case sw_first_major_digit:
-            if (ch < '1' || ch > '9') {
-                return NGX_HTTP_PARSE_INVALID_REQUEST;
-            }
-
-            r->http_major = ch - '0';
-
-            if (r->http_major > 1) {
+            if (ch != '1') {
+                if (ch < '1' || ch > '9') {
+                    return NGX_HTTP_PARSE_INVALID_REQUEST;
+                }
                 return NGX_HTTP_PARSE_INVALID_VERSION;
             }
 
+            r->http_major = 1;
             state = sw_major_digit;
             break;
 
@@ -772,13 +770,7 @@ ngx_http_parse_request_line(ngx_http_request_t *r, ngx_buf_t *b)
                 return NGX_HTTP_PARSE_INVALID_REQUEST;
             }
 
-            r->http_major = r->http_major * 10 + (ch - '0');
-
-            if (r->http_major > 1) {
-                return NGX_HTTP_PARSE_INVALID_VERSION;
-            }
-
-            break;
+            return NGX_HTTP_PARSE_INVALID_VERSION;
 
         /* first digit of minor HTTP version */
         case sw_first_minor_digit:
@@ -806,16 +798,7 @@ ngx_http_parse_request_line(ngx_http_request_t *r, ngx_buf_t *b)
                 break;
             }
 
-            if (ch < '0' || ch > '9') {
-                return NGX_HTTP_PARSE_INVALID_REQUEST;
-            }
-
-            if (r->http_minor > 99) {
-                return NGX_HTTP_PARSE_INVALID_REQUEST;
-            }
-
-            r->http_minor = r->http_minor * 10 + (ch - '0');
-            break;
+            return NGX_HTTP_PARSE_INVALID_REQUEST;
 
         case sw_spaces_after_digit:
             switch (ch) {
@@ -1756,13 +1739,13 @@ ngx_http_parse_status_line(ngx_http_request_t *r, ngx_buf_t *b,
 
         /* the first digit of major HTTP version */
         case sw_first_major_digit:
-            if (ch < '1' || ch > '9') {
-                return NGX_ERROR;
+            if (ch == '1') {
+                r->http_major = 1;
+                state = sw_major_digit;
+                break;
             }
 
-            r->http_major = ch - '0';
-            state = sw_major_digit;
-            break;
+            return NGX_ERROR;
 
         /* the major HTTP version or dot */
         case sw_major_digit:
@@ -1771,20 +1754,11 @@ ngx_http_parse_status_line(ngx_http_request_t *r, ngx_buf_t *b,
                 break;
             }
 
-            if (ch < '0' || ch > '9') {
-                return NGX_ERROR;
-            }
-
-            if (r->http_major > 99) {
-                return NGX_ERROR;
-            }
-
-            r->http_major = r->http_major * 10 + (ch - '0');
-            break;
+            return NGX_ERROR;
 
         /* the first digit of minor HTTP version */
         case sw_first_minor_digit:
-            if (ch < '0' || ch > '9') {
+            if (ch < '0' || ch > '1') {
                 return NGX_ERROR;
             }
 
@@ -1798,17 +1772,7 @@ ngx_http_parse_status_line(ngx_http_request_t *r, ngx_buf_t *b,
                 state = sw_status;
                 break;
             }
-
-            if (ch < '0' || ch > '9') {
-                return NGX_ERROR;
-            }
-
-            if (r->http_minor > 99) {
-                return NGX_ERROR;
-            }
-
-            r->http_minor = r->http_minor * 10 + (ch - '0');
-            break;
+            return NGX_ERROR;
 
         /* HTTP status code */
         case sw_status:

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -2084,6 +2084,16 @@ ngx_http_process_request_header(ngx_http_request_t *r)
         }
     }
 
+    if (r->headers_in.upgrade) {
+        if (r->http_version != NGX_HTTP_VERSION_11) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent HTTP/1.0 request with "
+                          "\"Upgrade\" header");
+            ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+            return NGX_ERROR;
+        }
+    }
+
     if (r->headers_in.connection_type == NGX_HTTP_CONNECTION_KEEP_ALIVE) {
         if (r->headers_in.keep_alive) {
             r->headers_in.keep_alive_n =

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -5498,6 +5498,13 @@ ngx_http_upstream_process_transfer_encoding(ngx_http_request_t *r,
         return NGX_HTTP_UPSTREAM_INVALID_HEADER;
     }
 
+    if (u->headers_in.status_n < NGX_HTTP_OK) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "upstream sent \"Transfer-Encoding\" header "
+                      "in a 1xx response");
+        return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+    }
+
     u->headers_in.transfer_encoding = h;
     h->next = NULL;
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -27,6 +27,8 @@ static ngx_int_t ngx_http_upstream_cache_last_modified(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_upstream_cache_etag(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_upstream_process_upgrade(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset);
 #endif
 
 static void ngx_http_upstream_init_request(ngx_http_request_t *r);
@@ -329,6 +331,10 @@ static ngx_http_upstream_header_t  ngx_http_upstream_headers_in[] = {
                  ngx_http_upstream_ignore_header_line, 0,
                  ngx_http_upstream_copy_header_line,
                  offsetof(ngx_http_headers_out_t, content_encoding), 0 },
+
+    { ngx_string("Upgrade"),
+                 ngx_http_upstream_process_upgrade, 0,
+                 ngx_http_upstream_copy_header_line, 0, 0 },
 
     { ngx_null_string, NULL, 0, NULL, 0, 0 }
 };
@@ -2644,7 +2650,7 @@ ngx_http_upstream_process_early_hints(ngx_http_request_t *r,
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http upstream early hints");
 
-    if (u->conf->pass_early_hints) {
+    if (u->conf->pass_early_hints && r->http_version >= NGX_HTTP_VERSION_11) {
 
         u->early_hints_length += u->buffer.pos - u->buffer.start;
 
@@ -5454,6 +5460,15 @@ ngx_http_upstream_process_connection(ngx_http_request_t *r, ngx_table_elt_t *h,
         u->headers_in.connection_close = 1;
     }
 
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_process_upgrade(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset)
+{
+    r->upstream->headers_in.upgrade = 1;
     return NGX_OK;
 }
 

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -311,6 +311,7 @@ typedef struct {
     unsigned                         chunked:1;
     unsigned                         no_cache:1;
     unsigned                         expired:1;
+    unsigned                         upgrade:1;
 } ngx_http_upstream_headers_in_t;
 
 


### PR DESCRIPTION
## Problem

1xx responses from upstream could result in response smuggling.

## Solution

Fix 1xx response handling.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [ ] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #ISSUE\_NUMBER

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

Properly handle 1xx responses so that an upstream cannot smuggle HTTP responses and cause desynchronization.