### PR TITLE
HTTP/2, HTTP/3: fix error_page for 413 Request Entity Too Large

### DIFF
--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3956,6 +3956,21 @@ ngx_http_v2_read_request_body(ngx_http_request_t *r)
     ngx_http_core_loc_conf_t  *clcf;
     ngx_http_v2_connection_t  *h2c;
 
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    if (r->headers_in.content_length_n != -1
+        && !r->discard_body
+        && clcf->client_max_body_size
+        && clcf->client_max_body_size < r->headers_in.content_length_n)
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "client intended to send too large body: %O bytes",
+                      r->headers_in.content_length_n);
+
+        r->expect_tested = 1;
+        return NGX_HTTP_REQUEST_ENTITY_TOO_LARGE;
+    }
+
     stream = r->stream;
     rb = r->request_body;
 

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -1284,6 +1284,21 @@ ngx_http_v3_read_request_body(ngx_http_request_t *r)
     ngx_http_request_body_t   *rb;
     ngx_http_core_loc_conf_t  *clcf;
 
+    clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+    if (r->headers_in.content_length_n != -1
+        && !r->discard_body
+        && clcf->client_max_body_size
+        && clcf->client_max_body_size < r->headers_in.content_length_n)
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "client intended to send too large body: %O bytes",
+                      r->headers_in.content_length_n);
+
+        r->expect_tested = 1;
+        return NGX_HTTP_REQUEST_ENTITY_TOO_LARGE;
+    }
+
     rb = r->request_body;
 
     preread = r->header_in->last - r->header_in->pos;


### PR DESCRIPTION
## Problem

When `client_max_body_size` is exceeded and `error_page 413` is configured, HTTP/1.x correctly serves the custom error page, but HTTP/2 and HTTP/3 deliver the default nginx 413 page instead.

**Root cause:** `ngx_http_finalize_connection()` short-circuits for HTTP/2 and HTTP/3 streams:

```c
if (r->stream) {
    ngx_http_close_request(r, 0);  /* skips all lingering-close logic */
    return;
}
```

When `error_page 413` redirects to the custom page, the response is queued as HTTP/2 frames but `stream->queued` is still 0 and `stream->out_closed` is still 0 at the moment `ngx_http_v2_close_stream()` is reached. The function then sends `RST_STREAM` before the queued response frames are flushed to the client.

## Solution

Add an early `client_max_body_size` check at the entry of `ngx_http_v2_read_request_body()` and `ngx_http_v3_read_request_body()`, mirroring the existing check in `ngx_http_core_find_config_phase()` for HTTP/1.x.

By returning `NGX_HTTP_REQUEST_ENTITY_TOO_LARGE` **before** any stream or body state is modified, the error propagates back through `ngx_http_read_client_request_body()` to the content handler. The content handler calls `ngx_http_finalize_request()` while `r->count` is still elevated, so `ngx_http_v2_close_stream()` defers the close until all queued frames are flushed — allowing the `error_page` response to reach the client.

The `!r->discard_body` guard prevents double-triggering when body discarding is already in progress.

## Testing

- [ ] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Manual repro config:**

```nginx
http2 on;
http3 on;

server {
    listen 443 ssl;
    ssl_certificate      cert.crt;
    ssl_certificate_key  cert.key;

    client_max_body_size 1;
    error_page 413 /413.html;

    location = /413.html {
        root /usr/share/nginx/html;
        internal;
    }
}
```

```bash
# Before patch: returns default nginx 413 page for HTTP/2 and HTTP/3
# After patch:  returns custom 413.html for all three protocols
curl -k https://127.0.0.1 --data-raw test --http1.1
curl -k https://127.0.0.1 --data-raw test --http2
curl -k https://127.0.0.1 --data-raw test --http3
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear subject, references related issue)

## Release Notes

Fixed `error_page` not being honoured for 413 responses over HTTP/2 and HTTP/3. Custom error pages configured with `error_page 413` are now correctly served for all HTTP protocol versions.

**Closes:** #1356