### PR TITLE
http: Reject leading or trailing SP or HTAB in HTTP/2 or HTTP/3 field values

### DIFF
--- a/src/core/ngx_string.h
+++ b/src/core/ngx_string.h
@@ -236,4 +236,11 @@ void ngx_sort(void *base, size_t n, size_t size,
 #define ngx_value(n)          ngx_value_helper(n)
 
 
+static ngx_inline ngx_int_t
+ngx_str_is_hws(ngx_uint_t c)
+{
+    return c == '\t' || c == ' ';
+}
+
+
 #endif /* _NGX_STRING_H_INCLUDED_ */

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -3437,6 +3437,16 @@ ngx_http_grpc_validate_header_value(ngx_http_request_t *r, ngx_str_t *s)
     u_char      ch;
     ngx_uint_t  i;
 
+    if (s->len == 0) {
+        return NGX_OK;
+    }
+
+    if (ngx_str_is_hws(s->data[0])
+        || ngx_str_is_hws(s->data[s->len - 1]))
+    {
+        return NGX_ERROR;
+    }
+
     for (i = 0; i < s->len; i++) {
         ch = s->data[i];
 

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -3275,6 +3275,16 @@ ngx_http_proxy_v2_validate_header_value(ngx_http_request_t *r, ngx_str_t *s)
     u_char      ch;
     ngx_uint_t  i;
 
+    if (s->len == 0) {
+        return NGX_OK;
+    }
+
+    if (ngx_str_is_hws(s->data[0])
+        || ngx_str_is_hws(s->data[s->len - 1]))
+    {
+        return NGX_ERROR;
+    }
+
     for (i = 0; i < s->len; i++) {
         ch = s->data[i];
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3277,6 +3277,20 @@ ngx_http_v2_validate_header(ngx_http_request_t *r, ngx_http_v2_header_t *header)
         r->invalid_header = 1;
     }
 
+    if (header->value.len == 0) {
+        return NGX_OK;
+    }
+
+    if (ngx_str_is_hws(header->value.data[0])
+        || ngx_str_is_hws(header->value.data[header->value.len - 1]))
+    {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent header \"%V\" with "
+                      "leading or trailing space or HTAB in value",
+                      &header->name);
+        return NGX_ERROR;
+    }
+
     for (i = 0; i != header->value.len; i++) {
         ch = header->value.data[i];
 

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -736,6 +736,20 @@ ngx_http_v3_validate_header(ngx_http_request_t *r, ngx_str_t *name,
         r->invalid_header = 1;
     }
 
+    if (value->len == 0) {
+        return NGX_OK;
+    }
+
+    if (ngx_str_is_hws(value->data[0])
+        || ngx_str_is_hws(value->data[value->len - 1]))
+    {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent header \"%V\" with "
+                      "leading or trailing space or HTAB in value",
+                      name);
+        return NGX_ERROR;
+    }
+
     for (i = 0; i != value->len; i++) {
         ch = value->data[i];
 


### PR DESCRIPTION
Per RFC9113 and RFC9114 these are forbidden.

## Problem

Leading and trailing space in HTTP/2 or HTTP/3 field values must be treated as malformed.

## Solution

Reject them during validation.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [ ] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #ISSUE\_NUMBER

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass that passed on my machine before the change.
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

Leading and trailing whitespace in HTTP/2 and HTTP/3 fields are now rejected.  This is required by RFC9113 and RFC9114.