### PR TITLE
ci: fix expression injection in set-creation-date workflow

### DIFF
--- a/.github/workflows/set-creation-date.yaml
+++ b/.github/workflows/set-creation-date.yaml
@@ -34,6 +34,9 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           ORGANIZATION: nginx
           PROJECT_NUMBER: 33
+
+        env:
+          ISSUE_CREATED_AT: ${{ github.event.issue.created_at }}
         run: |
           gh api graphql -f query='
             query($org: String!, $number: Int!) {
@@ -59,6 +62,9 @@ jobs:
       - name: Add item to project
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+        env:
+          ISSUE_CREATED_AT: ${{ github.event.issue.created_at }}
         run: |
           NODE_ID=${{ github.event.issue.node_id }}
 
@@ -78,8 +84,11 @@ jobs:
       - name: Set item creation date
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+        env:
+          ISSUE_CREATED_AT: ${{ github.event.issue.created_at }}
         run: |
-          DATE=${{ github.event.issue.created_at }}
+          DATE=$ISSUE_CREATED_AT
 
           gh api graphql -f query='
             mutation(


### PR DESCRIPTION
## Summary

The `.github/workflows/set-creation-date.yaml` workflow uses a GitHub Actions expression directly inside a shell `run` step:

```yaml
run: |
  DATE=${{ github.event.issue.created_at }}
```

## Why this is a problem

Inline expressions like `${{ ... }}` are interpolated into the shell script before it runs. This is a well-documented [script injection pattern](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) that GitHub explicitly warns against.

While `issue.created_at` is controlled by GitHub's own API and not directly user-supplied, the pattern is:
- Flagged by security scanners (e.g. [zizmor](https://github.com/woodruffw/zizmor), [actionlint](https://github.com/rhysd/actionlint))
- A bad practice that can be accidentally copied into contexts where the value IS attacker-controlled
- Against GitHub's own hardening recommendations

## Fix

Move the expression into a dedicated environment variable and reference the env var in the shell command:

```yaml
env:
  ISSUE_CREATED_AT: ${{ github.event.issue.created_at }}
run: |
  DATE=$ISSUE_CREATED_AT
```

This ensures the value is passed through the environment (safely quoted) rather than interpolated directly into the shell script.