### PR TITLE
QUIC: fix path MTU discovery when GSO is enabled

### DIFF
--- a/src/event/quic/ngx_event_quic_output.c
+++ b/src/event/quic/ngx_event_quic_output.c
@@ -1356,7 +1356,17 @@ ngx_quic_frame_sendto(ngx_connection_t *c, ngx_quic_frame_t *frame,
 
     ctx->pnum++;
 
-    sent = ngx_quic_send(c, res.data, res.len, path->sockaddr, path->socklen);
+#if ((NGX_HAVE_UDP_SEGMENT) && (NGX_HAVE_MSGHDR_MSG_CONTROL))
+    if (qc->conf->gso_enabled) {
+        sent = ngx_quic_send_segments(c, res.data, res.len, path->sockaddr,
+                                      path->socklen, res.len);
+    } else
+#endif
+    {
+        sent = ngx_quic_send(c, res.data, res.len, path->sockaddr,
+                             path->socklen);
+    }
+
     if (sent < 0) {
         ngx_quic_free_frame(c, frame);
         return sent;


### PR DESCRIPTION
## Problem

HTTP/3 connections fail when a client reaches nginx through a WireGuard
tunnel. With `quic_gso on`, loading a larger response over HTTP/3 makes
nginx log `sendmsg() failed (90: Message too large) while sending frames`
and reset the connection (CONNECTION_CLOSE); the browser shows
`ERR_QUIC_PROTOCOL_ERROR`. The handshake and small responses work; only
larger transfers fail. Over a direct, non-tunnel path the same setup works.

Root cause: path MTU discovery probes are sent by `ngx_quic_frame_sendto()`
as plain datagrams via `ngx_quic_send()`, while the regular output path uses
`ngx_quic_send_segments()` when GSO is enabled. On an interface that
advertises UDP GSO offload (such as WireGuard), an oversized plain probe is
not rejected locally by the kernel and gets acknowledged, so path MTU
discovery raises the path MTU to a value the GSO output path cannot send.
The next segmented send then fails with EMSGSIZE, which is treated as fatal
and closes the connection.

## Solution

Route `ngx_quic_frame_sendto()` through `ngx_quic_send_segments()` as well
when GSO is enabled, so the kernel applies the same segment size check to
MTU probes as to regular output. Oversized probes are then rejected locally
and handled by the existing logic for rejected probes, so discovery
converges to a size the connection can actually transmit. The change is
guarded by `#if ((NGX_HAVE_UDP_SEGMENT) && (NGX_HAVE_MSGHDR_MSG_CONTROL))`,
so platforms without UDP segmentation keep the previous behavior. Other
packets sent via `ngx_quic_frame_sendto()` (PATH_CHALLENGE/RESPONSE,
CONNECTION_CLOSE, ACK) are never expanded beyond the path MTU and are
unaffected.

I've used an LLM to help debug this issue and write the commit message body and this PR description. I've verified myself that everything is correct and tested this change as described below.

## Testing

Manual testing with an HTTP/3 client reaching nginx (`quic_gso on`, HTTP/3
enabled) through a WireGuard tunnel, wg0 MTU 1420:
* Before: loading a ~2.5 MB asset over HTTP/3 triggers `sendmsg() failed (90: Message too large) while sending frames` and a connection reset; the debug log shows the path MTU climbing to 2400 just before the failure. A reload falls back to HTTP/2 over TCP and succeeds.
* After: the same request completes; path MTU discovery converges to ~1416 (wg0 1420) with no EMSGSIZE.
* Counter-check: with `quic_gso off` the request works both before and after, confirming the issue is specific to the GSO output path.
* A direct, non-tunnel path is unaffected and works before and after.

- [x] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)
