### PR TITLE
Access log: Fix "request_length" format length

### DIFF
--- a/src/http/modules/ngx_http_log_module.c
+++ b/src/http/modules/ngx_http_log_module.c
@@ -243,7 +243,7 @@ static ngx_http_log_var_t  ngx_http_log_vars[] = {
     { ngx_string("bytes_sent"), NGX_OFF_T_LEN, ngx_http_log_bytes_sent },
     { ngx_string("body_bytes_sent"), NGX_OFF_T_LEN,
                           ngx_http_log_body_bytes_sent },
-    { ngx_string("request_length"), NGX_SIZE_T_LEN,
+    { ngx_string("request_length"), NGX_OFF_T_LEN,
                           ngx_http_log_request_length },
 
     { ngx_null_string, 0, NULL }


### PR DESCRIPTION
Fix "request_length" format length. The variable handler uses "%O" format specifier.

## Solution

Replace `NGX_SIZE_T_LEN` with `NGX_OFF_T_LEN`. Increasing the buffer size to 20 bytes on 32-bit LFS, maintaining uniformity with 64-bit. 

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

