### PR TITLE
Core: add `ngx_current_usec`

### DIFF
--- a/src/core/ngx_times.c
+++ b/src/core/ngx_times.c
@@ -9,7 +9,7 @@
 #include <ngx_core.h>
 
 
-static ngx_msec_t ngx_monotonic_time(time_t sec, ngx_uint_t msec);
+static ngx_usec_t ngx_monotonic_time(time_t sec, ngx_uint_t usec);
 
 
 /*
@@ -27,6 +27,7 @@ static ngx_uint_t        slot;
 static ngx_atomic_t      ngx_time_lock;
 
 volatile ngx_msec_t      ngx_current_msec;
+volatile ngx_usec_t      ngx_current_usec;
 volatile ngx_time_t     *ngx_cached_time;
 volatile ngx_str_t       ngx_cached_err_log_time;
 volatile ngx_str_t       ngx_cached_http_time;
@@ -83,7 +84,8 @@ ngx_time_update(void)
     u_char          *p0, *p1, *p2, *p3, *p4;
     ngx_tm_t         tm, gmt;
     time_t           sec;
-    ngx_uint_t       msec;
+    ngx_uint_t       msec, usec;
+    ngx_usec_t       current_usec;
     ngx_time_t      *tp;
     struct timeval   tv;
 
@@ -94,9 +96,13 @@ ngx_time_update(void)
     ngx_gettimeofday(&tv);
 
     sec = tv.tv_sec;
-    msec = tv.tv_usec / 1000;
+    usec = tv.tv_usec;
+    msec = usec / 1000;
 
-    ngx_current_msec = ngx_monotonic_time(sec, msec);
+    current_usec = ngx_monotonic_time(sec, usec);
+
+    ngx_current_msec = (ngx_msec_t) (current_usec / 1000);
+    ngx_current_usec = current_usec;
 
     tp = &cached_time[slot];
 
@@ -192,8 +198,8 @@ ngx_time_update(void)
 }
 
 
-static ngx_msec_t
-ngx_monotonic_time(time_t sec, ngx_uint_t msec)
+static ngx_usec_t
+ngx_monotonic_time(time_t sec, ngx_uint_t usec)
 {
 #if (NGX_HAVE_CLOCK_MONOTONIC)
     struct timespec  ts;
@@ -201,11 +207,11 @@ ngx_monotonic_time(time_t sec, ngx_uint_t msec)
     clock_gettime(CLOCK_MONOTONIC, &ts);
 
     sec = ts.tv_sec;
-    msec = ts.tv_nsec / 1000000;
+    usec = ts.tv_nsec / 1000;
 
 #endif
 
-    return (ngx_msec_t) sec * 1000 + msec;
+    return (ngx_usec_t) sec * 1000000 + usec;
 }
 
 

--- a/src/core/ngx_times.h
+++ b/src/core/ngx_times.h
@@ -48,5 +48,8 @@ extern volatile ngx_str_t    ngx_cached_syslog_time;
  */
 extern volatile ngx_msec_t  ngx_current_msec;
 
+/* microseconds elapsed since some unspecified point in the past */
+extern volatile ngx_usec_t  ngx_current_usec;
+
 
 #endif /* _NGX_TIMES_H_INCLUDED_ */

--- a/src/os/unix/ngx_time.h
+++ b/src/os/unix/ngx_time.h
@@ -15,6 +15,7 @@
 
 typedef ngx_rbtree_key_t      ngx_msec_t;
 typedef ngx_rbtree_key_int_t  ngx_msec_int_t;
+typedef uint64_t              ngx_usec_t;
 
 typedef struct tm             ngx_tm_t;
 

--- a/src/os/win32/ngx_time.h
+++ b/src/os/win32/ngx_time.h
@@ -15,6 +15,7 @@
 
 typedef ngx_rbtree_key_t      ngx_msec_t;
 typedef ngx_rbtree_key_int_t  ngx_msec_int_t;
+typedef uint64_t              ngx_usec_t;
 
 typedef SYSTEMTIME            ngx_tm_t;
 typedef FILETIME              ngx_mtime_t;


### PR DESCRIPTION
## Problem

Currently only milliseconds are exposed, but the actual syscalls that are being used does expose microseconds.

## Solution

- Expose a new variable for microseconds.
- Keep updating the existing millisecond variable.

## Testing

I couldn't find a test for `ngx_current_msec` so I don't think a test for `ngx_current_usec` is needed. I've compiled the code and it works.

- [x] Manual Testing: I've compiled the code.
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

N/A.
