### PR TITLE
Refuse to emit 1xx responses as normal responses

### DIFF
--- a/src/http/ngx_http_header_filter_module.c
+++ b/src/http/ngx_http_header_filter_module.c
@@ -177,6 +177,22 @@ ngx_http_header_filter(ngx_http_request_t *r)
         return NGX_OK;
     }
 
+    status = r->headers_out.status;
+
+    /* 1xx responses should not reach here */
+    if (status >= 100
+        && status < NGX_HTTP_OK
+        && (status != NGX_HTTP_SWITCHING_PROTOCOLS
+            || r->upstream == NULL
+            || !r->upstream->upgrade))
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "Unsupported 1xx status code %ui", status);
+        ngx_http_filter_finalize_request(r, NULL,
+                                         NGX_HTTP_INTERNAL_SERVER_ERROR);
+        return NGX_ERROR;
+    }
+
     r->header_sent = 1;
 
     if (r != r->main) {

--- a/src/http/v2/ngx_http_v2_filter_module.c
+++ b/src/http/v2/ngx_http_v2_filter_module.c
@@ -147,6 +147,17 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
         return NGX_OK;
     }
 
+    if (r->headers_out.status >= 100
+        && r->headers_out.status < NGX_HTTP_OK)
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "Unsupported 1xx status code %ui",
+                      r->headers_out.status);
+        ngx_http_filter_finalize_request(r, NULL,
+                                         NGX_HTTP_INTERNAL_SERVER_ERROR);
+        return NGX_ERROR;
+    }
+
     r->header_sent = 1;
 
     if (r != r->main) {

--- a/src/http/v3/ngx_http_v3_filter_module.c
+++ b/src/http/v3/ngx_http_v3_filter_module.c
@@ -107,6 +107,16 @@ ngx_http_v3_header_filter(ngx_http_request_t *r)
         return NGX_OK;
     }
 
+    if (r->headers_out.status >= 100
+        && r->headers_out.status < NGX_HTTP_OK)
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "Unsupported 1xx status code %ui",
+                      r->headers_out.status);
+        ngx_http_filter_finalize_request(r, NULL, NGX_HTTP_INTERNAL_SERVER_ERROR);
+        return NGX_ERROR;
+    }
+
     r->header_sent = 1;
 
     if (r != r->main) {


### PR DESCRIPTION

## Problem

Sending a 1xx response as if it were a normal response is invalid.  With HTTP/1.x, it causes a connection desync.  With HTTP/2 and HTTP/3, it sends garbage to the client.

## Solution

Regardless of how Nginx decides it needs to emit a response, it must go through one of the code paths that serializes a response for transmission.  Make the HTTP/1.x, HTTP/2, and HTTP/3 header serializers simply refuse to process 1xx responses.

1xx responses that reach the normal response paths will now return a 500 response instead, regardless of how they are generated internally.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

nginx/nginx-tests#64

- [ ] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1427

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

1xx responses from upstream, other than 103 Early Hints and 101 responses that result in a protocol transition, will result in 500 Internal Server Error responses being sent to the client.  While still incorrect, this is better than the previous behavior of allowing response smuggling (for HTTP/1.x) or sending invalid responses (HTTP/2 and HTTP/3).
