### PR TITLE
Support sending all 1xx statuses (other than 101) to upstream

### DIFF
--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -1873,7 +1873,7 @@ ngx_http_grpc_process_header(ngx_http_request_t *r)
                         return NGX_HTTP_UPSTREAM_INVALID_HEADER;
                     }
 
-                    if (status < NGX_HTTP_OK && status != NGX_HTTP_EARLY_HINTS)
+                    if (status < 100 || status == NGX_HTTP_SWITCHING_PROTOCOLS)
                     {
                         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                                       "upstream sent unexpected :status \"%V\"",
@@ -1907,7 +1907,9 @@ ngx_http_grpc_process_header(ngx_http_request_t *r)
                 h->lowcase_key = h->key.data;
                 h->hash = ngx_hash_key(h->key.data, h->key.len);
 
-                if (u->headers_in.status_n == NGX_HTTP_EARLY_HINTS) {
+                if (u->headers_in.status_n >= 100
+                    && u->headers_in.status_n < NGX_HTTP_OK)
+                {
                     continue;
                 }
 
@@ -1932,7 +1934,9 @@ ngx_http_grpc_process_header(ngx_http_request_t *r)
                 ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                                "grpc header done");
 
-                if (u->headers_in.status_n == NGX_HTTP_EARLY_HINTS) {
+                if (u->headers_in.status_n >= 100
+                    && u->headers_in.status_n < NGX_HTTP_OK)
+                {
                     if (ctx->end_stream) {
                         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                                       "upstream prematurely closed stream");
@@ -1991,7 +1995,9 @@ ngx_http_grpc_filter_init(void *data)
     r = ctx->request;
     u = r->upstream;
 
-    if (u->headers_in.status_n == NGX_HTTP_NO_CONTENT
+    if ((u->headers_in.status_n >= 100
+         && u->headers_in.status_n < NGX_HTTP_OK)
+        || u->headers_in.status_n == NGX_HTTP_NO_CONTENT
         || u->headers_in.status_n == NGX_HTTP_NOT_MODIFIED
         || r->method == NGX_HTTP_HEAD)
     {

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -1808,11 +1808,12 @@ ngx_http_proxy_process_status_line(ngx_http_request_t *r)
                    "http proxy status %ui \"%V\"",
                    u->headers_in.status_n, &u->headers_in.status_line);
 
-    if (ctx->status.http_version < NGX_HTTP_VERSION_11) {
+    if (ctx->status.http_version != NGX_HTTP_VERSION_11) {
 
-        if (ctx->status.code == NGX_HTTP_EARLY_HINTS) {
+        if (ctx->status.code >= 100 && ctx->status.code < NGX_HTTP_OK) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                          "upstream sent HTTP/1.0 response with early hints");
+                          "upstream sent HTTP/1.0 response with status %ui",
+                          (ngx_uint_t)ctx->status.code);
             return NGX_HTTP_UPSTREAM_INVALID_HEADER;
         }
 
@@ -1838,14 +1839,15 @@ ngx_http_proxy_process_header(ngx_http_request_t *r)
     umcf = ngx_http_get_module_main_conf(r, ngx_http_upstream_module);
 
     for ( ;; ) {
+        u = r->upstream;
 
-        rc = ngx_http_parse_header_line(r, &r->upstream->buffer, 1);
+        rc = ngx_http_parse_header_line(r, &u->buffer, 1);
 
         if (rc == NGX_OK) {
 
             /* a header line has been parsed successfully */
 
-            h = ngx_list_push(&r->upstream->headers_in.headers);
+            h = ngx_list_push(&u->headers_in.headers);
             if (h == NULL) {
                 return NGX_ERROR;
             }
@@ -1881,7 +1883,10 @@ ngx_http_proxy_process_header(ngx_http_request_t *r)
                            "http proxy header: \"%V: %V\"",
                            &h->key, &h->value);
 
-            if (r->upstream->headers_in.status_n == NGX_HTTP_EARLY_HINTS) {
+            if (u->headers_in.status_n >= 100
+                && u->headers_in.status_n < NGX_HTTP_OK
+                && u->headers_in.status_n != NGX_HTTP_SWITCHING_PROTOCOLS)
+            {
                 continue;
             }
 
@@ -1908,14 +1913,20 @@ ngx_http_proxy_process_header(ngx_http_request_t *r)
 
             ctx = ngx_http_get_module_ctx(r, ngx_http_proxy_module);
 
-            if (r->upstream->headers_in.status_n == NGX_HTTP_EARLY_HINTS) {
+            if (u->headers_in.status_n >= 100
+                && u->headers_in.status_n < NGX_HTTP_OK
+                && u->headers_in.status_n != NGX_HTTP_SWITCHING_PROTOCOLS)
+            {
+                /* These responses never have a body. */
+                u->headers_in.chunked = 0;
+                u->headers_in.content_length_n = -1;
+
                 ctx->status.code = 0;
                 ctx->status.count = 0;
                 ctx->status.start = NULL;
                 ctx->status.end = NULL;
 
-                r->upstream->process_header =
-                                            ngx_http_proxy_process_status_line;
+                u->process_header = ngx_http_proxy_process_status_line;
                 r->state = 0;
                 return NGX_HTTP_UPSTREAM_EARLY_HINTS;
             }

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -1510,7 +1510,7 @@ ngx_http_proxy_v2_process_header(ngx_http_request_t *r)
                         return NGX_HTTP_UPSTREAM_INVALID_HEADER;
                     }
 
-                    if (status < NGX_HTTP_OK && status != NGX_HTTP_EARLY_HINTS)
+                    if (status < 100 || status == NGX_HTTP_SWITCHING_PROTOCOLS)
                     {
                         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                                       "upstream sent unexpected :status \"%V\"",
@@ -1544,7 +1544,10 @@ ngx_http_proxy_v2_process_header(ngx_http_request_t *r)
                 h->lowcase_key = h->key.data;
                 h->hash = ngx_hash_key(h->key.data, h->key.len);
 
-                if (u->headers_in.status_n == NGX_HTTP_EARLY_HINTS) {
+                if (r->upstream->headers_in.status_n < NGX_HTTP_OK
+                    && (r->upstream->headers_in.status_n
+                        != NGX_HTTP_SWITCHING_PROTOCOLS))
+                {
                     continue;
                 }
 
@@ -1569,7 +1572,11 @@ ngx_http_proxy_v2_process_header(ngx_http_request_t *r)
                 ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                                "http proxy header done");
 
-                if (u->headers_in.status_n == NGX_HTTP_EARLY_HINTS) {
+                if (u->headers_in.status_n >= 100
+                    && u->headers_in.status_n < NGX_HTTP_OK
+                    && (r->upstream->headers_in.status_n
+                        != NGX_HTTP_SWITCHING_PROTOCOLS))
+                {
                     if (ctx->end_stream) {
                         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                                       "upstream prematurely closed stream");
@@ -1628,7 +1635,8 @@ ngx_http_proxy_v2_filter_init(void *data)
         return NGX_ERROR;
     }
 
-    if (u->headers_in.status_n == NGX_HTTP_NO_CONTENT
+    if (u->headers_in.status_n < NGX_HTTP_OK
+        || u->headers_in.status_n == NGX_HTTP_NO_CONTENT
         || u->headers_in.status_n == NGX_HTTP_NOT_MODIFIED
         || ctx->ctx.head)
     {

--- a/src/http/ngx_http_header_filter_module.c
+++ b/src/http/ngx_http_header_filter_module.c
@@ -52,7 +52,7 @@ static u_char ngx_http_server_full_string[] = "Server: " NGINX_VER CRLF;
 static u_char ngx_http_server_build_string[] = "Server: " NGINX_VER_BUILD CRLF;
 
 static ngx_str_t ngx_http_early_hints_status_line =
-    ngx_string("HTTP/1.1 103 Early Hints" CRLF);
+    ngx_string("103 Early Hints");
 
 
 static ngx_str_t ngx_http_status_lines[] = {
@@ -211,7 +211,7 @@ ngx_http_header_filter(ngx_http_request_t *r)
 
     /* status line */
 
-    if (r->headers_out.status_line.len) {
+    if (r->headers_out.status_line.len > 4) {
         len += r->headers_out.status_line.len;
         status_line = &r->headers_out.status_line;
 #if (NGX_SUPPRESS_WARN)
@@ -632,12 +632,16 @@ ngx_http_header_filter(ngx_http_request_t *r)
 static ngx_int_t
 ngx_http_early_hints_filter(ngx_http_request_t *r)
 {
-    size_t            len;
-    ngx_buf_t        *b;
-    ngx_uint_t        i;
-    ngx_chain_t       out;
-    ngx_list_part_t  *part;
-    ngx_table_elt_t  *header;
+    size_t               len;
+    ngx_buf_t           *b;
+    ngx_str_t           *status_line;
+    ngx_uint_t           i;
+    ngx_chain_t          out;
+    ngx_list_part_t     *part;
+    ngx_table_elt_t     *header;
+    ngx_http_upstream_t *u;
+
+    status_line = NULL;
 
     if (r != r->main) {
         return NGX_OK;
@@ -645,6 +649,18 @@ ngx_http_early_hints_filter(ngx_http_request_t *r)
 
     if (r->http_version < NGX_HTTP_VERSION_11) {
         return NGX_OK;
+    }
+
+    u = r->upstream;
+
+    if (u->headers_in.status_n < 100
+        || u->headers_in.status_n > 199
+        || u->headers_in.status_n == NGX_HTTP_SWITCHING_PROTOCOLS)
+    {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                      "Bad status code %ui in early hints filter",
+                      r->headers_out.status);
+        return NGX_ERROR;
     }
 
     len = 0;
@@ -676,17 +692,36 @@ ngx_http_early_hints_filter(ngx_http_request_t *r)
         return NGX_OK;
     }
 
-    len += ngx_http_early_hints_status_line.len
-           /* the end of the early hints */
-           + sizeof(CRLF) - 1;
+    if (u->headers_in.status_line.len > 4) {
+        status_line = &u->headers_in.status_line;
+        len += status_line->len;
+    } else if (u->headers_in.status_n == NGX_HTTP_EARLY_HINTS) {
+        len += ngx_http_early_hints_status_line.len;
+    } else {
+        len += 4;
+    }
+
+    /* the end of the early hints */
+    len += (sizeof("HTTP/1.1 ") - 1) + 2 * (sizeof(CRLF) - 1);
 
     b = ngx_create_temp_buf(r->pool, len);
     if (b == NULL) {
         return NGX_ERROR;
     }
 
-    b->last = ngx_copy(b->last, ngx_http_early_hints_status_line.data,
-                       ngx_http_early_hints_status_line.len);
+    b->last = ngx_copy(b->last, "HTTP/1.1 ", sizeof("HTTP/1.1 ") - 1);
+
+    if (status_line != NULL) {
+        b->last = ngx_copy(b->last, status_line->data, status_line->len);
+    } else if (u->headers_in.status_n == NGX_HTTP_EARLY_HINTS) {
+        b->last = ngx_copy(b->last, ngx_http_early_hints_status_line.data,
+                           ngx_http_early_hints_status_line.len);
+    } else {
+        b->last = ngx_sprintf(b->last, "%03ui ", u->headers_in.status_n);
+    }
+
+    /* the end of status line */
+    *b->last++ = CR; *b->last++ = LF;
 
     part = &r->headers_out.headers.part;
     header = part->elts;

--- a/src/http/v2/ngx_http_v2_filter_module.c
+++ b/src/http/v2/ngx_http_v2_filter_module.c
@@ -651,10 +651,12 @@ ngx_http_v2_early_hints_filter(ngx_http_request_t *r)
     ngx_list_part_t           *part;
     ngx_table_elt_t           *header;
     ngx_connection_t          *fc;
+    ngx_http_upstream_t       *u;
     ngx_http_v2_stream_t      *stream;
     ngx_http_v2_out_frame_t   *frame;
     ngx_http_v2_connection_t  *h2c;
 
+    u      = r->upstream;
     stream = r->stream;
 
     if (!stream) {
@@ -746,11 +748,11 @@ ngx_http_v2_early_hints_filter(ngx_http_request_t *r)
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, fc->log, 0,
                    "http2 output header: \":status: %03ui\"",
-                   (ngx_uint_t) NGX_HTTP_EARLY_HINTS);
+                   (ngx_uint_t) u->headers_in.status_n);
 
     *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_STATUS_INDEX);
     *pos++ = NGX_HTTP_V2_ENCODE_RAW | 3;
-    pos = ngx_sprintf(pos, "%03ui", (ngx_uint_t) NGX_HTTP_EARLY_HINTS);
+    pos = ngx_sprintf(pos, "%03ui", (ngx_uint_t) u->headers_in.status_n);
 
     part = &r->headers_out.headers.part;
     header = part->elts;

--- a/src/http/v3/ngx_http_v3_filter_module.c
+++ b/src/http/v3/ngx_http_v3_filter_module.c
@@ -595,12 +595,17 @@ static ngx_int_t
 ngx_http_v3_early_hints_filter(ngx_http_request_t *r)
 {
     size_t                  len, n;
+    u_char                  status_buf[3];
     ngx_buf_t              *b;
-    ngx_uint_t              i;
+    ngx_str_t               status_key, status_value;
+    ngx_uint_t              i, status;
     ngx_chain_t            *out, *hl, *cl;
     ngx_list_part_t        *part;
     ngx_table_elt_t        *header;
+    ngx_http_upstream_t    *u;
     ngx_http_v3_session_t  *h3c;
+
+    u = r->upstream;
 
     if (r->http_version != NGX_HTTP_VERSION_30) {
         return ngx_http_next_early_hints_filter(r);
@@ -641,7 +646,16 @@ ngx_http_v3_early_hints_filter(ngx_http_request_t *r)
 
     len += ngx_http_v3_encode_field_section_prefix(NULL, 0, 0, 0);
 
-    len += ngx_http_v3_encode_field_ri(NULL, 0, NGX_HTTP_V3_HEADER_STATUS_103);
+    status = u->headers_in.status_n;
+    if (status == NGX_HTTP_EARLY_HINTS) {
+        len += ngx_http_v3_encode_field_ri(NULL, 0, NGX_HTTP_V3_HEADER_STATUS_103);
+    } else {
+        ngx_sprintf(status_buf, "%03ui", status);
+        status_key = (ngx_str_t)ngx_string(":status");
+        status_value.len = 3;
+        status_value.data = status_buf;
+        len += ngx_http_v3_encode_field_l(NULL, &status_key, &status_value);
+    }
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http3 header len:%uz", len);
@@ -656,10 +670,15 @@ ngx_http_v3_early_hints_filter(ngx_http_request_t *r)
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http3 output header: \":status: %03ui\"",
-                   (ngx_uint_t) NGX_HTTP_EARLY_HINTS);
+                   (ngx_uint_t) status);
 
-    b->last = (u_char *) ngx_http_v3_encode_field_ri(b->last, 0,
+    if (status == NGX_HTTP_EARLY_HINTS) {
+        b->last = (u_char *) ngx_http_v3_encode_field_ri(b->last, 0,
                                                 NGX_HTTP_V3_HEADER_STATUS_103);
+    } else {
+        b->last = (u_char *) ngx_http_v3_encode_field_l(b->last, &status_key,
+                                                        &status_value);
+    }
 
     part = &r->headers_out.headers.part;
     header = part->elts;


### PR DESCRIPTION
## Problem

NGINX only supports 103 Early Hints, not other 1xx statuses.

## Solution

Support them all.  <del>gRPC is broken, but that is better than everything else being broken.</del> gRPC works too.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [ ] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1427

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

1xx responses other than 103 Early Hints are supported in HTTP/1.1, HTTP/2, and HTTP/3.