### PR TITLE
HTTP/2: reject connection-specific headers in upstream responses

### DIFF
--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -157,6 +157,7 @@ static ngx_int_t ngx_http_grpc_parse_header(ngx_http_request_t *r,
     ngx_http_grpc_ctx_t *ctx, ngx_buf_t *b);
 static ngx_int_t ngx_http_grpc_parse_fragment(ngx_http_request_t *r,
     ngx_http_grpc_ctx_t *ctx, ngx_buf_t *b);
+static ngx_uint_t ngx_http_grpc_connection_specific(ngx_str_t *name);
 static ngx_int_t ngx_http_grpc_validate_header_name(ngx_http_request_t *r,
     ngx_str_t *s);
 static ngx_int_t ngx_http_grpc_validate_header_value(ngx_http_request_t *r,
@@ -1941,6 +1942,29 @@ ngx_http_grpc_process_header(ngx_http_request_t *r)
                     return NGX_HTTP_UPSTREAM_INVALID_HEADER;
                 }
 
+                /*
+                 * RFC 9113, 8.2.2: an HTTP/2 message that contains
+                 * connection-specific header fields is malformed.
+                 * RFC 9110, 7.6.1 lists Connection, Proxy-Connection,
+                 * Keep-Alive, TE, Transfer-Encoding, and Upgrade.  On the
+                 * HTTP/2 wire all of these are malformed regardless of the
+                 * response, so all are rejected; Upgrade in particular is
+                 * defined for 101 and 426 responses but still may not
+                 * appear over HTTP/2.  TE is request-only (RFC 9110,
+                 * 10.1.4), so the "TE: trailers" request allowance does
+                 * not apply here.  Header names on the wire are lowercase
+                 * and have already been validated as such by
+                 * ngx_http_grpc_validate_header_name().
+                 */
+
+                if (ngx_http_grpc_connection_specific(&ctx->name)) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent connection-specific "
+                                  "header \"%V: %V\"",
+                                  &ctx->name, &ctx->value);
+                    return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+                }
+
                 h = ngx_list_push(&u->headers_in.headers);
                 if (h == NULL) {
                     return NGX_ERROR;
@@ -3446,6 +3470,33 @@ ngx_http_grpc_parse_fragment(ngx_http_request_t *r, ngx_http_grpc_ctx_t *ctx,
     }
 
     return NGX_DONE;
+}
+
+
+static ngx_uint_t
+ngx_http_grpc_connection_specific(ngx_str_t *name)
+{
+    ngx_uint_t  i;
+
+    static ngx_str_t  headers[] = {
+        ngx_string("connection"),
+        ngx_string("proxy-connection"),
+        ngx_string("keep-alive"),
+        ngx_string("te"),
+        ngx_string("transfer-encoding"),
+        ngx_string("upgrade"),
+        ngx_null_string
+    };
+
+    for (i = 0; headers[i].len; i++) {
+        if (name->len == headers[i].len
+            && ngx_strncmp(name->data, headers[i].data, headers[i].len) == 0)
+        {
+            return 1;
+        }
+    }
+
+    return 0;
 }
 
 

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -132,6 +132,7 @@ static ngx_int_t ngx_http_proxy_v2_parse_header(ngx_http_request_t *r,
     ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b);
 static ngx_int_t ngx_http_proxy_v2_parse_fragment(ngx_http_request_t *r,
     ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b);
+static ngx_uint_t ngx_http_proxy_v2_connection_specific(ngx_str_t *name);
 static ngx_int_t ngx_http_proxy_v2_validate_header_name(ngx_http_request_t *r,
     ngx_str_t *s);
 static ngx_int_t ngx_http_proxy_v2_validate_header_value(ngx_http_request_t *r,
@@ -1575,6 +1576,29 @@ ngx_http_proxy_v2_process_header(ngx_http_request_t *r)
                 } else if (!ctx->status) {
                     ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                                   "upstream sent no :status header");
+                    return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+                }
+
+                /*
+                 * RFC 9113, 8.2.2: an HTTP/2 message that contains
+                 * connection-specific header fields is malformed.
+                 * RFC 9110, 7.6.1 lists Connection, Proxy-Connection,
+                 * Keep-Alive, TE, Transfer-Encoding, and Upgrade.  On the
+                 * HTTP/2 wire all of these are malformed regardless of the
+                 * response, so all are rejected; Upgrade in particular is
+                 * defined for 101 and 426 responses but still may not
+                 * appear over HTTP/2.  TE is request-only (RFC 9110,
+                 * 10.1.4), so the "TE: trailers" request allowance does
+                 * not apply here.  Header names on the wire are lowercase
+                 * and have already been validated as such by
+                 * ngx_http_proxy_v2_validate_header_name().
+                 */
+
+                if (ngx_http_proxy_v2_connection_specific(&ctx->name)) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "upstream sent connection-specific "
+                                  "header \"%V: %V\"",
+                                  &ctx->name, &ctx->value);
                     return NGX_HTTP_UPSTREAM_INVALID_HEADER;
                 }
 
@@ -3284,6 +3308,33 @@ ngx_http_proxy_v2_parse_fragment(ngx_http_request_t *r,
     }
 
     return NGX_DONE;
+}
+
+
+static ngx_uint_t
+ngx_http_proxy_v2_connection_specific(ngx_str_t *name)
+{
+    ngx_uint_t  i;
+
+    static ngx_str_t  headers[] = {
+        ngx_string("connection"),
+        ngx_string("proxy-connection"),
+        ngx_string("keep-alive"),
+        ngx_string("te"),
+        ngx_string("transfer-encoding"),
+        ngx_string("upgrade"),
+        ngx_null_string
+    };
+
+    for (i = 0; headers[i].len; i++) {
+        if (name->len == headers[i].len
+            && ngx_strncmp(name->data, headers[i].data, headers[i].len) == 0)
+        {
+            return 1;
+        }
+    }
+
+    return 0;
 }
 
 


### PR DESCRIPTION
## Problem

The HTTP/2 upstream response parsers — `ngx_http_grpc_process_header()`
in `src/http/modules/ngx_http_grpc_module.c` and
`ngx_http_proxy_v2_process_header()` in
`src/http/modules/ngx_http_proxy_v2_module.c` — do not reject
connection-specific header fields in responses.

Per RFC 9113, 8.2.2, an HTTP/2 message containing such fields is
malformed.  RFC 9110, 7.6.1 lists them: `Connection`,
`Proxy-Connection`, `Keep-Alive`, `TE`, `Transfer-Encoding`, and
`Upgrade`.  The request side already enforces this (d3a76322cf7a,
"Restrict connection-specific headers in HTTP/2 and HTTP/3"); the
HTTP/2 upstream response path did not.

Closes: #1394

## Solution

Add the well-formedness check to both modules that parse HTTP/2
responses from upstreams (the gRPC module and the HTTP/2 proxy module),
between the `:status` handling and the point where the header is
appended to `u->headers_in.headers`.

The disallowed names are kept in a small table matched by a per-module
helper (`ngx_http_grpc_connection_specific` /
`ngx_http_proxy_v2_connection_specific`), following the existing
per-module `validate_header_name` style.  Header names on the wire are
lowercase — already enforced by `validate_header_name()` — so a
length-guarded `ngx_strncmp()` is sufficient.

Unlike the request side, `TE` is rejected unconditionally: it is a
request-only field (RFC 9110, 10.1.4) with no defined meaning in a
response, so the `trailers` exception does not apply here.

The trailers path is intentionally left unchanged; trailer field
restrictions (RFC 9110, 6.5.1) are a separate concern.

## Testing

- [x] Compiles cleanly under the project's strict warning set
      (`-Wall -Wextra -Werror -Wpointer-arith
      -Wconditional-uninitialized`).
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))
      — the companion request-side fix was tested via additions to the
      `nginx-tests` repository; an equivalent upstream-response test
      belongs there as well.  Happy to extend the relevant test if a
      maintainer wants it to land alongside this change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (tests live in the external nginx-tests repo)
- [x] All existing in-tree checks pass (whitespace clean; strict-warning build clean)
- [x] I have updated documentation where necessary (no doc-visible behavior change)
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (subject prefix, <=72 cols, references the issue)

## Release Notes

Bugfix.  Reject malformed responses from HTTP/2 upstreams (gRPC and the
HTTP/2 proxy module) that carry connection-specific headers, per
RFC 9113, 8.2.2.  No change in behavior for well-formed peers.