### PR TITLE
GH: explicitly set permissions in workflows

### DIFF
--- a/.github/workflows/buildbot.yml
+++ b/.github/workflows/buildbot.yml
@@ -6,6 +6,9 @@ on:
       - master
       - 'stable-1.*'
 
+permissions:
+  contents: read
+
 jobs:
   buildbot:
     uses: nginx/ci-self-hosted/.github/workflows/nginx-buildbot.yml@main

--- a/.github/workflows/check-commit-message.yaml
+++ b/.github/workflows/check-commit-message.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 
+permissions:
+  contents: read
+
 jobs:
   check-commit-messages:
     runs-on: ubuntu-24.04

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -3,6 +3,10 @@ name: check-pr
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check-pr:
     uses: nginx/ci-self-hosted/.github/workflows/nginx-check-pr.yml@main

--- a/.github/workflows/check-version-bump.yaml
+++ b/.github/workflows/check-version-bump.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 
+permissions:
+  contents: read
+
 jobs:
   check-version-bump:
     runs-on: ubuntu-24.04

--- a/.github/workflows/check-whitespace.yaml
+++ b/.github/workflows/check-whitespace.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 
+permissions:
+  contents: read
+
 jobs:
   check-whitespace:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
```
GH: explicitly set permissions in workflows

These will override the default repo/org GITHUB_TOKEN scope.
```

**Full disclosure:** This patch was generated by Copilot

**NOTE:** Regarding the update to _buildbot.yml_ if the workflow it
includes ever adds write permissions, then this workflow will fail until
updated to match.
