### PR TITLE
GH: Fix the whitespace checker workflow

### DIFF
--- a/.github/workflows/check-whitespace.yaml
+++ b/.github/workflows/check-whitespace.yaml
@@ -17,6 +17,7 @@ jobs:
     - name: git log --check
       run: |
         echo "## Whitespace Check Results" >${GITHUB_STEP_SUMMARY}
+        echo '```' >>${GITHUB_STEP_SUMMARY}
         err=0
         commit=
         while read dash hash subj
@@ -42,6 +43,7 @@ jobs:
             ;;
           esac
         done <<< $(git log --check --pretty=format:"--- %h %s" ${{github.event.pull_request.base.sha}}..)
+        echo '```' >>${GITHUB_STEP_SUMMARY}
 
         if test ${err} -ne 0
         then

--- a/.github/workflows/check-whitespace.yaml
+++ b/.github/workflows/check-whitespace.yaml
@@ -18,7 +18,6 @@ jobs:
       run: |
         echo "## Whitespace Check Results" >${GITHUB_STEP_SUMMARY}
         echo '```' >>${GITHUB_STEP_SUMMARY}
-        err=0
         commit=
         while read dash hash subj
         do


### PR DESCRIPTION
This comprises two commits

- **GH: fix summary formatting for check-whitespace.yaml**

Prevent undesirable formatting in the GitHub workflow summary.

- **GH: fix check-whitespace.yaml error return with multiple commits**

Fix the whitespace checker when there are multiple commits. If there's
an issue with a commit but then one or more subsequent commits are OK,
we wouldn't flag this as a failure.
