### PR TITLE
Mail: RFC7628 - SASL Oauth - IMAP only

### DIFF
--- a/src/mail/ngx_mail.h
+++ b/src/mail/ngx_mail.h
@@ -301,16 +301,18 @@ typedef struct {
 #define NGX_MAIL_AUTH_LOGIN_USERNAME    2
 #define NGX_MAIL_AUTH_APOP              3
 #define NGX_MAIL_AUTH_CRAM_MD5          4
-#define NGX_MAIL_AUTH_EXTERNAL          5
-#define NGX_MAIL_AUTH_NONE              6
+#define NGX_MAIL_AUTH_OAUTHBEARER       5
+#define NGX_MAIL_AUTH_EXTERNAL          6
+#define NGX_MAIL_AUTH_NONE              7
 
 
-#define NGX_MAIL_AUTH_PLAIN_ENABLED     0x0002
-#define NGX_MAIL_AUTH_LOGIN_ENABLED     0x0004
-#define NGX_MAIL_AUTH_APOP_ENABLED      0x0008
-#define NGX_MAIL_AUTH_CRAM_MD5_ENABLED  0x0010
-#define NGX_MAIL_AUTH_EXTERNAL_ENABLED  0x0020
-#define NGX_MAIL_AUTH_NONE_ENABLED      0x0040
+#define NGX_MAIL_AUTH_PLAIN_ENABLED            0x0002
+#define NGX_MAIL_AUTH_LOGIN_ENABLED            0x0004
+#define NGX_MAIL_AUTH_APOP_ENABLED             0x0008
+#define NGX_MAIL_AUTH_CRAM_MD5_ENABLED         0x0010
+#define NGX_MAIL_AUTH_OAUTHBEARER_ENABLED      0x0020
+#define NGX_MAIL_AUTH_EXTERNAL_ENABLED         0x0040
+#define NGX_MAIL_AUTH_NONE_ENABLED             0x0080
 
 
 #define NGX_MAIL_PARSE_INVALID_COMMAND  20
@@ -397,6 +399,11 @@ ngx_int_t ngx_mail_auth_cram_md5_salt(ngx_mail_session_t *s,
     ngx_connection_t *c, char *prefix, size_t len);
 ngx_int_t ngx_mail_auth_cram_md5(ngx_mail_session_t *s, ngx_connection_t *c);
 ngx_int_t ngx_mail_auth_external(ngx_mail_session_t *s, ngx_connection_t *c,
+    ngx_uint_t n);
+ngx_int_t ngx_mail_decode_oauthbearer(ngx_str_t *passwd, ngx_str_t *login,
+    ngx_str_t *host,
+    ngx_connection_t *c);
+ngx_int_t ngx_mail_auth_oauthbearer(ngx_mail_session_t *s, ngx_connection_t *c,
     ngx_uint_t n);
 ngx_int_t ngx_mail_auth_parse(ngx_mail_session_t *s, ngx_connection_t *c);
 

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -758,6 +758,124 @@ ngx_mail_auth_external(ngx_mail_session_t *s, ngx_connection_t *c,
     return NGX_DONE;
 }
 
+ngx_int_t
+ngx_mail_decode_oauthbearer(ngx_str_t *passwd, ngx_str_t *login,
+    ngx_str_t *host,
+    ngx_connection_t *c)
+{
+    size_t len;
+    size_t field_index;
+    size_t field_maxlen_name = 10;
+    size_t field_maxlen_value = 256;
+    uint field_sep_reached = 0;
+    ngx_str_t field_name;
+    ngx_str_t field_value;
+
+    u_char *p,*n,*l,*h,*v;
+    u_char field_sep = 0x01;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_MAIL, c->log, 0,
+                   "mail auth oauthbearer: \"%V\"", passwd);
+
+    p = passwd->data;
+
+    field_name.data = ngx_pnalloc(c->pool, field_maxlen_name);
+    field_name.len = 0;
+
+    field_value.data = ngx_pnalloc(c->pool, field_maxlen_value);
+    field_value.len = 0;
+
+    n = field_name.data;
+    v = field_value.data;
+    l = login->data;
+    h = host->data;
+
+    field_index = 0;
+
+    for(len = 0; len < passwd->len; len ++) {
+	    if(p[len] == field_sep) {
+		field_sep_reached = 0;
+		field_index = 0;
+
+		if (ngx_strncasecmp(n, (u_char *) "n,a", 3) == 0) {
+			/* comma at the end is not copied */
+			l = ngx_cpystrn(l, v, field_value.len);
+			login->len = field_value.len - 1;
+		} else if (ngx_strncasecmp(n, (u_char *) "host", 4) == 0) {
+			h = ngx_cpystrn(h, v, field_value.len + 1);
+			host->len = field_value.len;
+		}
+
+	        if (p[len+1] == field_sep) break;
+
+	    } else {
+		    if (p[len] == '=') {
+			    field_sep_reached = 1;
+			    field_index = 0;
+		    } else {
+			    if (field_sep_reached == 1) {
+				    v[field_index] = p[len];
+				    field_value.len = ++field_index;
+			    } else {
+				    n[field_index] = p[len];
+				    field_name.len = ++field_index;
+			    }
+		    }
+	    }
+    }
+
+    return NGX_DONE;
+}
+
+ngx_int_t
+ngx_mail_auth_oauthbearer(ngx_mail_session_t *s, ngx_connection_t *c,
+    ngx_uint_t n)
+{
+    ngx_str_t  *arg, passwd;
+    ngx_str_t  login;
+    ngx_str_t  host;
+
+    arg = s->args.elts;
+
+#if (NGX_DEBUG_MAIL_PASSWD)
+    ngx_log_debug1(NGX_LOG_DEBUG_MAIL, c->log, 0,
+                   "mail auth oauthbearer: \"%V\"", &arg[0]);
+#endif
+
+    passwd.data = ngx_pnalloc(c->pool, ngx_base64_decoded_length(arg[1].len));
+    if (passwd.data == NULL) {
+        return NGX_ERROR;
+    }
+
+    login.data = ngx_pnalloc(c->pool, ngx_base64_decoded_length(arg[1].len));
+    if (login.data == NULL) {
+        return NGX_ERROR;
+    }
+
+    host.data = ngx_pnalloc(c->pool, ngx_base64_decoded_length(arg[1].len));
+    if (host.data == NULL) {
+        return NGX_ERROR;
+    }
+
+    if (ngx_decode_base64(&passwd, &arg[1]) != NGX_OK) {
+        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+            "client sent invalid base64 encoding in AUTHENTICATE OAUTHBEARER command");
+        return NGX_MAIL_PARSE_INVALID_COMMAND;
+    }
+
+    ngx_mail_decode_oauthbearer(&passwd, &login, &host, c);
+
+    s->login = login;
+    s->host = host;
+    s->passwd = arg[1];
+
+#if (NGX_DEBUG_MAIL_PASSWD)
+    ngx_log_debug1(NGX_LOG_DEBUG_MAIL, c->log, 0,
+                   "mail auth oauthbearer: \"%V\"", &s->passwd);
+#endif
+
+    return NGX_DONE;
+}
 
 void
 ngx_mail_send(ngx_event_t *wev)

--- a/src/mail/ngx_mail_imap_module.c
+++ b/src/mail/ngx_mail_imap_module.c
@@ -29,6 +29,7 @@ static ngx_conf_bitmask_t  ngx_mail_imap_auth_methods[] = {
     { ngx_string("plain"), NGX_MAIL_AUTH_PLAIN_ENABLED },
     { ngx_string("login"), NGX_MAIL_AUTH_LOGIN_ENABLED },
     { ngx_string("cram-md5"), NGX_MAIL_AUTH_CRAM_MD5_ENABLED },
+    { ngx_string("oauthbearer"), NGX_MAIL_AUTH_OAUTHBEARER_ENABLED },
     { ngx_string("external"), NGX_MAIL_AUTH_EXTERNAL_ENABLED },
     { ngx_null_string, 0 }
 };
@@ -39,6 +40,7 @@ static ngx_str_t  ngx_mail_imap_auth_methods_names[] = {
     ngx_string("AUTH=LOGIN"),
     ngx_null_string,  /* APOP */
     ngx_string("AUTH=CRAM-MD5"),
+    ngx_string("AUTH=OAUTHBEARER"),
     ngx_string("AUTH=EXTERNAL"),
     ngx_null_string   /* NONE */
 };

--- a/src/mail/ngx_mail_parse.c
+++ b/src/mail/ngx_mail_parse.c
@@ -970,5 +970,21 @@ ngx_mail_auth_parse(ngx_mail_session_t *s, ngx_connection_t *c)
         return NGX_MAIL_PARSE_INVALID_COMMAND;
     }
 
+    if (arg[0].len == 11) {
+
+        if (ngx_strncasecmp(arg[0].data, (u_char *) "OAUTHBEARER", 11) == 0) {
+
+            if (s->args.nelts != 2) {
+                return NGX_MAIL_PARSE_INVALID_COMMAND;
+            }
+
+            if (s->args.nelts == 2) {
+                return ngx_mail_auth_oauthbearer(s, c, 2);
+            }
+        }
+
+        return NGX_MAIL_PARSE_INVALID_COMMAND;
+    }
+
     return NGX_MAIL_PARSE_INVALID_COMMAND;
 }


### PR DESCRIPTION
## Problem

Nginx mail module lacks SASL Oauth mechanism defined in RFC7628. This mechanism once added would trigger OIDC  flow from the mail client.

## Solution

Implements RFC 7628 for the mail IMAP part.
The OAUTHBEARER is provided to the IMAP server as PLAIN password.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1095

## Checklist

Before submitting this PR, please confirm:

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [ ] This PR targets the master branch from my fork
- [ ] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
