### PR TITLE
Gzip: compress responses with 410 status code

### DIFF
--- a/src/http/modules/ngx_http_gzip_filter_module.c
+++ b/src/http/modules/ngx_http_gzip_filter_module.c
@@ -229,7 +229,8 @@ ngx_http_gzip_header_filter(ngx_http_request_t *r)
     if (!conf->enable
         || (r->headers_out.status != NGX_HTTP_OK
             && r->headers_out.status != NGX_HTTP_FORBIDDEN
-            && r->headers_out.status != NGX_HTTP_NOT_FOUND)
+            && r->headers_out.status != NGX_HTTP_NOT_FOUND
+            && r->headers_out.status != NGX_HTTP_GONE)
         || (r->headers_out.content_encoding
             && r->headers_out.content_encoding->value.len)
         || (r->headers_out.content_length_n != -1

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -98,6 +98,7 @@
 #define NGX_HTTP_PROXY_AUTH_REQUIRED       407
 #define NGX_HTTP_REQUEST_TIME_OUT          408
 #define NGX_HTTP_CONFLICT                  409
+#define NGX_HTTP_GONE                      410
 #define NGX_HTTP_LENGTH_REQUIRED           411
 #define NGX_HTTP_PRECONDITION_FAILED       412
 #define NGX_HTTP_REQUEST_ENTITY_TOO_LARGE  413


### PR DESCRIPTION
# Gzip: compress responses with 410 status code

## Summary

Extend the gzip filter to compress **410 Gone** responses, in addition to the existing **200**, **403**, and **404** status codes.

## Problem

The `ngx_http_gzip_filter_module` only compresses responses with status 200, 403, or 404. When a location returns **410 Gone** (e.g. via `return 410` or upstream response), the body is sent uncompressed even if `gzip` is enabled and the client accepts gzip.

410 is commonly used like 404 for permanently removed resources, often with a similar HTML/text error page. Uncompressed 410 pages waste bandwidth and behave inconsistently with 404.

**Related issue:** https://github.com/nginx/nginx/issues/1452

## Solution

- Add `NGX_HTTP_GONE` (410) to `src/http/ngx_http_request.h` (410 was previously missing from the HTTP status constants).
- Include `NGX_HTTP_GONE` in the status check in `ngx_http_gzip_header_filter()` in `src/http/modules/ngx_http_gzip_filter_module.c`, alongside 200/403/404.

No new directive or configuration option; behavior matches existing special-response compression.

## Testing

### Manual testing

Built nginx locally and verified with a minimal config:

```nginx
gzip on;
gzip_min_length 0;
gzip_types text/plain;

location /410 {
    default_type text/plain;
    return 410 "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
}
```

Request:

```bash
curl -s -H "Accept-Encoding: gzip" -D - http://127.0.0.1:18910/410 -o /dev/null
```

Result: response is **410 Gone** with **`Content-Encoding: gzip`**.

### Functional testing (nginx-tests)

Added three test cases to `gzip.t` in the [nginx-tests](https://github.com/nginx/nginx-tests) repository:

- `410 gone` — response status is 410 Gone
- `gzip 410` — response includes `Content-Encoding: gzip`
- `gzip 410 content` — gzipped body decodes to the expected payload

Test location configuration:

```nginx
location /gone {
    gzip on;
    gzip_types text/plain;
    default_type text/plain;
    return 410 "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
}
```

Run:

```bash
git clone https://github.com/nginx/nginx-tests.git
cd nginx-tests
TEST_NGINX_BINARY=/path/to/nginx/objs/nginx prove gzip.t
```

The new 410-related subtests pass with the patched nginx binary.

> **Note:** nginx-tests is a separate repository. A companion PR to [nginx/nginx-tests](https://github.com/nginx/nginx-tests) with the `gzip.t` changes is included alongside this PR.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1452

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary *(no doc change needed; behavior aligns with existing gzip special-response handling)*
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear subject, references related issue if applicable, and contains only relevant changes)

## Release Notes

The gzip filter now compresses **410 Gone** responses when gzip is enabled, consistent with 404 Not Found.
