### PR TITLE
SSL: fixed memory leak in ngx_ssl_get_ech_outer_server_name().

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -5953,6 +5953,8 @@ ngx_ssl_get_ech_outer_server_name(ngx_connection_t *c, ngx_pool_t *pool,
 
         s->data = ngx_pnalloc(pool, s->len);
         if (s->data == NULL) {
+            OPENSSL_free(inner_sni);
+            OPENSSL_free(outer_sni);
             return NGX_ERROR;
         }
 


### PR DESCRIPTION


## Problem

SSL_ech_get1_status() allocates inner_sni and outer_sni and transfers ownership to the caller.  

## Solution

On the allocation-failure path the function returned without freeing them, unlike ngx_ssl_get_ech_status() which frees both on all paths.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)
