### PR TITLE
SSL: fixed memory leaks in init and connection error paths

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -174,12 +174,14 @@ ngx_ssl_init(ngx_log_t *log)
     if (OPENSSL_INIT_set_config_appname(init, "nginx") == 0) {
         ngx_ssl_error(NGX_LOG_ALERT, log, 0,
                       "OPENSSL_INIT_set_config_appname() failed");
+        OPENSSL_INIT_free(init);
         return NGX_ERROR;
     }
 #endif
 
     if (OPENSSL_init_ssl(opts, init) == 0) {
         ngx_ssl_error(NGX_LOG_ALERT, log, 0, "OPENSSL_init_ssl() failed");
+        OPENSSL_INIT_free(init);
         return NGX_ERROR;
     }
 

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -2135,6 +2135,7 @@ ngx_ssl_create_connection(ngx_ssl_t *ssl, ngx_connection_t *c, ngx_uint_t flags)
 
     if (SSL_set_fd(sc->connection, c->fd) == 0) {
         ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "SSL_set_fd() failed");
+        SSL_free(sc->connection);
         return NGX_ERROR;
     }
 
@@ -2151,6 +2152,7 @@ ngx_ssl_create_connection(ngx_ssl_t *ssl, ngx_connection_t *c, ngx_uint_t flags)
 
     if (SSL_set_ex_data(sc->connection, ngx_ssl_connection_index, c) == 0) {
         ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "SSL_set_ex_data() failed");
+        SSL_free(sc->connection);
         return NGX_ERROR;
     }
 


### PR DESCRIPTION
## Problem

Some SSL initialization and connection setup error paths leaked resources:

- ngx_ssl_init() did not free OPENSSL_INIT_SETTINGS when OPENSSL_INIT_set_config_appname() or OPENSSL_init_ssl() failed.
- ngx_ssl_create_connection() did not free the SSL object allocated by SSL_new() when SSL_set_fd() or SSL_set_ex_data() failed.

## Solution

Free OPENSSL_INIT_SETTINGS before returning from the affected ngx_ssl_init() error paths, and free the SSL object before returning from the affected ngx_ssl_create_connection() error paths.

## Testing

- [x] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

Manual testing performed:

- Ran .github/scripts/commit-msg-check.pl against the commit message.
- Ran git diff origin/master..HEAD --check.
- Ran make successfully with the existing local build configuration.

**Closes:**

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear subject, references related issue if applicable, and contains only relevant changes)

## Release Notes

No user-visible behavior change.