### PR TITLE
Stream: reject zero proxy_buffer_size

### DIFF
--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -2420,6 +2420,12 @@ ngx_stream_proxy_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_size_value(conf->buffer_size,
                               prev->buffer_size, 16384);
 
+    if (conf->buffer_size == 0) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "\"proxy_buffer_size\" must be greater than zero");
+        return NGX_CONF_ERROR;
+    }
+
     ngx_conf_merge_ptr_value(conf->upload_rate, prev->upload_rate, NULL);
 
     ngx_conf_merge_ptr_value(conf->download_rate, prev->download_rate, NULL);


### PR DESCRIPTION
## Problem

stream proxy accepts proxy_buffer_size 0.  The value is later used to allocate proxy buffers, producing zero-length buffers.  With no available buffer space, stream proxy cannot read data from the client or upstream connection.

## Solution

Reject zero proxy_buffer_size during stream proxy server configuration merging.

## Testing

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

Manual testing performed:

- Configured nginx with --with-stream --with-http_ssl_module --with-http_v2_module.
- Ran make successfully.
- Ran .github/scripts/commit-msg-check.pl against the commit message.
- Ran git diff origin/master..HEAD --check.
- Ran TEST_NGINX_BINARY=/Users/wind/Code/pro1/nginx/objs/nginx prove -v stream_proxy_buffer_size.t stream_proxy.t in nginx-tests.

Test PR: https://github.com/nginx/nginx-tests/pull/66

**Closes:**

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear subject, references related issue if applicable, and contains only relevant changes)

## Release Notes

Configurations with proxy_buffer_size set to 0 in stream proxy are now rejected.