### PR TITLE
Core: skipped path ownership changes during configuration testing

### DIFF
--- a/src/core/ngx_file.c
+++ b/src/core/ngx_file.c
@@ -614,7 +614,7 @@ ngx_create_paths(ngx_cycle_t *cycle, ngx_uid_t user)
             }
         }
 
-        if (user == (ngx_uid_t) NGX_CONF_UNSET_UINT) {
+        if (user == (ngx_uid_t) NGX_CONF_UNSET_UINT || ngx_test_config) {
             continue;
         }
 


### PR DESCRIPTION
## Problem

When the user directive is in effect and nginx -t / nginx -T is run by a user different from the one nginx normally runs as notably as root, while the workers run as an unprivileged, packager-provided user such as nginx or www-data ngx_create_paths() changed the ownership of the temporary directories (proxy_temp, client_body_temp, fastcgi_temp, scgi_temp, uwsgi_temp, andcache paths) to the configured user.

This left the directories owned by the wrong user for the instance that is actually running, causing a permission mismatch.

Configuration testing is not expected to mutate filesystem state. (Issue #1388)

## Solution

In ngx_create_paths() in [src/core/ngx_file.c](https://github.com/nginx/nginx/blob/master/src/core/ngx_file.c), skip the chown/chmod block when ngx_test_config is set:


```
-        if (user == (ngx_uid_t) NGX_CONF_UNSET_UINT) {
+        if (user == (ngx_uid_t) NGX_CONF_UNSET_UINT || ngx_test_config) {
               continue;
           }
```

  Directories are still created as before (the ngx_create_dir() call precedes the guard), so the config test keeps validating that the paths are usable. Only ownership/permission changes are skipped during a test. This is the single chokepoint for all temp-path modules, and real startup is unaffected because ngx_test_config is 0 there.

## Testing

Validated manually on Linux (Debian-family), since nginx's automated suite lives in the separate nginx-tests repository:

  1. Built with ./auto/configure && make — compiles cleanly.
  2. Reproduced the bug as root with user nobody nogroup; and temp dirs owned by root:
    - Unpatched: after nginx -t, dirs were chowned to 65534 (nobody) — bug confirmed.
    - Patched: after nginx -t, dirs stayed root:root — no filesystem mutation.
  3. Confirmed no regression on real start: after an actual nginx start (patched), the dirs are still correctly chowned to nobody.

- [X] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1388 

## Checklist

Before submitting this PR, please confirm:

- [X] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [X] I have updated documentation where necessary
- [ ] My branch is rebased on the latest master
- [ ] This PR targets the master branch from my fork
- [X] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

`nginx -t` / `nginx -T` no longer changes the ownership of temporary directories; configuration testing no longer modifies filesystem state.