### PR TITLE
Add missing bounds check in ngx_{http,stream}_compile_complex_value()

### DIFF
--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -150,7 +150,9 @@ ngx_http_compile_complex_value(ngx_http_compile_complex_value_t *ccv)
 
     for (i = 0; i < v->len; i++) {
         if (v->data[i] == '$') {
-            if (v->data[i + 1] >= '1' && v->data[i + 1] <= '9') {
+            if (i + 1 < v->len
+                && v->data[i + 1] >= '1' && v->data[i + 1] <= '9')
+            {
                 nc++;
 
             } else {

--- a/src/stream/ngx_stream_script.c
+++ b/src/stream/ngx_stream_script.c
@@ -151,7 +151,9 @@ ngx_stream_compile_complex_value(ngx_stream_compile_complex_value_t *ccv)
 
     for (i = 0; i < v->len; i++) {
         if (v->data[i] == '$') {
-            if (v->data[i + 1] >= '1' && v->data[i + 1] <= '9') {
+            if (i + 1 < v->len
+                && v->data[i + 1] >= '1' && v->data[i + 1] <= '9')
+            {
                 nc++;
 
             } else {


### PR DESCRIPTION
## Problem

ngx_{http,stream}_compile_complex_value() scans strings for $1..$9
capture references and reads v->data[i + 1] after seeing '$'.  The
standard configuration parser provides NUL-terminated strings, but
ngx_str_t itself does not guarantee NUL termination for module callers.

## Solution

Check that i + 1 is within v->len before testing v->data[i + 1].

## Testing

- [x] Compiles on macOS with ./auto/configure --with-stream --with-http_ssl_module --with-stream_ssl_module && make -j8
