### PR TITLE
Proxy: ignore NO_ERROR in upstream GOAWAY frame

### DIFF
--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -1919,9 +1919,11 @@ ngx_http_proxy_v2_process_control_frame(ngx_http_request_t *r,
 
             /* TODO: we can retry non-idempotent requests */
 
-            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                          "upstream sent goaway with error %ui",
-                          ctx->error);
+            if (ctx->error != 0) {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "upstream sent goaway with error %ui",
+                              ctx->error);
+            }
 
             return NGX_ERROR;
         }


### PR DESCRIPTION
## Problem

When using proxy_http_version 2, an upstream sending GOAWAY with
error code 0 (NO_ERROR, i.e. graceful shutdown) triggers an error
log entry and may cause the upstream to be temporarily disabled.

RFC 7540 defines NO_ERROR as "not a result of an error", but nginx
treats it identically to real errors like PROTOCOL_ERROR or
INTERNAL_ERROR.

Fixes #1431

## Solution

Only log the GOAWAY error when ctx->error is non-zero.  Graceful
shutdowns (error=0) no longer produce error log entries.

## Testing

- [x] Compiles on macOS with ./auto/configure && make -j8

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My commit message follows NGINX standards
- [x] This PR targets the master branch from my fork