### PR TITLE
HTTP/2: fix overlapping memcpy in CONTINUATION frames

### DIFF
--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1967,7 +1967,7 @@ ngx_http_v2_handle_continuation(ngx_http_v2_connection_t *h2c, u_char *pos,
     p = pos;
     pos += NGX_HTTP_V2_FRAME_HEADER_SIZE;
 
-    ngx_memcpy(pos, p, len);
+    ngx_memmove(pos, p, len);
 
     len = ngx_http_v2_parse_length(head);
 


### PR DESCRIPTION
## Problem

ngx_http_v2_handle_continuation() uses ngx_memcpy() to shift header
block fragment data past the frame header.  If the fragment exceeds
9 bytes, source and destination overlap — undefined behavior for
memcpy.  The same function already uses ngx_memmove() for another
overlapping shift.

## Solution

Replace ngx_memcpy() with ngx_memmove().

## Testing

- [x] Compiles on macOS with ./auto/configure && make -j8

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My commit message follows NGINX standards