### PR TITLE
HTTP: added QUERY method support.

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -4710,6 +4710,7 @@ static ngx_http_method_name_t  ngx_methods_names[] = {
     { (u_char *) "LOCK",      (uint32_t) ~NGX_HTTP_LOCK },
     { (u_char *) "UNLOCK",    (uint32_t) ~NGX_HTTP_UNLOCK },
     { (u_char *) "PATCH",     (uint32_t) ~NGX_HTTP_PATCH },
+    { (u_char *) "QUERY",     (uint32_t) ~NGX_HTTP_QUERY },
     { NULL, 0 }
 };
 

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -230,6 +230,11 @@ ngx_http_parse_request_line(ngx_http_request_t *r, ngx_buf_t *b)
                         break;
                     }
 
+                    if (ngx_str5cmp(m, 'Q', 'U', 'E', 'R', 'Y')) {
+                        r->method = NGX_HTTP_QUERY;
+                        break;
+                    }
+
                     break;
 
                 case 6:

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -43,6 +43,7 @@
 #define NGX_HTTP_PATCH                     0x00004000
 #define NGX_HTTP_TRACE                     0x00008000
 #define NGX_HTTP_CONNECT                   0x00010000
+#define NGX_HTTP_QUERY                     0x00020000
 
 #define NGX_HTTP_CONNECTION_CLOSE          1
 #define NGX_HTTP_CONNECTION_KEEP_ALIVE     2

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -482,6 +482,7 @@ ngx_conf_bitmask_t  ngx_http_upstream_cache_method_mask[] = {
     { ngx_string("GET"), NGX_HTTP_GET },
     { ngx_string("HEAD"), NGX_HTTP_HEAD },
     { ngx_string("POST"), NGX_HTTP_POST },
+    { ngx_string("QUERY"), NGX_HTTP_QUERY },
     { ngx_null_string, 0 }
 };
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3389,11 +3389,6 @@ ngx_http_v2_parse_method(ngx_http_request_t *r, ngx_str_t *value)
     ngx_uint_t     n;
     const u_char  *p, *m;
 
-    /*
-     * This array takes less than 256 sequential bytes,
-     * and if typical CPU cache line size is 64 bytes,
-     * it is prefetched for 4 load operations.
-     */
     static const struct {
         u_char            len;
         const u_char      method[11];
@@ -3414,7 +3409,8 @@ ngx_http_v2_parse_method(ngx_http_request_t *r, ngx_str_t *value)
         { 6, "UNLOCK",    NGX_HTTP_UNLOCK },
         { 5, "PATCH",     NGX_HTTP_PATCH },
         { 5, "TRACE",     NGX_HTTP_TRACE },
-        { 7, "CONNECT",   NGX_HTTP_CONNECT }
+        { 7, "CONNECT",   NGX_HTTP_CONNECT },
+        { 5, "QUERY",     NGX_HTTP_QUERY }
     }, *test;
 
     if (r->method_name.len) {

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -51,7 +51,8 @@ static const struct {
     { ngx_string("UNLOCK"),    NGX_HTTP_UNLOCK },
     { ngx_string("PATCH"),     NGX_HTTP_PATCH },
     { ngx_string("TRACE"),     NGX_HTTP_TRACE },
-    { ngx_string("CONNECT"),   NGX_HTTP_CONNECT }
+    { ngx_string("CONNECT"),   NGX_HTTP_CONNECT },
+    { ngx_string("QUERY"),     NGX_HTTP_QUERY }
 };
 
 


### PR DESCRIPTION
## Problem

RFC 10008 defines the HTTP QUERY method. nginx does not currently recognize
QUERY as a known HTTP method.

As a result, QUERY cannot be selected in `limit_except` or enabled in
`proxy_cache_methods`, and HTTP/2 and HTTP/3 requests do not receive a
dedicated method identifier.

## Solution

Add a method identifier for QUERY and recognize it in the HTTP/1.x, HTTP/2,
and HTTP/3 request parsers. Also allow QUERY in `limit_except` and
`proxy_cache_methods`.

This is an initial implementation for method recognition and method-based
configuration. It does not add special handling for QUERY request content, and
does not include the request body in the proxy cache key for configurations such
as `proxy_cache_methods QUERY`. Cache-key behavior for QUERY can be considered
separately if needed.

## Testing

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests#67](https://github.com/nginx/nginx-tests/pull/67))

Built nginx with HTTP/2 and HTTP/3 enabled and ran the QUERY method tests for
HTTP/1.x, HTTP/2, HTTP/3, `limit_except`, proxy forwarding, and proxy caching.
All 232 checks pass.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests to validate my changes
- [x] All relevant tests pass
- [x] Documentation changes are not applicable
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards

## Release Notes

nginx recognizes the HTTP QUERY method over HTTP/1.x, HTTP/2, and HTTP/3, and
supports it in method-based access and proxy cache configuration.