### PR TITLE
Configure: set cache line size for loongarch64

### DIFF
--- a/auto/os/conf
+++ b/auto/os/conf
@@ -130,6 +130,11 @@ case "$NGX_MACHINE" in
         NGX_MACH_CACHE_LINE=256
     ;;
 
+    loongarch64)
+        have=NGX_ALIGNMENT value=16 . auto/define
+        NGX_MACH_CACHE_LINE=64
+    ;;
+
     *)
         have=NGX_ALIGNMENT value=16 . auto/define
         NGX_MACH_CACHE_LINE=32

--- a/src/core/nginx.h
+++ b/src/core/nginx.h
@@ -9,8 +9,8 @@
 #define _NGINX_H_INCLUDED_
 
 
-#define nginx_version      1031002
-#define NGINX_VERSION      "1.31.2"
+#define nginx_version      1031003
+#define NGINX_VERSION      "1.31.3"
 #define NGINX_VER          "nginx/" NGINX_VERSION
 
 #ifdef NGX_BUILD


### PR DESCRIPTION
## Problem

On loongarch64. the setting of `ngx_cacheline_size` is 32, which is default for unknown architectures and not optimized.

## Solution

Another case is added for loongarch64 to set the cache line size in the configure scripts

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [X] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

## Checklist

Before submitting this PR, please confirm:

- [X] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [ ] I have updated documentation where necessary
- [X] My branch is rebased on the latest master
- [X] This PR targets the master branch from my fork
- [X] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
