### PR TITLE
HTTP/3: emit STREAM_DATA_BLOCKED/DATA_BLOCKED (RFC 9000 §4.1 SHOULD) and raise default window

### DIFF
--- a/src/event/quic/ngx_event_quic.h
+++ b/src/event/quic/ngx_event_quic.h
@@ -124,6 +124,7 @@ struct ngx_quic_stream_s {
     ngx_quic_stream_recv_state_e   recv_state;
     unsigned                       cancelable:1;
     unsigned                       fin_acked:1;
+    unsigned                       blocked:1;
 };
 
 

--- a/src/event/quic/ngx_event_quic_connection.h
+++ b/src/event/quic/ngx_event_quic_connection.h
@@ -156,6 +156,8 @@ typedef struct {
     uint64_t                          send_offset;
     uint64_t                          send_max_data;
 
+    ngx_uint_t                        blocked;  /* unsigned  blocked:1; */
+
     uint64_t                          server_max_streams_uni;
     uint64_t                          server_max_streams_bidi;
     uint64_t                          server_streams_uni;

--- a/src/event/quic/ngx_event_quic_streams.c
+++ b/src/event/quic/ngx_event_quic_streams.c
@@ -39,6 +39,8 @@ static ngx_int_t ngx_quic_control_flow(ngx_quic_stream_t *qs, uint64_t last);
 static ngx_int_t ngx_quic_update_flow(ngx_quic_stream_t *qs, uint64_t last);
 static ngx_int_t ngx_quic_update_max_stream_data(ngx_quic_stream_t *qs);
 static ngx_int_t ngx_quic_update_max_data(ngx_connection_t *c);
+static ngx_int_t ngx_quic_queue_data_blocked(ngx_connection_t *c);
+static ngx_int_t ngx_quic_queue_stream_data_blocked(ngx_quic_stream_t *qs);
 static void ngx_quic_set_event(ngx_event_t *ev);
 
 
@@ -1036,6 +1038,33 @@ ngx_quic_stream_flush(ngx_quic_stream_t *qs)
     ngx_log_debug2(NGX_LOG_DEBUG_EVENT, pc->log, 0,
                    "quic stream id:0x%xL flush limit:%O", qs->id, limit);
 
+    /* clear blocked state once flow-control credit becomes available again */
+
+    if (qc->streams.send_offset < qc->streams.send_max_data) {
+        qc->streams.blocked = 0;
+    }
+
+    if (qs->send_offset < qs->send_max_data) {
+        qs->blocked = 0;
+    }
+
+    /*
+     * There is buffered application data, but no flow-control credit to
+     * send it.  Advertise the blocked condition (RFC 9000, Section 4.1) so
+     * a peer that lost or delayed its MAX_DATA / MAX_STREAM_DATA update has
+     * an ack-eliciting signal to retransmit it within one RTT, rather than
+     * leaving the stream stalled until the idle timeout fires.
+     */
+
+    if (limit == 0 && qs->send.offset < qs->sent) {
+
+        if (qc->streams.send_offset >= qc->streams.send_max_data) {
+            return ngx_quic_queue_data_blocked(pc);
+        }
+
+        return ngx_quic_queue_stream_data_blocked(qs);
+    }
+
     len = qs->send.offset;
 
     out = ngx_quic_read_buffer(pc, &qs->send, limit);
@@ -1812,6 +1841,74 @@ ngx_quic_update_max_data(ngx_connection_t *c)
     frame->u.max_data.max_data = qc->streams.recv_max_data;
 
     ngx_quic_queue_frame(qc, frame);
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_quic_queue_data_blocked(ngx_connection_t *c)
+{
+    ngx_quic_frame_t       *frame;
+    ngx_quic_connection_t  *qc;
+
+    qc = ngx_quic_get_connection(c);
+
+    if (qc->streams.blocked) {
+        return NGX_OK;
+    }
+
+    frame = ngx_quic_alloc_frame(c);
+    if (frame == NULL) {
+        return NGX_ERROR;
+    }
+
+    frame->level = NGX_QUIC_ENCRYPTION_APPLICATION;
+    frame->type = NGX_QUIC_FT_DATA_BLOCKED;
+    frame->u.data_blocked.limit = qc->streams.send_max_data;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "quic data blocked limit:%uL", qc->streams.send_max_data);
+
+    ngx_quic_queue_frame(qc, frame);
+
+    qc->streams.blocked = 1;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_quic_queue_stream_data_blocked(ngx_quic_stream_t *qs)
+{
+    ngx_connection_t       *pc;
+    ngx_quic_frame_t       *frame;
+    ngx_quic_connection_t  *qc;
+
+    pc = qs->parent;
+    qc = ngx_quic_get_connection(pc);
+
+    if (qs->blocked) {
+        return NGX_OK;
+    }
+
+    frame = ngx_quic_alloc_frame(pc);
+    if (frame == NULL) {
+        return NGX_ERROR;
+    }
+
+    frame->level = NGX_QUIC_ENCRYPTION_APPLICATION;
+    frame->type = NGX_QUIC_FT_STREAM_DATA_BLOCKED;
+    frame->u.stream_data_blocked.id = qs->id;
+    frame->u.stream_data_blocked.limit = qs->send_max_data;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_EVENT, pc->log, 0,
+                   "quic stream id:0x%xL data blocked limit:%uL",
+                   qs->id, qs->send_max_data);
+
+    ngx_quic_queue_frame(qc, frame);
+
+    qs->blocked = 1;
 
     return NGX_OK;
 }

--- a/src/event/quic/ngx_event_quic_transport.c
+++ b/src/event/quic/ngx_event_quic_transport.c
@@ -118,6 +118,10 @@ static size_t ngx_quic_create_max_stream_data(u_char *p,
     ngx_quic_max_stream_data_frame_t *ms);
 static size_t ngx_quic_create_max_data(u_char *p,
     ngx_quic_max_data_frame_t *md);
+static size_t ngx_quic_create_data_blocked(u_char *p,
+    ngx_quic_data_blocked_frame_t *db);
+static size_t ngx_quic_create_stream_data_blocked(u_char *p,
+    ngx_quic_stream_data_blocked_frame_t *sdb);
 static size_t ngx_quic_create_path_challenge(u_char *p,
     ngx_quic_path_challenge_frame_t *pc);
 static size_t ngx_quic_create_path_response(u_char *p,
@@ -1328,6 +1332,13 @@ ngx_quic_create_frame(u_char *p, ngx_quic_frame_t *f)
     case NGX_QUIC_FT_MAX_DATA:
         return ngx_quic_create_max_data(p, &f->u.max_data);
 
+    case NGX_QUIC_FT_DATA_BLOCKED:
+        return ngx_quic_create_data_blocked(p, &f->u.data_blocked);
+
+    case NGX_QUIC_FT_STREAM_DATA_BLOCKED:
+        return ngx_quic_create_stream_data_blocked(p,
+                                                   &f->u.stream_data_blocked);
+
     case NGX_QUIC_FT_PATH_CHALLENGE:
         return ngx_quic_create_path_challenge(p, &f->u.path_challenge);
 
@@ -1884,6 +1895,51 @@ ngx_quic_create_max_data(u_char *p, ngx_quic_max_data_frame_t *md)
 
     ngx_quic_build_int(&p, NGX_QUIC_FT_MAX_DATA);
     ngx_quic_build_int(&p, md->max_data);
+
+    return p - start;
+}
+
+
+static size_t
+ngx_quic_create_data_blocked(u_char *p, ngx_quic_data_blocked_frame_t *db)
+{
+    size_t   len;
+    u_char  *start;
+
+    if (p == NULL) {
+        len = ngx_quic_varint_len(NGX_QUIC_FT_DATA_BLOCKED);
+        len += ngx_quic_varint_len(db->limit);
+        return len;
+    }
+
+    start = p;
+
+    ngx_quic_build_int(&p, NGX_QUIC_FT_DATA_BLOCKED);
+    ngx_quic_build_int(&p, db->limit);
+
+    return p - start;
+}
+
+
+static size_t
+ngx_quic_create_stream_data_blocked(u_char *p,
+    ngx_quic_stream_data_blocked_frame_t *sdb)
+{
+    size_t   len;
+    u_char  *start;
+
+    if (p == NULL) {
+        len = ngx_quic_varint_len(NGX_QUIC_FT_STREAM_DATA_BLOCKED);
+        len += ngx_quic_varint_len(sdb->id);
+        len += ngx_quic_varint_len(sdb->limit);
+        return len;
+    }
+
+    start = p;
+
+    ngx_quic_build_int(&p, NGX_QUIC_FT_STREAM_DATA_BLOCKED);
+    ngx_quic_build_int(&p, sdb->id);
+    ngx_quic_build_int(&p, sdb->limit);
 
     return p - start;
 }

--- a/src/http/v3/ngx_http_v3_module.c
+++ b/src/http/v3/ngx_http_v3_module.c
@@ -237,7 +237,7 @@ ngx_http_v3_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_size_value(conf->quic.stream_buffer_size,
                               prev->quic.stream_buffer_size,
-                              65536);
+                              1048576);
 
     conf->quic.max_concurrent_streams_bidi = conf->max_concurrent_streams;
 


### PR DESCRIPTION
Problem

On lossy network paths (mobile / CGNAT in particular) individual HTTP/3 streams stall at the per-stream flow-control limit and hang until the QUIC idle timeout (~60s) closes the connection. The connection itself stays alive; only streams that exhaust their send credit deadlock. The same client immediately completes the same resources over HTTP/2 in well under a second.

Server-side access log for an affected client (50 parallel fetch() against small static assets, Cosmote (GR) 5G):

"GET /img/042.png HTTP/3.0" status=200 bytes=65536 rt=60.000
... 49 of 50 requests stuck until idle timeout

There are two distinct mechanisms:

    On the send path, quic_stream_buffer_size (default 64k) bounds the amount of unacknowledged stream data nginx keeps in flight (ngx_quic_stream_send_chain()), so a stream never has more than 64k outstanding regardless of the peer's window. On any path whose bandwidth-delay product exceeds 64k this caps per-stream throughput; the bytes=65536 above is this local cap.
    When a stream exhausts its send credit, nginx stops and waits silently for the peer's MAX_STREAM_DATA / MAX_DATA. If that update is lost on the return path, nothing prompts the peer to resend it and the stream deadlocks until the idle timeout. RFC 9000, Section 4.1, defines STREAM_DATA_BLOCKED and DATA_BLOCKED as the ack-eliciting signals for exactly this situation, but nginx-quic emits neither — the parser handles them on receive, yet the encoder was missing entirely.

Solution

Two independent commits:

    HTTP/3: increase default quic_stream_buffer_size to 1m. Restores throughput on high-BDP and lossy paths. The directive remains configurable; initial_max_data is nstreams * stream_buffer_size, so the advertised connection-level receive window grows proportionally (operators who want the old behaviour can set quic_stream_buffer_size 64k;).
    QUIC: send STREAM_DATA_BLOCKED / DATA_BLOCKED (RFC 9000, Section 4.1). The actual correctness fix. Adds the missing encoder and queues the appropriate frame from ngx_quic_stream_flush() when the send limit is reached.

Design notes:

    Connection-level DATA_BLOCKED takes precedence over stream-level STREAM_DATA_BLOCKED, matching the binding constraint.
    Emission is deduplicated per flow-control limit (one frame per limit until the peer raises it), so repeated flush calls do not spam identical frames. The blocked state is cleared in ngx_quic_stream_flush() once credit becomes available again.
    The frames are ack-eliciting and are retransmitted on loss by the existing loss-recovery path (ngx_quic_resend_frames()), so recovery does not depend on the deduplication flag.
    No new wire format and no new directives; the change is purely additive.

Testing

Manual testing on production hardware against a real mobile carrier: the 50-parallel-fetch reproducer that left 49/50 HTTP/3 streams stalled at bytes=65536 rt=60.000 on Cosmote (GR) 5G now completes 50/50 in 96–2110 ms. The bug also reproduces deterministically in a VM:

tc qdisc add dev eth0 root netem loss 3% delay 50ms

A functional test (h3_stream_data_blocked.t, plus a small parse_frames() addition to [lib/Test/Nginx/HTTP3.pm](https://github.com/chrismfz/nginx/blob/claude/wizardly-curie-p91uo0/lib/Test/Nginx/HTTP3.pm)) is submitted as a separate [nginx-tests](https://github.com/nginx/nginx-tests) PR. It drives the server into both the stream-level and connection-level blocked states and asserts the corresponding frames are sent, then that the transfer resumes once credit is granted.


    PR Closes: [#1407] ( https://github.com/nginx/nginx/issues/1407 )


Release Notes

HTTP/3: nginx now sends STREAM_DATA_BLOCKED and DATA_BLOCKED frames when a stream is blocked by flow control (RFC 9000, Section 4.1), allowing recovery from a lost MAX_STREAM_DATA / MAX_DATA update within one RTT instead of stalling until the idle timeout on lossy paths. The default quic_stream_buffer_size is raised from 64k to 1m.