### PR TITLE
QUIC: defer server stream counter increment until after successful creation

### DIFF
--- a/src/event/quic/ngx_event_quic_streams.c
+++ b/src/event/quic/ngx_event_quic_streams.c
@@ -76,8 +76,6 @@ ngx_quic_open_stream(ngx_connection_t *c, ngx_uint_t bidi)
                        qc->streams.server_streams_bidi,
                        qc->streams.server_max_streams_bidi, id);
 
-        qc->streams.server_streams_bidi++;
-
     } else {
         if (qc->streams.server_streams_uni
             >= qc->streams.server_max_streams_uni)
@@ -97,13 +95,18 @@ ngx_quic_open_stream(ngx_connection_t *c, ngx_uint_t bidi)
                        " streams:%uL max:%uL id:0x%xL",
                        qc->streams.server_streams_uni,
                        qc->streams.server_max_streams_uni, id);
-
-        qc->streams.server_streams_uni++;
     }
 
     qs = ngx_quic_create_stream(pc, id);
     if (qs == NULL) {
         return NULL;
+    }
+
+    if (bidi) {
+        qc->streams.server_streams_bidi++;
+
+    } else {
+        qc->streams.server_streams_uni++;
     }
 
     sc = qs->connection;


### PR DESCRIPTION
## Problem

`ngx_quic_open_stream()` increments `server_streams_bidi` (or
`server_streams_uni`) before calling `ngx_quic_create_stream()`.
If `ngx_quic_create_stream()` fails — due to pool OOM, fd exhaustion,
or a failed `ngx_pool_cleanup_add()` call — the counter is never rolled
back, permanently leaking a stream ID slot.  Under repeated transient
allocation failures this gradually exhausts the server-initiated stream
ID space for that direction.

## Fix

Move both counter increments to after `ngx_quic_create_stream()` returns
successfully.  The stream ID is computed from the pre-increment counter
value so IDs stay consistent; a failed allocation now leaves the counter
unchanged.

## Affected function

`ngx_quic_open_stream()` in `src/event/quic/ngx_event_quic_streams.c`
