### PR TITLE
Added Prometheus metrics module

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -1000,6 +1000,19 @@ if [ $HTTP = YES ]; then
 
         . auto/module
     fi
+
+    if [ $HTTP_PROMETHEUS_METRICS = YES ]; then
+        have=NGX_PROMETHEUS_METRICS . auto/have
+
+        ngx_module_name=ngx_http_prometheus_metrics_module
+        ngx_module_incs=
+        ngx_module_deps=
+        ngx_module_srcs=src/http/modules/ngx_http_prometheus_metrics_module.c
+        ngx_module_libs=
+        ngx_module_link=$HTTP_PROMETHEUS_METRICS
+
+        . auto/module
+    fi
 fi
 
 

--- a/auto/options
+++ b/auto/options
@@ -114,6 +114,9 @@ HTTP_UPSTREAM_STICKY=YES
 # STUB
 HTTP_STUB_STATUS=NO
 
+# PROMETHEUS METRICS
+HTTP_PROMETHEUS_METRICS=NO
+
 MAIL=NO
 MAIL_SSL=NO
 MAIL_POP3=YES
@@ -314,6 +317,8 @@ use the \"--without-http_upstream_sticky_module\" option instead"
 
         # STUB
         --with-http_stub_status_module)  HTTP_STUB_STATUS=YES       ;;
+        # PROMETHEUS METRICS
+        --with-http_prometheus_metrics_module) HTTP_PROMETHEUS_METRICS=YES ;;
 
         --with-mail)                     MAIL=YES                   ;;
         --with-mail=dynamic)             MAIL=DYNAMIC               ;;
@@ -496,6 +501,8 @@ cat << END
   --with-http_degradation_module     enable ngx_http_degradation_module
   --with-http_slice_module           enable ngx_http_slice_module
   --with-http_stub_status_module     enable ngx_http_stub_status_module
+  --with-http_prometheus_metrics_module
+                                     enable ngx_http_prometheus_metrics_module
 
   --without-http_charset_module      disable ngx_http_charset_module
   --without-http_gzip_module         disable ngx_http_gzip_module

--- a/src/http/modules/ngx_http_prometheus_metrics_module.c
+++ b/src/http/modules/ngx_http_prometheus_metrics_module.c
@@ -1,0 +1,260 @@
+
+/*
+ * Copyright (C) Michał Dec
+ * Copyright (C) Igor Sysoev
+ * Copyright (C) Nginx, Inc.
+ * 
+ * Based on ngx_http_stub_status_module.c
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+
+static ngx_int_t ngx_http_prometheus_metrics_handler(ngx_http_request_t *r);
+static ngx_int_t ngx_http_prometheus_metrics_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_prometheus_metrics_add_variables(ngx_conf_t *cf);
+static char *ngx_http_set_prometheus_metrics(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+
+static ngx_command_t  ngx_http_status_commands[] = {
+
+    { ngx_string("prometheus_metrics"),
+      NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_NOARGS,
+      ngx_http_set_prometheus_metrics,
+      0,
+      0,
+      NULL },
+
+      ngx_null_command
+};
+
+
+static ngx_http_module_t  ngx_http_prometheus_metrics_module_ctx = {
+    ngx_http_prometheus_metrics_add_variables, /* preconfiguration */
+    NULL,                                      /* postconfiguration */
+
+    NULL,                                      /* create main configuration */
+    NULL,                                      /* init main configuration */
+
+    NULL,                                      /* create server configuration */
+    NULL,                                      /* merge server configuration */
+
+    NULL,                                      /* create location configuration */
+    NULL                                       /* merge location configuration */
+};
+
+
+ngx_module_t  ngx_http_prometheus_metrics_module = {
+    NGX_MODULE_V1,
+    &ngx_http_prometheus_metrics_module_ctx, /* module context */
+    ngx_http_status_commands,                /* module directives */
+    NGX_HTTP_MODULE,                         /* module type */
+    NULL,                                    /* init master */
+    NULL,                                    /* init module */
+    NULL,                                    /* init process */
+    NULL,                                    /* init thread */
+    NULL,                                    /* exit thread */
+    NULL,                                    /* exit process */
+    NULL,                                    /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+static ngx_http_variable_t  ngx_http_prometheus_metrics_vars[] = {
+
+    { ngx_string("connections_active"), NULL, ngx_http_prometheus_metrics_variable,
+      0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+
+    { ngx_string("connections_reading"), NULL, ngx_http_prometheus_metrics_variable,
+      1, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+
+    { ngx_string("connections_writing"), NULL, ngx_http_prometheus_metrics_variable,
+      2, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+
+    { ngx_string("connections_waiting"), NULL, ngx_http_prometheus_metrics_variable,
+      3, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+
+      ngx_http_null_variable
+};
+
+#define METRICS_COUNT 7
+static ngx_int_t
+ngx_http_prometheus_metrics_handler(ngx_http_request_t *r)
+{
+    size_t             size;
+    ngx_int_t          rc;
+    ngx_buf_t         *b;
+    ngx_chain_t        out;
+    ngx_atomic_int_t   ap, hn, ac, rq, rd, wr, wa;
+
+    if (!(r->method & (NGX_HTTP_GET|NGX_HTTP_HEAD))) {
+        return NGX_HTTP_NOT_ALLOWED;
+    }
+
+    rc = ngx_http_discard_request_body(r);
+
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    r->headers_out.content_type_len = sizeof("text/plain") - 1;
+    ngx_str_set(&r->headers_out.content_type, "text/plain");
+    r->headers_out.content_type_lowcase = NULL;
+
+    size = METRICS_COUNT * NGX_ATOMIC_T_LEN +
+           sizeof("# HELP nginx_connections_active Active client connections\n\
+# TYPE nginx_connections_active gauge\n\
+nginx_connections_active  \n") +
+           sizeof("# HELP nginx_connections_accepted Accepted client connections\n\
+# TYPE nginx_connections_accepted counter\n\
+nginx_connections_accepted  \n") +
+           sizeof("# HELP nginx_connections_handled Handled client connections\n\
+# TYPE nginx_connections_handled counter\n\
+nginx_connections_handled  \n") +
+           sizeof("# HELP nginx_http_requests_total Total http requests\n\
+# TYPE nginx_http_requests_total counter\n\
+nginx_http_requests_total  \n") +
+           sizeof("# HELP nginx_connections_reading Connections where NGINX is reading the request header\n\
+# TYPE nginx_connections_reading gauge\n\
+nginx_connections_reading  \n") +
+           sizeof("# HELP nginx_connections_writing Connections where NGINX is writing the response back to the client\n\
+# TYPE nginx_connections_writing gauge\n\
+nginx_connections_writing  \n") +
+           sizeof("# HELP nginx_connections_waiting Idle client connections\n\
+# TYPE nginx_connections_waiting gauge\n\
+nginx_connections_waiting  \n") + 1;
+
+    b = ngx_create_temp_buf(r->pool, size);
+    if (b == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    out.buf = b;
+    out.next = NULL;
+
+    ap = *ngx_stat_accepted;
+    hn = *ngx_stat_handled;
+    ac = *ngx_stat_active;
+    rq = *ngx_stat_requests;
+    rd = *ngx_stat_reading;
+    wr = *ngx_stat_writing;
+    wa = *ngx_stat_waiting;
+
+    b->last = ngx_sprintf(b->last, "# HELP nginx_connections_active Active client connections\n\
+# TYPE nginx_connections_active gauge\n\
+nginx_connections_active %uA\n", ac);
+    b->last = ngx_sprintf(b->last, "# HELP nginx_connections_accepted Accepted client connections\n\
+# TYPE nginx_connections_accepted counter\n\
+nginx_connections_accepted %uA\n", ap);
+    b->last = ngx_sprintf(b->last, "# HELP nginx_connections_handled Handled client connections\n\
+# TYPE nginx_connections_handled counter\n\
+nginx_connections_handled %uA\n", hn);
+    b->last = ngx_sprintf(b->last, "# HELP nginx_http_requests_total Total http requests\n\
+# TYPE nginx_http_requests_total counter\n\
+nginx_http_requests_total %uA\n", rq);
+    b->last = ngx_sprintf(b->last, "# HELP nginx_connections_reading Connections where NGINX is reading the request header\n\
+# TYPE nginx_connections_reading gauge\n\
+nginx_connections_reading %uA\n", rd);
+    b->last = ngx_sprintf(b->last, "# HELP nginx_connections_writing Connections where NGINX is writing the response back to the client\n\
+# TYPE nginx_connections_writing gauge\n\
+nginx_connections_writing %uA\n", wr);
+    b->last = ngx_sprintf(b->last, "# HELP nginx_connections_waiting Idle client connections\n\
+# TYPE nginx_connections_waiting gauge\n\
+nginx_connections_waiting %uA\n", wa);
+
+    r->headers_out.status = NGX_HTTP_OK;
+    r->headers_out.content_length_n = b->last - b->pos;
+
+    b->last_buf = (r == r->main) ? 1 : 0;
+    b->last_in_chain = 1;
+
+    rc = ngx_http_send_header(r);
+
+    if (rc == NGX_ERROR || rc > NGX_OK || r->header_only) {
+        return rc;
+    }
+
+    return ngx_http_output_filter(r, &out);
+}
+
+
+static ngx_int_t
+ngx_http_prometheus_metrics_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    u_char            *p;
+    ngx_atomic_int_t   value;
+
+    p = ngx_pnalloc(r->pool, NGX_ATOMIC_T_LEN);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    switch (data) {
+    case 0:
+        value = *ngx_stat_active;
+        break;
+
+    case 1:
+        value = *ngx_stat_reading;
+        break;
+
+    case 2:
+        value = *ngx_stat_writing;
+        break;
+
+    case 3:
+        value = *ngx_stat_waiting;
+        break;
+
+    /* suppress warning */
+    default:
+        value = 0;
+        break;
+    }
+
+    v->len = ngx_sprintf(p, "%uA", value) - p;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+    v->data = p;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_prometheus_metrics_add_variables(ngx_conf_t *cf)
+{
+#if !(NGX_STAT_STUB)
+    ngx_http_variable_t  *var, *v;
+
+    for (v = ngx_http_stub_status_vars; v->name.len; v++) {
+        var = ngx_http_add_variable(cf, &v->name, v->flags);
+        if (var == NULL) {
+            return NGX_ERROR;
+        }
+
+        var->get_handler = v->get_handler;
+        var->data = v->data;
+    }
+#endif
+    return NGX_OK;
+}
+
+
+static char *
+ngx_http_set_prometheus_metrics(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_core_loc_conf_t  *clcf;
+
+    clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
+    clcf->handler = ngx_http_prometheus_metrics_handler;
+
+    return NGX_CONF_OK;
+}


### PR DESCRIPTION
## Problem

NGINX Prometheus Exporter has not been rebuilt in over 6 months, despite the community asking for updates: https://github.com/nginx/nginx-prometheus-exporter/issues/1213.
In that time, it has accumulated vulnerabilities coming from:
- being statically linked against internal libraries of an old Go compiler that already has vulnerabilities
- being statically linked against and old version of golang.org/x/crypto that already has vulnerabilities
- being statically linked against and old version of golang.org/x/net that already has vulnerabilities

Every time when Sysdig Secure scans our containers, it detects those vulnerabilities and registers when it has first seen them in our Kubernetes namespaces. When these vulnerabilities go unfixed for 90 days, I get a deadline of 4 weeks to fix them. Because NPE has been radio silent for much longer than that, I recognized the risk that NPE could sustain silence for much longer than the deadline would allow me to wait, so I made my own downstream patches that bump the versions of affected libraries and I recompiled NPE with the latest Go compiler, thus avoiding risks.

On top of that, sustaining NPE in a manner that prevents triggering https://github.com/nginx/nginx-prometheus-exporter/issues/1000 requires the following resources:
- 0.05 vCPU per container
- minimum 50 MiB RAM, maximum 100 MiB RAM per container

## Solution

We don't want to maintain downstream patches. The existence of NPE has always been puzzling to me. A native NGINX module has always made sense. It's basically like stub_status, but different printf templates.

At scale, these numbers can easily start counting entire cores and GiBs. This is an unreasonable amount of resources required to do what `sed` could do. A native NGINX module that emits Prometheus metrics also makes sense in this context.

So, I've taken a little time to copy stub_status, modify it to emit Prometheus metrics and test it.

Also in my tests I found out that adding global variables in NGINX is not an idempotent operation, so this module will compile to 2 forms depending on if stub status module is included.
- Not included: Prometheus metrics module will add those variables
- Included: Prometheus metrics module will not add those variables, allowing stub status module to do that

## Testing

- [X] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

I have performed manual tests on my Gentoo box. I've added this commit as a separate patch to my ebuild and emerged nginx from my modified ebuild. Next, I made this NGINX config:
```
user nginx nginx;
worker_processes auto;
events {
}
http {
        types_hash_max_size 4096;
        include /etc/nginx/mime.types.nginx;
        sendfile on;
        server {
                listen 127.0.0.1:81;
                server_name localhost;
                location / {
                        prometheus_metrics;
                }
        }
}
```
Finally, I curled the address:
```
# HELP nginx_connections_active Active client connections
# TYPE nginx_connections_active gauge
nginx_connections_active 1
# HELP nginx_connections_accepted Accepted client connections
# TYPE nginx_connections_accepted counter
nginx_connections_accepted 2
# HELP nginx_connections_handled Handled client connections
# TYPE nginx_connections_handled counter
nginx_connections_handled 2
# HELP nginx_http_requests_total Total http requests
# TYPE nginx_http_requests_total counter
nginx_http_requests_total 2
# HELP nginx_connections_reading Connections where NGINX is reading the request header
# TYPE nginx_connections_reading gauge
nginx_connections_reading 0
# HELP nginx_connections_writing Connections where NGINX is writing the response back to the client
# TYPE nginx_connections_writing gauge
nginx_connections_writing 1
# HELP nginx_connections_waiting Idle client connections
# TYPE nginx_connections_waiting gauge
nginx_connections_waiting 0
```

**Closes:** #1509

## Checklist

Before submitting this PR, please confirm:

- [X] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [ ] I have updated documentation where necessary
- [ ] My branch is rebased on the latest master
- [X] This PR targets the master branch from my fork
- [X] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

Adds Prometheus metrics module.
