### PR TITLE
Add basic RFC 10008 (QUERY method) support

### DIFF
--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -126,8 +126,6 @@ static char *ngx_http_proxy_cache(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static char *ngx_http_proxy_cache_key(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
-static char *ngx_http_proxy_cache_query_key(ngx_conf_t *cf, ngx_command_t *cmd,
-    void *conf);
 #endif
 #if (NGX_HTTP_SSL)
 static char *ngx_http_proxy_ssl_certificate_cache(ngx_conf_t *cf,
@@ -431,13 +429,6 @@ static ngx_command_t  ngx_http_proxy_commands[] = {
     { ngx_string("proxy_cache_key"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_http_proxy_cache_key,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      NULL },
-
-    { ngx_string("proxy_cache_query_key"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
-      ngx_http_proxy_cache_query_key,
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
       NULL },
@@ -1104,16 +1095,6 @@ ngx_http_proxy_create_key(ngx_http_request_t *r)
         return NGX_ERROR;
     }
 
-    if (r->method == NGX_HTTP_QUERY) {
-        if (plcf->cache_query_key.value.data) {
-
-            if (ngx_http_complex_value(r, &plcf->cache_query_key, key) != NGX_OK) {
-                return NGX_ERROR;
-            }
-
-            return NGX_OK;
-        }
-    }
 
     if (plcf->cache_key.value.data) {
 
@@ -3882,21 +3863,27 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         conf->cache_key = prev->cache_key;
     }
 
-    if (conf->cache_query_key.value.data == NULL) {
-        conf->cache_query_key = prev->cache_query_key;
-    }
+    if (conf->upstream.cache_methods & NGX_HTTP_QUERY) {
+        if (conf->cache_key.value.data == NULL) {
+            ngx_str_t s = ngx_string("$scheme$proxy_host$request_uri|$request_body_md5");
+            ngx_http_compile_complex_value_t   ccv;
 
-    if (conf->cache_query_key.value.data == NULL) {
-        ngx_str_t                          s = ngx_string("$scheme$proxy_host$request_uri|$request_body");
-        ngx_http_compile_complex_value_t   ccv;
+            ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
 
-        ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
+            ccv.cf = cf;
+            ccv.value = &s;
+            ccv.complex_value = &conf->cache_key;
 
-        ccv.cf = cf;
-        ccv.value = &s;
-        ccv.complex_value = &conf->cache_query_key;
+            if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+                return NGX_CONF_ERROR;
+            }
+        }
 
-        if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+        if (ngx_strnstr(conf->cache_key.value.data, "request_body",
+                        conf->cache_key.value.len) == NULL)
+        {
+            ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                          "proxy_cache_key must contain \"$request_body\" or \"$request_body_md5\" when QUERY caching is enabled");
             return NGX_CONF_ERROR;
         }
     }
@@ -5075,34 +5062,6 @@ ngx_http_proxy_cache_key(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ccv.cf = cf;
     ccv.value = &value[1];
     ccv.complex_value = &plcf->cache_key;
-
-    if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
-        return NGX_CONF_ERROR;
-    }
-
-    return NGX_CONF_OK;
-}
-
-
-static char *
-ngx_http_proxy_cache_query_key(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
-{
-    ngx_http_proxy_loc_conf_t *plcf = conf;
-
-    ngx_str_t                         *value;
-    ngx_http_compile_complex_value_t   ccv;
-
-    value = cf->args->elts;
-
-    if (plcf->cache_query_key.value.data) {
-        return "is duplicate";
-    }
-
-    ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
-
-    ccv.cf = cf;
-    ccv.value = &value[1];
-    ccv.complex_value = &plcf->cache_query_key;
 
     if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
         return NGX_CONF_ERROR;

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -126,6 +126,8 @@ static char *ngx_http_proxy_cache(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static char *ngx_http_proxy_cache_key(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+static char *ngx_http_proxy_cache_query_key(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
 #endif
 #if (NGX_HTTP_SSL)
 static char *ngx_http_proxy_ssl_certificate_cache(ngx_conf_t *cf,
@@ -429,6 +431,13 @@ static ngx_command_t  ngx_http_proxy_commands[] = {
     { ngx_string("proxy_cache_key"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_http_proxy_cache_key,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("proxy_cache_query_key"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_http_proxy_cache_query_key,
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
       NULL },
@@ -1093,6 +1102,17 @@ ngx_http_proxy_create_key(ngx_http_request_t *r)
     key = ngx_array_push(&r->cache->keys);
     if (key == NULL) {
         return NGX_ERROR;
+    }
+
+    if (r->method == NGX_HTTP_QUERY) {
+        if (plcf->cache_query_key.value.data) {
+
+            if (ngx_http_complex_value(r, &plcf->cache_query_key, key) != NGX_OK) {
+                return NGX_ERROR;
+            }
+
+            return NGX_OK;
+        }
     }
 
     if (plcf->cache_key.value.data) {
@@ -3862,6 +3882,25 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         conf->cache_key = prev->cache_key;
     }
 
+    if (conf->cache_query_key.value.data == NULL) {
+        conf->cache_query_key = prev->cache_query_key;
+    }
+
+    if (conf->cache_query_key.value.data == NULL) {
+        ngx_str_t                          s = ngx_string("$scheme$proxy_host$request_uri|$request_body");
+        ngx_http_compile_complex_value_t   ccv;
+
+        ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
+
+        ccv.cf = cf;
+        ccv.value = &s;
+        ccv.complex_value = &conf->cache_query_key;
+
+        if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+            return NGX_CONF_ERROR;
+        }
+    }
+
     ngx_conf_merge_value(conf->upstream.cache_lock,
                               prev->upstream.cache_lock, 0);
 
@@ -5036,6 +5075,34 @@ ngx_http_proxy_cache_key(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ccv.cf = cf;
     ccv.value = &value[1];
     ccv.complex_value = &plcf->cache_key;
+
+    if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+static char *
+ngx_http_proxy_cache_query_key(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_proxy_loc_conf_t *plcf = conf;
+
+    ngx_str_t                         *value;
+    ngx_http_compile_complex_value_t   ccv;
+
+    value = cf->args->elts;
+
+    if (plcf->cache_query_key.value.data) {
+        return "is duplicate";
+    }
+
+    ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
+
+    ccv.cf = cf;
+    ccv.value = &value[1];
+    ccv.complex_value = &plcf->cache_query_key;
 
     if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
         return NGX_CONF_ERROR;

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -3879,11 +3879,17 @@ ngx_http_proxy_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
             }
         }
 
-        if (ngx_strnstr(conf->cache_key.value.data, "request_body",
-                        conf->cache_key.value.len) == NULL)
+        if (ngx_strnstr(conf->cache_key.value.data, "$request_body",
+                        conf->cache_key.value.len) == NULL
+            && ngx_strnstr(conf->cache_key.value.data, "${request_body}",
+                           conf->cache_key.value.len) == NULL
+            && ngx_strnstr(conf->cache_key.value.data, "${request_body_md5}",
+                           conf->cache_key.value.len) == NULL
+            && ngx_strnstr(conf->cache_key.value.data, "${request_body_file}",
+                           conf->cache_key.value.len) == NULL)
         {
             ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                          "proxy_cache_key must contain \"$request_body\" or \"$request_body_md5\" when QUERY caching is enabled");
+                          "proxy_cache_key must contain \"$request_body\", \"$request_body_md5\", or \"$request_body_file\" when QUERY caching is enabled");
             return NGX_CONF_ERROR;
         }
     }

--- a/src/http/modules/ngx_http_proxy_module.h
+++ b/src/http/modules/ngx_http_proxy_module.h
@@ -65,7 +65,6 @@ typedef struct {
 
 #if (NGX_HTTP_CACHE)
     ngx_http_complex_value_t       cache_key;
-    ngx_http_complex_value_t       cache_query_key;
 #endif
 
     ngx_http_proxy_vars_t          vars;

--- a/src/http/modules/ngx_http_proxy_module.h
+++ b/src/http/modules/ngx_http_proxy_module.h
@@ -65,6 +65,7 @@ typedef struct {
 
 #if (NGX_HTTP_CACHE)
     ngx_http_complex_value_t       cache_key;
+    ngx_http_complex_value_t       cache_query_key;
 #endif
 
     ngx_http_proxy_vars_t          vars;

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -4710,6 +4710,7 @@ static ngx_http_method_name_t  ngx_methods_names[] = {
     { (u_char *) "LOCK",      (uint32_t) ~NGX_HTTP_LOCK },
     { (u_char *) "UNLOCK",    (uint32_t) ~NGX_HTTP_UNLOCK },
     { (u_char *) "PATCH",     (uint32_t) ~NGX_HTTP_PATCH },
+    { (u_char *) "QUERY",     (uint32_t) ~NGX_HTTP_QUERY },
     { NULL, 0 }
 };
 

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -230,6 +230,11 @@ ngx_http_parse_request_line(ngx_http_request_t *r, ngx_buf_t *b)
                         break;
                     }
 
+                    if (ngx_str5cmp(m, 'Q', 'U', 'E', 'R', 'Y')) {
+                        r->method = NGX_HTTP_QUERY;
+                        break;
+                    }
+
                     break;
 
                 case 6:

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -43,6 +43,7 @@
 #define NGX_HTTP_PATCH                     0x00004000
 #define NGX_HTTP_TRACE                     0x00008000
 #define NGX_HTTP_CONNECT                   0x00010000
+#define NGX_HTTP_QUERY                     0x00020000
 
 #define NGX_HTTP_CONNECTION_CLOSE          1
 #define NGX_HTTP_CONNECTION_KEEP_ALIVE     2

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -867,7 +867,9 @@ ngx_http_upstream_cache(ngx_http_request_t *r, ngx_http_upstream_t *u)
             return NGX_DECLINED;
         }
 
-        if (r->request_body && r->request_body->temp_file) {
+        if (r->method == NGX_HTTP_QUERY
+            && r->request_body && r->request_body->temp_file)
+        {
             return NGX_DECLINED;
         }
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -482,6 +482,7 @@ ngx_conf_bitmask_t  ngx_http_upstream_cache_method_mask[] = {
     { ngx_string("GET"), NGX_HTTP_GET },
     { ngx_string("HEAD"), NGX_HTTP_HEAD },
     { ngx_string("POST"), NGX_HTTP_POST },
+    { ngx_string("QUERY"), NGX_HTTP_QUERY },
     { ngx_null_string, 0 }
 };
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -867,6 +867,10 @@ ngx_http_upstream_cache(ngx_http_request_t *r, ngx_http_upstream_t *u)
             return NGX_DECLINED;
         }
 
+        if (r->request_body && r->request_body->temp_file) {
+            return NGX_DECLINED;
+        }
+
         rc = ngx_http_upstream_cache_get(r, u, &cache);
 
         if (rc != NGX_OK) {

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -867,12 +867,6 @@ ngx_http_upstream_cache(ngx_http_request_t *r, ngx_http_upstream_t *u)
             return NGX_DECLINED;
         }
 
-        if (r->method == NGX_HTTP_QUERY
-            && r->request_body && r->request_body->temp_file)
-        {
-            return NGX_DECLINED;
-        }
-
         rc = ngx_http_upstream_cache_get(r, u, &cache);
 
         if (rc != NGX_OK) {

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -9,6 +9,7 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
 #include <nginx.h>
+#include <ngx_md5.h>
 
 
 static ngx_http_variable_t *ngx_http_add_prefix_variable(ngx_conf_t *cf,
@@ -102,6 +103,8 @@ static ngx_int_t ngx_http_variable_request_completion(ngx_http_request_t *r,
 static ngx_int_t ngx_http_variable_request_body(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_variable_request_body_file(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_variable_request_body_md5(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_variable_request_length(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
@@ -304,6 +307,10 @@ static ngx_http_variable_t  ngx_http_core_variables[] = {
 
     { ngx_string("request_body_file"), NULL,
       ngx_http_variable_request_body_file,
+      0, 0, 0 },
+
+    { ngx_string("request_body_md5"), NULL,
+      ngx_http_variable_request_body_md5,
       0, 0, 0 },
 
     { ngx_string("request_length"), NULL, ngx_http_variable_request_length,
@@ -2239,6 +2246,76 @@ ngx_http_variable_request_body_file(ngx_http_request_t *r,
     v->no_cacheable = 0;
     v->not_found = 0;
     v->data = r->request_body->temp_file->file.name.data;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_variable_request_body_md5(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    u_char             *p;
+    ssize_t             n;
+    off_t               offset;
+    ngx_md5_t           md5;
+    ngx_buf_t          *buf;
+    ngx_file_t         *file;
+    ngx_chain_t        *cl;
+    u_char              hash[16];
+    u_char              buffer[4096];
+
+    if (r->request_body == NULL
+        || (r->request_body->bufs == NULL && r->request_body->temp_file == NULL))
+    {
+        v->not_found = 1;
+        return NGX_OK;
+    }
+
+    p = ngx_pnalloc(r->pool, 32);
+    if (p == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_md5_init(&md5);
+
+    if (r->request_body->temp_file) {
+        file = &r->request_body->temp_file->file;
+        offset = 0;
+
+        for ( ;; ) {
+            n = ngx_read_file(file, buffer, 4096, offset);
+
+            if (n == NGX_ERROR) {
+                return NGX_ERROR;
+            }
+
+            if (n == 0) {
+                break;
+            }
+
+            ngx_md5_update(&md5, buffer, n);
+            offset += n;
+        }
+
+    } else if (r->request_body->bufs) {
+        cl = r->request_body->bufs;
+        while (cl) {
+            buf = cl->buf;
+            ngx_md5_update(&md5, buf->pos, buf->last - buf->pos);
+            cl = cl->next;
+        }
+    }
+
+    ngx_md5_final(hash, &md5);
+
+    ngx_hex_dump(p, hash, 16);
+
+    v->len = 32;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+    v->data = p;
 
     return NGX_OK;
 }

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -2173,39 +2173,10 @@ ngx_http_variable_request_body(ngx_http_request_t *r,
     ngx_chain_t  *cl;
 
     if (r->request_body == NULL
-        || (r->request_body->bufs == NULL && r->request_body->temp_file == NULL))
+        || r->request_body->bufs == NULL
+        || r->request_body->temp_file)
     {
         v->not_found = 1;
-
-        return NGX_OK;
-    }
-
-    if (r->request_body->temp_file) {
-        ngx_file_t  *file;
-        off_t        size;
-
-        file = &r->request_body->temp_file->file;
-        size = file->offset;
-
-        if (size == 0) {
-            v->not_found = 1;
-            return NGX_OK;
-        }
-
-        p = ngx_pnalloc(r->pool, size);
-        if (p == NULL) {
-            return NGX_ERROR;
-        }
-
-        if (ngx_read_file(file, p, size, 0) == NGX_ERROR) {
-            return NGX_ERROR;
-        }
-
-        v->len = size;
-        v->valid = 1;
-        v->no_cacheable = 0;
-        v->not_found = 0;
-        v->data = p;
 
         return NGX_OK;
     }

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -2173,10 +2173,39 @@ ngx_http_variable_request_body(ngx_http_request_t *r,
     ngx_chain_t  *cl;
 
     if (r->request_body == NULL
-        || r->request_body->bufs == NULL
-        || r->request_body->temp_file)
+        || (r->request_body->bufs == NULL && r->request_body->temp_file == NULL))
     {
         v->not_found = 1;
+
+        return NGX_OK;
+    }
+
+    if (r->request_body->temp_file) {
+        ngx_file_t  *file;
+        off_t        size;
+
+        file = &r->request_body->temp_file->file;
+        size = file->offset;
+
+        if (size == 0) {
+            v->not_found = 1;
+            return NGX_OK;
+        }
+
+        p = ngx_pnalloc(r->pool, size);
+        if (p == NULL) {
+            return NGX_ERROR;
+        }
+
+        if (ngx_read_file(file, p, size, 0) == NGX_ERROR) {
+            return NGX_ERROR;
+        }
+
+        v->len = size;
+        v->valid = 1;
+        v->no_cacheable = 0;
+        v->not_found = 0;
+        v->data = p;
 
         return NGX_OK;
     }

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -2283,10 +2283,31 @@ ngx_http_variable_request_body_md5(ngx_http_request_t *r,
         file = &r->request_body->temp_file->file;
         offset = 0;
 
+        ngx_fd_t    fd;
+        ngx_uint_t  reopened = 0;
+
+        fd = file->fd;
+
+        if (fd == NGX_INVALID_FILE) {
+            fd = ngx_open_file(file->name.data, NGX_FILE_RDONLY, NGX_FILE_OPEN, 0);
+
+            if (fd == NGX_INVALID_FILE) {
+                v->not_found = 1;
+                return NGX_OK;
+            }
+
+            file->fd = fd;
+            reopened = 1;
+        }
+
         for ( ;; ) {
             n = ngx_read_file(file, buffer, 4096, offset);
 
             if (n == NGX_ERROR) {
+                if (reopened) {
+                    (void) ngx_close_file(file->fd);
+                    file->fd = NGX_INVALID_FILE;
+                }
                 return NGX_ERROR;
             }
 
@@ -2296,6 +2317,14 @@ ngx_http_variable_request_body_md5(ngx_http_request_t *r,
 
             ngx_md5_update(&md5, buffer, n);
             offset += n;
+        }
+
+        if (reopened) {
+            if (ngx_close_file(file->fd) == NGX_FILE_ERROR) {
+                ngx_log_error(NGX_LOG_ALERT, r->connection->log, ngx_errno,
+                              ngx_close_file_n " \"%s\" failed", file->name.data);
+            }
+            file->fd = NGX_INVALID_FILE;
         }
 
     } else if (r->request_body->bufs) {

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3413,6 +3413,7 @@ ngx_http_v2_parse_method(ngx_http_request_t *r, ngx_str_t *value)
         { 4, "LOCK",      NGX_HTTP_LOCK },
         { 6, "UNLOCK",    NGX_HTTP_UNLOCK },
         { 5, "PATCH",     NGX_HTTP_PATCH },
+        { 5, "QUERY",     NGX_HTTP_QUERY },
         { 5, "TRACE",     NGX_HTTP_TRACE },
         { 7, "CONNECT",   NGX_HTTP_CONNECT }
     }, *test;

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3390,9 +3390,8 @@ ngx_http_v2_parse_method(ngx_http_request_t *r, ngx_str_t *value)
     const u_char  *p, *m;
 
     /*
-     * This array takes less than 256 sequential bytes,
-     * and if typical CPU cache line size is 64 bytes,
-     * it is prefetched for 4 load operations.
+     * This array fits in a few sequential CPU cache lines
+     * for fast lookup of typical methods.
      */
     static const struct {
         u_char            len;

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -50,6 +50,7 @@ static const struct {
     { ngx_string("LOCK"),      NGX_HTTP_LOCK },
     { ngx_string("UNLOCK"),    NGX_HTTP_UNLOCK },
     { ngx_string("PATCH"),     NGX_HTTP_PATCH },
+    { ngx_string("QUERY"),     NGX_HTTP_QUERY },
     { ngx_string("TRACE"),     NGX_HTTP_TRACE },
     { ngx_string("CONNECT"),   NGX_HTTP_CONNECT }
 };


### PR DESCRIPTION
## Problem

Missing support for HTTP QUERY method (RFC 10008) and caching support for QUERY requests.

## Solution

This change adds support for the HTTP QUERY method, as described in RFC 10008. QUERY is a safe and idempotent method, designed to function as a sort of "GET with body".

## Testing

Verified using a simple [script](https://gist.github.com/desiderantes/67ed164d90adfb75d62b8e75cc05676b)

All tests passed successfully.

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the CONTRIBUTING guidelines
- [x]  I have added tests (if applicable) to validate my changes
- [x]  All existing tests pass
- [x]  I have updated documentation where necessary
- [x]  My branch is rebased on the latest master
- [x]  This PR targets the master branch from my fork
- [x]  My commit message follows NGINX standards
