### PR TITLE
Darwin, FreeBSD: avoid reusing sysctlbyname() result size

### DIFF
--- a/src/os/unix/ngx_darwin_init.c
+++ b/src/os/unix/ngx_darwin_init.c
@@ -115,7 +115,8 @@ ngx_os_specific_init(ngx_log_t *log)
                 return NGX_ERROR;
             }
 
-            ngx_darwin_kern_ostype[size - 1] = '\0';
+            ngx_darwin_kern_ostype[sizeof(ngx_darwin_kern_ostype) - 1]
+                = '\0';
         }
     }
 
@@ -135,7 +136,8 @@ ngx_os_specific_init(ngx_log_t *log)
                 return NGX_ERROR;
             }
 
-            ngx_darwin_kern_osrelease[size - 1] = '\0';
+            ngx_darwin_kern_osrelease[sizeof(ngx_darwin_kern_osrelease) - 1]
+                = '\0';
         }
     }
 

--- a/src/os/unix/ngx_freebsd_init.c
+++ b/src/os/unix/ngx_freebsd_init.c
@@ -116,7 +116,8 @@ ngx_os_specific_init(ngx_log_t *log)
             return NGX_ERROR;
         }
 
-        ngx_freebsd_kern_ostype[size - 1] = '\0';
+        ngx_freebsd_kern_ostype[sizeof(ngx_freebsd_kern_ostype) - 1]
+            = '\0';
     }
 
     size = sizeof(ngx_freebsd_kern_osrelease);
@@ -129,7 +130,8 @@ ngx_os_specific_init(ngx_log_t *log)
             return NGX_ERROR;
         }
 
-        ngx_freebsd_kern_osrelease[size - 1] = '\0';
+        ngx_freebsd_kern_osrelease[sizeof(ngx_freebsd_kern_osrelease) - 1]
+            = '\0';
     }
 
 


### PR DESCRIPTION
## Problem

On Darwin, `sysctlbyname()` may update `oldlenp` on `ENOMEM` to reflect
the full data length rather than the destination buffer size.  Using this
updated value for array indexing can therefore be unsafe.

The `ENOMEM` fallback for `kern.ostype` and `kern.osrelease` used this
returned size to write a terminating NUL byte.

On FreeBSD, the returned size is capped to the original buffer length, so
this is not the same issue there.  The same pattern is updated for
consistency and to avoid relying on a syscall-updated size value for array
indexing.

## Solution

Use the static destination buffer sizes when terminating the truncated
strings.

## Testing

- [x] Verified the ENOMEM behavior with a small ASan reproducer on macOS.
- [x] Verified the fixed truncation logic with the same reproducer.
- [x] Built nginx on macOS with `./auto/configure && make -j8`.
