### PR TITLE
Core: fixed zero writes in ngx_write_file()

### DIFF
--- a/src/os/unix/ngx_files.c
+++ b/src/os/unix/ngx_files.c
@@ -221,6 +221,12 @@ ngx_write_file(ngx_file_t *file, u_char *buf, size_t size, off_t offset)
             return NGX_ERROR;
         }
 
+        if (n == 0) {
+            ngx_log_error(NGX_LOG_CRIT, file->log, 0,
+                          "pwrite() \"%s\" returned zero", file->name.data);
+            return NGX_ERROR;
+        }
+
         file->offset += n;
         written += n;
 
@@ -258,6 +264,12 @@ ngx_write_file(ngx_file_t *file, u_char *buf, size_t size, off_t offset)
 
             ngx_log_error(NGX_LOG_CRIT, file->log, err,
                           "write() \"%s\" failed", file->name.data);
+            return NGX_ERROR;
+        }
+
+        if (n == 0) {
+            ngx_log_error(NGX_LOG_CRIT, file->log, 0,
+                          "write() \"%s\" returned zero", file->name.data);
             return NGX_ERROR;
         }
 


### PR DESCRIPTION
## Problem

`ngx_write_file()` retries partial `write()` / `pwrite()` results until the
requested buffer is written.  If either call returns zero while data remains,
the loop makes no progress: offsets are unchanged and the remaining size is
not reduced.

## Solution

Treat zero-length successful writes as errors and return `NGX_ERROR` instead
of retrying the same operation indefinitely.

## Testing

- [x] Verified the no-progress loop with a small reproducer using a stubbed zero return.
- [x] Verified the fixed logic exits after the zero return.
- [x] Built nginx on macOS with `./auto/configure && make -j8`.
