### PR TITLE
rfc9218

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -77,7 +77,8 @@ if [ $HTTP = YES ]; then
                          src/http/ngx_http_variables.h \
                          src/http/ngx_http_script.h \
                          src/http/ngx_http_upstream.h \
-                         src/http/ngx_http_upstream_round_robin.h"
+                         src/http/ngx_http_upstream_round_robin.h \
+                         src/http/ngx_http_priority.h"
         ngx_module_srcs="src/http/ngx_http.c \
                          src/http/ngx_http_core_module.c \
                          src/http/ngx_http_special_response.c \
@@ -88,7 +89,8 @@ if [ $HTTP = YES ]; then
                          src/http/ngx_http_variables.c \
                          src/http/ngx_http_script.c \
                          src/http/ngx_http_upstream.c \
-                         src/http/ngx_http_upstream_round_robin.c"
+                         src/http/ngx_http_upstream_round_robin.c \
+                         src/http/ngx_http_priority.c"
         ngx_module_libs=
         ngx_module_link=YES
 

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -36,6 +36,7 @@ typedef u_char *(*ngx_http_log_handler_pt)(ngx_http_request_t *r,
 #include <ngx_http_upstream.h>
 #include <ngx_http_upstream_round_robin.h>
 #include <ngx_http_core_module.h>
+#include <ngx_http_priority.h>
 
 #if (NGX_HTTP_V2)
 #include <ngx_http_v2.h>

--- a/src/http/ngx_http_priority.c
+++ b/src/http/ngx_http_priority.c
@@ -1,0 +1,292 @@
+
+/*
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <ngx_http_priority.h>
+
+
+/*
+ * Parse RFC9218 Priority header value.
+ *
+ * The value is a Structured Fields Dictionary (RFC8941) containing:
+ *   - u: Integer 0-7 (urgency)
+ *   - i: Boolean (incremental)
+ *
+ * This is a simplified parser that handles the common formats:
+ *   "u=5"
+ *   "u=5, i"
+ *   "u=5, i=?1"
+ *   "i, u=3"
+ *
+ * Per RFC9218 Section 4, unknown parameters and out-of-range values
+ * are ignored, and defaults are used instead.
+ */
+
+
+static ngx_int_t
+ngx_http_priority_parse_int(u_char **pos, u_char *end, ngx_int_t *value)
+{
+    u_char      *p;
+    ngx_int_t    n;
+    ngx_uint_t   negative;
+
+    p = *pos;
+    negative = 0;
+
+    if (p >= end) {
+        return NGX_ERROR;
+    }
+
+    if (*p == '-') {
+        negative = 1;
+        p++;
+    }
+
+    if (p >= end || *p < '0' || *p > '9') {
+        return NGX_ERROR;
+    }
+
+    n = 0;
+
+    while (p < end && *p >= '0' && *p <= '9') {
+        n = n * 10 + (*p - '0');
+
+        /* Prevent overflow - RFC8941 limits integers to 15 digits */
+        if (n > 999999999999999LL) {
+            return NGX_ERROR;
+        }
+
+        p++;
+    }
+
+    *pos = p;
+    *value = negative ? -n : n;
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_http_priority_skip_ows(u_char **pos, u_char *end)
+{
+    u_char  *p;
+
+    p = *pos;
+
+    while (p < end && (*p == ' ' || *p == '\t')) {
+        p++;
+    }
+
+    *pos = p;
+}
+
+
+ngx_int_t
+ngx_http_priority_parse(ngx_str_t *value, ngx_http_priority_t *p)
+{
+    u_char     *pos, *end;
+    ngx_int_t   n;
+
+    /* Initialize with defaults */
+    ngx_http_priority_init(p);
+
+    if (value == NULL || value->len == 0) {
+        return NGX_OK;
+    }
+
+    pos = value->data;
+    end = pos + value->len;
+
+    while (pos < end) {
+        ngx_http_priority_skip_ows(&pos, end);
+
+        if (pos >= end) {
+            break;
+        }
+
+        /* Parse parameter key */
+        if (pos + 1 < end && pos[1] == '=') {
+            /* Key=Value format */
+
+            if (*pos == 'u' || *pos == 'U') {
+                /* urgency parameter: u=<integer> */
+                pos += 2;  /* skip "u=" */
+
+                if (ngx_http_priority_parse_int(&pos, end, &n) == NGX_OK) {
+                    if (n >= NGX_HTTP_PRIORITY_URGENCY_MIN
+                        && n <= NGX_HTTP_PRIORITY_URGENCY_MAX)
+                    {
+                        p->urgency = (ngx_uint_t) n;
+                        p->valid = 1;
+                    }
+                    /* Out of range values are ignored per RFC9218 */
+                }
+
+            } else if (*pos == 'i' || *pos == 'I') {
+                /* incremental parameter: i=?0 or i=?1 */
+                pos += 2;  /* skip "i=" */
+
+                if (pos < end && *pos == '?') {
+                    pos++;
+
+                    if (pos < end) {
+                        if (*pos == '1') {
+                            p->incremental = 1;
+                            p->valid = 1;
+                            pos++;
+                        } else if (*pos == '0') {
+                            p->incremental = 0;
+                            p->valid = 1;
+                            pos++;
+                        }
+                    }
+                }
+
+            } else {
+                /* Unknown parameter - skip value */
+                while (pos < end && *pos != ',' && *pos != ';') {
+                    pos++;
+                }
+            }
+
+        } else if (*pos == 'i' || *pos == 'I') {
+            /*
+             * Bare "i" means incremental=true (Structured Fields Boolean)
+             * This is the common shorthand form
+             */
+            pos++;
+
+            /* Check it's not followed by alphanumeric (part of longer key) */
+            if (pos >= end || *pos == ',' || *pos == ' ' || *pos == '\t'
+                || *pos == ';')
+            {
+                p->incremental = 1;
+                p->valid = 1;
+            } else {
+                /* Part of a longer key - skip it */
+                while (pos < end && *pos != ',' && *pos != ';') {
+                    pos++;
+                }
+            }
+
+        } else {
+            /* Unknown parameter - skip to next */
+            while (pos < end && *pos != ',' && *pos != ';') {
+                pos++;
+            }
+        }
+
+        /* Skip to next parameter */
+        ngx_http_priority_skip_ows(&pos, end);
+
+        if (pos < end && *pos == ',') {
+            pos++;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+void
+ngx_http_priority_merge(ngx_http_priority_t *result,
+    ngx_http_priority_t *client, ngx_http_priority_t *server)
+{
+    /*
+     * Per RFC9218 Section 8:
+     * The absence of a priority parameter in a response indicates the
+     * server's disinterest in changing the client-provided value.
+     */
+
+    /* Start with client values */
+    result->urgency = client->urgency;
+    result->incremental = client->incremental;
+    result->valid = client->valid;
+
+    /* Override with server values if server provided priority */
+    if (server->valid) {
+        result->urgency = server->urgency;
+        result->incremental = server->incremental;
+        result->valid = 1;
+    }
+}
+
+
+ngx_int_t
+ngx_http_priority_compare(ngx_http_priority_t *a, ngx_http_priority_t *b)
+{
+    /*
+     * RFC9218 priority comparison for scheduling.
+     *
+     * Returns:
+     *   < 0 if a should be sent before b
+     *   > 0 if b should be sent before a
+     *   = 0 if equal priority (caller handles tie-breaking)
+     *
+     * Ordering rules:
+     *   1. Lower urgency value = higher priority
+     *   2. At same urgency: non-incremental before incremental
+     *      (non-incremental resources should complete quickly)
+     */
+
+    /* Primary: compare urgency (lower = higher priority) */
+    if (a->urgency < b->urgency) {
+        return -1;
+    }
+
+    if (a->urgency > b->urgency) {
+        return 1;
+    }
+
+    /*
+     * Same urgency: non-incremental streams should be sent first
+     * so they complete quickly. Incremental streams can wait and
+     * be interleaved later.
+     */
+    if (!a->incremental && b->incremental) {
+        return -1;  /* a (non-incr) before b (incr) */
+    }
+
+    if (a->incremental && !b->incremental) {
+        return 1;   /* b (non-incr) before a (incr) */
+    }
+
+    return 0;  /* Same urgency and same incremental status */
+}
+
+
+u_char *
+ngx_http_priority_format(u_char *buf, ngx_http_priority_t *p)
+{
+    /*
+     * Format priority as RFC9218/RFC8941 Structured Fields Dictionary.
+     *
+     * Output formats:
+     *   "u=3"     - urgency only (non-default)
+     *   "u=3, i"  - urgency and incremental
+     *   "i"       - incremental only (default urgency)
+     *
+     * If urgency is default (3) and incremental is false, returns empty.
+     */
+
+    u_char  *start = buf;
+
+    if (p->urgency != NGX_HTTP_PRIORITY_DEFAULT_URGENCY) {
+        buf = ngx_sprintf(buf, "u=%ui", p->urgency);
+    }
+
+    if (p->incremental) {
+        if (buf != start) {
+            *buf++ = ',';
+            *buf++ = ' ';
+        }
+        *buf++ = 'i';
+    }
+
+    return buf;
+}

--- a/src/http/ngx_http_priority.h
+++ b/src/http/ngx_http_priority.h
@@ -1,0 +1,92 @@
+
+/*
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#ifndef _NGX_HTTP_PRIORITY_H_INCLUDED_
+#define _NGX_HTTP_PRIORITY_H_INCLUDED_
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+
+
+/*
+ * RFC9218: Extensible Prioritization Scheme for HTTP
+ *
+ * Priority parameters:
+ *   - urgency (u): Integer 0-7, lower is more urgent, default 3
+ *   - incremental (i): Boolean, whether response can be processed
+ *                      incrementally, default false
+ */
+
+
+#define NGX_HTTP_PRIORITY_DEFAULT_URGENCY     3
+#define NGX_HTTP_PRIORITY_URGENCY_MIN         0
+#define NGX_HTTP_PRIORITY_URGENCY_MAX         7
+
+#define NGX_HTTP_PRIORITY_URGENCY_BACKGROUND  7
+
+
+typedef struct {
+    ngx_uint_t   urgency;       /* 0-7, default 3, lower = more urgent */
+    unsigned     incremental:1; /* default 0 (false) */
+    unsigned     valid:1;       /* 1 if explicitly set by client/server */
+} ngx_http_priority_t;
+
+
+/*
+ * Initialize priority to default values (u=3, i=false)
+ */
+#define ngx_http_priority_init(p)                                             \
+    do {                                                                      \
+        (p)->urgency = NGX_HTTP_PRIORITY_DEFAULT_URGENCY;                     \
+        (p)->incremental = 0;                                                 \
+        (p)->valid = 0;                                                       \
+    } while (0)
+
+
+/*
+ * Parse RFC9218 Priority header value (Structured Fields Dictionary).
+ *
+ * Format: "u=<0-7>, i" or "u=<0-7>" or "i" or empty
+ * Examples:
+ *   "u=0"       -> urgency=0, incremental=false
+ *   "u=5, i"    -> urgency=5, incremental=true
+ *   "i"         -> urgency=3 (default), incremental=true
+ *   "u=3, i=?1" -> urgency=3, incremental=true
+ *
+ * Invalid or out-of-range values are ignored (defaults preserved).
+ */
+ngx_int_t ngx_http_priority_parse(ngx_str_t *value, ngx_http_priority_t *p);
+
+
+/*
+ * Merge server-provided priority with client priority per RFC9218 Section 8.
+ * Server values override client values when present.
+ */
+void ngx_http_priority_merge(ngx_http_priority_t *result,
+    ngx_http_priority_t *client, ngx_http_priority_t *server);
+
+
+/*
+ * Compare two priorities for scheduling.
+ * Returns:
+ *   < 0 if a has higher priority (lower urgency, should be sent first)
+ *   > 0 if b has higher priority
+ *   = 0 if equal priority
+ */
+ngx_int_t ngx_http_priority_compare(ngx_http_priority_t *a,
+    ngx_http_priority_t *b);
+
+
+/*
+ * Format priority as a header value (RFC8941 Structured Fields Dictionary).
+ * Returns pointer to the character after the last written byte.
+ * Buffer should have at least 16 bytes capacity ("u=7, i" = 6 bytes max).
+ */
+u_char *ngx_http_priority_format(u_char *buf, ngx_http_priority_t *p);
+
+
+#endif /* _NGX_HTTP_PRIORITY_H_INCLUDED_ */

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -139,6 +139,8 @@ static ngx_int_t
     ngx_table_elt_t *h, ngx_uint_t offset);
 static ngx_int_t ngx_http_upstream_process_vary(ngx_http_request_t *r,
     ngx_table_elt_t *h, ngx_uint_t offset);
+static ngx_int_t ngx_http_upstream_process_priority(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset);
 static ngx_int_t ngx_http_upstream_copy_header_line(ngx_http_request_t *r,
     ngx_table_elt_t *h, ngx_uint_t offset);
 static ngx_int_t
@@ -329,6 +331,10 @@ static ngx_http_upstream_header_t  ngx_http_upstream_headers_in[] = {
                  ngx_http_upstream_ignore_header_line, 0,
                  ngx_http_upstream_copy_header_line,
                  offsetof(ngx_http_headers_out_t, content_encoding), 0 },
+
+    { ngx_string("Priority"),
+                 ngx_http_upstream_process_priority, 0,
+                 ngx_http_upstream_copy_header_line, 0, 1 },
 
     { ngx_null_string, NULL, 0, NULL, 0, 0 }
 };
@@ -5573,6 +5579,49 @@ ngx_http_upstream_process_vary(ngx_http_request_t *r,
     }
 
     r->cache->vary = vary;
+    }
+#endif
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_process_priority(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset)
+{
+#if (NGX_HTTP_V2)
+    ngx_http_priority_t      server_priority;
+    ngx_http_v2_stream_t    *stream;
+    ngx_http_v2_srv_conf_t  *h2scf;
+
+    /*
+     * RFC9218 Section 8: Intermediaries can combine server priority hints
+     * with client priority.  When the upstream sends a Priority header,
+     * merge it with the client's requested priority.
+     */
+
+    stream = r->stream;
+
+    if (stream != NULL) {
+        h2scf = ngx_http_get_module_srv_conf(r, ngx_http_v2_module);
+
+        if (h2scf->rfc9218_priority) {
+            ngx_http_priority_init(&server_priority);
+
+            if (ngx_http_priority_parse(&h->value, &server_priority) == NGX_OK
+                && server_priority.valid)
+            {
+                ngx_http_priority_merge(&stream->priority,
+                                        &stream->priority,
+                                        &server_priority);
+
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                               "http2 upstream priority merged: u=%ui i=%ui",
+                               stream->priority.urgency,
+                               stream->priority.incremental);
+            }
+        }
     }
 #endif
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -38,11 +38,12 @@
 #define NGX_HTTP_V2_SETTINGS_PARAM_SIZE          6
 
 /* settings fields */
-#define NGX_HTTP_V2_HEADER_TABLE_SIZE_SETTING    0x1
-#define NGX_HTTP_V2_ENABLE_PUSH_SETTING          0x2
-#define NGX_HTTP_V2_MAX_STREAMS_SETTING          0x3
-#define NGX_HTTP_V2_INIT_WINDOW_SIZE_SETTING     0x4
-#define NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING       0x5
+#define NGX_HTTP_V2_HEADER_TABLE_SIZE_SETTING      0x1
+#define NGX_HTTP_V2_ENABLE_PUSH_SETTING            0x2
+#define NGX_HTTP_V2_MAX_STREAMS_SETTING            0x3
+#define NGX_HTTP_V2_INIT_WINDOW_SIZE_SETTING       0x4
+#define NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING         0x5
+#define NGX_HTTP_V2_NO_RFC7540_PRIORITIES_SETTING  0x9
 
 #define NGX_HTTP_V2_FRAME_BUFFER_SIZE            24
 
@@ -2728,7 +2729,16 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
         return NGX_ERROR;
     }
 
+    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                         ngx_http_v2_module);
+
+    /* Base settings: MAX_STREAMS, INIT_WINDOW_SIZE, MAX_FRAME_SIZE */
     len = NGX_HTTP_V2_SETTINGS_PARAM_SIZE * 3;
+
+    /* Add NO_RFC7540_PRIORITIES if RFC9218 is enabled */
+    if (h2scf->rfc9218_priority) {
+        len += NGX_HTTP_V2_SETTINGS_PARAM_SIZE;
+    }
 
     buf = ngx_create_temp_buf(h2c->pool, NGX_HTTP_V2_FRAME_HEADER_SIZE + len);
     if (buf == NULL) {
@@ -2756,9 +2766,6 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
 
     buf->last = ngx_http_v2_write_sid(buf->last, 0);
 
-    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
-                                         ngx_http_v2_module);
-
     buf->last = ngx_http_v2_write_uint16(buf->last,
                                          NGX_HTTP_V2_MAX_STREAMS_SETTING);
     buf->last = ngx_http_v2_write_uint32(buf->last,
@@ -2772,6 +2779,18 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
                                          NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING);
     buf->last = ngx_http_v2_write_uint32(buf->last,
                                          NGX_HTTP_V2_MAX_FRAME_SIZE);
+
+    if (h2scf->rfc9218_priority) {
+        /* RFC9218: Signal that we want to use extensible priorities */
+        buf->last = ngx_http_v2_write_uint16(buf->last,
+                                    NGX_HTTP_V2_NO_RFC7540_PRIORITIES_SETTING);
+        buf->last = ngx_http_v2_write_uint32(buf->last, 1);
+
+        h2c->rfc9218_enabled = 1;
+
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                       "http2 RFC9218 extensible priorities enabled");
+    }
 
     ngx_http_v2_queue_blocked_frame(h2c, frame);
 
@@ -3098,6 +3117,9 @@ ngx_http_v2_create_stream(ngx_http_v2_connection_t *h2c)
 
     stream->request = r;
     stream->connection = h2c;
+
+    /* RFC9218: Initialize with default priority */
+    ngx_http_priority_init(&stream->priority);
 
     h2scf = ngx_http_get_module_srv_conf(r, ngx_http_v2_module);
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1721,6 +1721,7 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
     ngx_http_core_main_conf_t  *cmcf;
 
     static ngx_str_t cookie = ngx_string("cookie");
+    static ngx_str_t priority_name = ngx_string("priority");
 
     header = &h2c->state.header;
 
@@ -1813,6 +1814,27 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
 
             return ngx_http_v2_state_header_complete(h2c, pos, end);
         }
+    }
+
+    /*
+     * RFC9218: Handle Priority request header for extensible priorities.
+     * Parse and store the priority parameters in the stream.
+     */
+    if (header->name.len == priority_name.len
+        && ngx_memcmp(header->name.data, priority_name.data,
+                      priority_name.len) == 0)
+    {
+        if (ngx_http_priority_parse(&header->value,
+                                    &h2c->state.stream->priority) == NGX_OK)
+        {
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http2 priority header: u=%ui, i=%ui",
+                           h2c->state.stream->priority.urgency,
+                           h2c->state.stream->priority.incremental);
+        }
+        /* Malformed priority values use defaults per RFC9218 */
+
+        return ngx_http_v2_state_header_complete(h2c, pos, end);
     }
 
     if (header->name.len == cookie.len

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -86,6 +86,8 @@ static u_char *ngx_http_v2_handle_continuation(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end, ngx_http_v2_handler_pt handler);
 static u_char *ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
+static u_char *ngx_http_v2_state_priority_update(ngx_http_v2_connection_t *h2c,
+    u_char *pos, u_char *end);
 static u_char *ngx_http_v2_state_rst_stream(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
 static u_char *ngx_http_v2_state_settings(ngx_http_v2_connection_t *h2c,
@@ -907,6 +909,11 @@ ngx_http_v2_state_head(ngx_http_v2_connection_t *h2c, u_char *pos, u_char *end)
                    "http2 frame type:%ui f:%Xd l:%uz sid:%ui",
                    type, h2c->state.flags, h2c->state.length, h2c->state.sid);
 
+    /* RFC9218: Handle PRIORITY_UPDATE frame (type 0x10) */
+    if (type == NGX_HTTP_V2_PRIORITY_UPDATE_FRAME) {
+        return ngx_http_v2_state_priority_update(h2c, pos, end);
+    }
+
     if (type >= NGX_HTTP_V2_FRAME_STATES) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
                       "client sent frame with unknown type %ui", type);
@@ -1338,6 +1345,34 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     node->stream = stream;
 
+    /*
+     * RFC9218: Apply any pending priority updates for this stream.
+     * PRIORITY_UPDATE frames may arrive before HEADERS.
+     */
+    if (h2c->pending_priorities) {
+        ngx_uint_t                       i;
+        ngx_http_v2_pending_priority_t  *pp;
+
+        pp = h2c->pending_priorities->elts;
+
+        for (i = 0; i < h2c->pending_priorities->nelts; i++) {
+            if (pp[i].sid == node->id) {
+                stream->priority = pp[i].priority;
+
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                               "http2 applied pending priority for stream %ui: "
+                               "u=%ui", node->id, stream->priority.urgency);
+                break;
+            }
+        }
+    }
+
+    /*
+     * RFC9218: Even when RFC9218 is enabled, we still need to set up the
+     * node tree structure for proper node lifecycle management (the closed
+     * queue uses the node's queue member). We just don't use the dependency
+     * tree for scheduling.
+     */
     if (priority || node->parent == NULL) {
         node->weight = weight;
         ngx_http_v2_set_dependency(h2c, node, depend, excl);
@@ -2060,6 +2095,16 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
     }
 
+    /*
+     * RFC9218: When RFC9218 is enabled, ignore PRIORITY frames after
+     * validating them. Protocol errors are still detected.
+     */
+    if (h2c->rfc9218_enabled) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                       "http2 PRIORITY frame ignored (RFC9218 mode)");
+        return ngx_http_v2_state_complete(h2c, pos, end);
+    }
+
     node = ngx_http_v2_get_node_by_id(h2c, h2c->state.sid, 1);
 
     if (node == NULL) {
@@ -2081,6 +2126,127 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     ngx_http_v2_set_dependency(h2c, node, depend, excl);
 
+    return ngx_http_v2_state_complete(h2c, pos, end);
+}
+
+
+static u_char *
+ngx_http_v2_state_priority_update(ngx_http_v2_connection_t *h2c, u_char *pos,
+    u_char *end)
+{
+    size_t                           len;
+    ngx_str_t                        value;
+    ngx_uint_t                       sid;
+    ngx_http_v2_node_t              *node;
+    ngx_http_v2_stream_t            *stream;
+    ngx_http_v2_pending_priority_t  *pp;
+
+    /*
+     * RFC9218: PRIORITY_UPDATE frame format:
+     *   - Prioritized Stream ID (31 bits)
+     *   - Priority Field Value (variable length)
+     *
+     * Must be sent on stream 0, for client-initiated streams only.
+     */
+
+    if (h2c->state.sid != 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent PRIORITY_UPDATE frame on non-zero stream");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
+    }
+
+    if (h2c->state.length < 4) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent PRIORITY_UPDATE frame too short");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
+    }
+
+    len = h2c->state.length;
+
+    if ((size_t) (end - pos) < len) {
+        return ngx_http_v2_state_save(h2c, pos, end,
+                                      ngx_http_v2_state_priority_update);
+    }
+
+    /* Parse Prioritized Stream ID (first 4 bytes, top bit reserved) */
+    sid = ngx_http_v2_parse_uint32(pos) & 0x7fffffff;
+    pos += 4;
+    len -= 4;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 PRIORITY_UPDATE frame for stream %ui, len=%uz",
+                   sid, len);
+
+    /* Must be odd (client-initiated) */
+    if (sid == 0 || (sid & 1) == 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent PRIORITY_UPDATE for invalid stream %ui",
+                      sid);
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
+    }
+
+    /* Parse Priority Field Value */
+    value.data = pos;
+    value.len = len;
+
+    node = ngx_http_v2_get_node_by_id(h2c, sid, 0);
+
+    if (node && node->stream) {
+        /* Stream exists, apply priority immediately */
+        stream = node->stream;
+
+        if (ngx_http_priority_parse(&value, &stream->priority) == NGX_OK) {
+            ngx_log_debug3(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                           "http2 PRIORITY_UPDATE applied to stream %ui: "
+                           "u=%ui, i=%ui",
+                           sid, stream->priority.urgency,
+                           stream->priority.incremental);
+        }
+
+    } else {
+        /* Stream doesn't exist yet, buffer the priority */
+        if (h2c->pending_priorities == NULL) {
+            h2c->pending_priorities = ngx_array_create(h2c->pool, 4,
+                                        sizeof(ngx_http_v2_pending_priority_t));
+            if (h2c->pending_priorities == NULL) {
+                return ngx_http_v2_connection_error(h2c,
+                                                    NGX_HTTP_V2_INTERNAL_ERROR);
+            }
+        }
+
+        /* Check if we already have a pending priority for this stream */
+        pp = h2c->pending_priorities->elts;
+        for (len = 0; len < h2c->pending_priorities->nelts; len++) {
+            if (pp[len].sid == sid) {
+                /* Update existing entry */
+                ngx_http_priority_parse(&value, &pp[len].priority);
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                               "http2 PRIORITY_UPDATE updated pending for "
+                               "stream %ui: u=%ui",
+                               sid, pp[len].priority.urgency);
+                goto done;
+            }
+        }
+
+        /* Add new pending priority */
+        pp = ngx_array_push(h2c->pending_priorities);
+        if (pp == NULL) {
+            return ngx_http_v2_connection_error(h2c,
+                                                NGX_HTTP_V2_INTERNAL_ERROR);
+        }
+
+        pp->sid = sid;
+        ngx_http_priority_init(&pp->priority);
+        ngx_http_priority_parse(&value, &pp->priority);
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                       "http2 PRIORITY_UPDATE buffered for stream %ui: u=%ui",
+                       sid, pp->priority.urgency);
+    }
+
+done:
+
+    pos += h2c->state.length - 4;
     return ngx_http_v2_state_complete(h2c, pos, end);
 }
 

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -74,6 +74,7 @@ typedef struct {
 
 typedef struct {
     ngx_flag_t                       enable;
+    ngx_flag_t                       rfc9218_priority;
     size_t                           pool_size;
     ngx_uint_t                       concurrent_streams;
     size_t                           preread_size;

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -28,16 +28,17 @@
 #define NGX_HTTP_V2_FRAME_HEADER_SIZE    9
 
 /* frame types */
-#define NGX_HTTP_V2_DATA_FRAME           0x0
-#define NGX_HTTP_V2_HEADERS_FRAME        0x1
-#define NGX_HTTP_V2_PRIORITY_FRAME       0x2
-#define NGX_HTTP_V2_RST_STREAM_FRAME     0x3
-#define NGX_HTTP_V2_SETTINGS_FRAME       0x4
-#define NGX_HTTP_V2_PUSH_PROMISE_FRAME   0x5
-#define NGX_HTTP_V2_PING_FRAME           0x6
-#define NGX_HTTP_V2_GOAWAY_FRAME         0x7
-#define NGX_HTTP_V2_WINDOW_UPDATE_FRAME  0x8
-#define NGX_HTTP_V2_CONTINUATION_FRAME   0x9
+#define NGX_HTTP_V2_DATA_FRAME             0x00
+#define NGX_HTTP_V2_HEADERS_FRAME          0x01
+#define NGX_HTTP_V2_PRIORITY_FRAME         0x02
+#define NGX_HTTP_V2_RST_STREAM_FRAME       0x03
+#define NGX_HTTP_V2_SETTINGS_FRAME         0x04
+#define NGX_HTTP_V2_PUSH_PROMISE_FRAME     0x05
+#define NGX_HTTP_V2_PING_FRAME             0x06
+#define NGX_HTTP_V2_GOAWAY_FRAME           0x07
+#define NGX_HTTP_V2_WINDOW_UPDATE_FRAME    0x08
+#define NGX_HTTP_V2_CONTINUATION_FRAME     0x09
+#define NGX_HTTP_V2_PRIORITY_UPDATE_FRAME  0x10
 
 /* frame flags */
 #define NGX_HTTP_V2_NO_FLAG              0x00

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -11,6 +11,7 @@
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
+#include <ngx_http_priority.h>
 
 
 #define NGX_HTTP_V2_ALPN_PROTO           "\x02h2"
@@ -59,6 +60,16 @@ typedef struct ngx_http_v2_out_frame_s    ngx_http_v2_out_frame_t;
 
 typedef u_char *(*ngx_http_v2_handler_pt) (ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
+
+
+/*
+ * RFC9218: Pending priority update for streams not yet created.
+ * PRIORITY_UPDATE frames may arrive before the HEADERS frame.
+ */
+typedef struct {
+    ngx_uint_t                       sid;
+    ngx_http_priority_t              priority;
+} ngx_http_v2_pending_priority_t;
 
 
 typedef struct {
@@ -168,6 +179,12 @@ struct ngx_http_v2_connection_s {
     unsigned                         table_update:1;
     unsigned                         blocked:1;
     unsigned                         goaway:1;
+
+    /* RFC9218 Extensible Priorities */
+    unsigned                         no_rfc7540_priorities:1;
+    unsigned                         rfc9218_enabled:1;
+
+    ngx_array_t                     *pending_priorities;
 };
 
 
@@ -222,6 +239,9 @@ struct ngx_http_v2_stream_s {
     unsigned                         rst_sent:1;
     unsigned                         no_flow_control:1;
     unsigned                         skip_data:1;
+
+    /* RFC9218 Extensible Priorities */
+    ngx_http_priority_t              priority;
 };
 
 

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -266,7 +266,11 @@ static ngx_inline void
 ngx_http_v2_queue_frame(ngx_http_v2_connection_t *h2c,
     ngx_http_v2_out_frame_t *frame)
 {
+    ngx_int_t                  cmp;
+    ngx_http_v2_stream_t      *s, *fs;
     ngx_http_v2_out_frame_t  **out;
+
+    fs = frame->stream;
 
     for (out = &h2c->last_out; *out; out = &(*out)->next) {
 
@@ -274,12 +278,44 @@ ngx_http_v2_queue_frame(ngx_http_v2_connection_t *h2c,
             break;
         }
 
-        if ((*out)->stream->node->rank < frame->stream->node->rank
-            || ((*out)->stream->node->rank == frame->stream->node->rank
-                && (*out)->stream->node->rel_weight
-                   >= frame->stream->node->rel_weight))
+        s = (*out)->stream;
+
+        /*
+         * RFC9218: When using extensible priorities, schedule by urgency.
+         * Lower urgency value = higher priority.
+         */
+        if (h2c->rfc9218_enabled
+            || (fs->priority.valid && s->priority.valid))
         {
-            break;
+            /* RFC9218 urgency-based scheduling */
+            cmp = ngx_http_priority_compare(&s->priority, &fs->priority);
+
+            if (cmp < 0) {
+                /* s has higher priority, frame goes after */
+                break;
+            }
+
+            if (cmp == 0) {
+                /*
+                 * Same urgency and incremental status.
+                 * Use stream ID as tiebreaker (lower ID = higher priority).
+                 * Always maintain FIFO for frames from the same stream.
+                 */
+                if (s->node->id <= fs->node->id) {
+                    break;
+                }
+            }
+
+            /* cmp > 0: frame has higher priority, continue searching */
+
+        } else {
+            /* Legacy RFC7540 scheduling (rank/weight based) */
+            if (s->node->rank < fs->node->rank
+                || (s->node->rank == fs->node->rank
+                    && s->node->rel_weight >= fs->node->rel_weight))
+            {
+                break;
+            }
         }
     }
 

--- a/src/http/v2/ngx_http_v2_filter_module.c
+++ b/src/http/v2/ngx_http_v2_filter_module.c
@@ -1431,6 +1431,7 @@ static void
 ngx_http_v2_waiting_queue(ngx_http_v2_connection_t *h2c,
     ngx_http_v2_stream_t *stream)
 {
+    ngx_int_t              cmp;
     ngx_queue_t           *q;
     ngx_http_v2_stream_t  *s;
 
@@ -1446,11 +1447,44 @@ ngx_http_v2_waiting_queue(ngx_http_v2_connection_t *h2c,
     {
         s = ngx_queue_data(q, ngx_http_v2_stream_t, queue);
 
-        if (s->node->rank < stream->node->rank
-            || (s->node->rank == stream->node->rank
-                && s->node->rel_weight >= stream->node->rel_weight))
+        /*
+         * RFC9218: When using extensible priorities, schedule by urgency.
+         */
+        if (h2c->rfc9218_enabled
+            || (stream->priority.valid && s->priority.valid))
         {
-            break;
+            cmp = ngx_http_priority_compare(&s->priority, &stream->priority);
+
+            if (cmp < 0) {
+                break;
+            }
+
+            if (cmp == 0) {
+                /*
+                 * Same urgency and incremental status.
+                 * Match queue_frame() logic for consistency.
+                 */
+                if (!s->priority.incremental && !stream->priority.incremental) {
+                    /* Both non-incremental: strict FIFO */
+                    if (s->node->id <= stream->node->id) {
+                        break;
+                    }
+                } else {
+                    /* Both incremental: allow interleaving */
+                    if (s->node->id < stream->node->id) {
+                        break;
+                    }
+                }
+            }
+
+        } else {
+            /* Legacy RFC7540 scheduling */
+            if (s->node->rank < stream->node->rank
+                || (s->node->rank == stream->node->rank
+                    && s->node->rel_weight >= stream->node->rel_weight))
+            {
+                break;
+            }
         }
     }
 

--- a/src/http/v2/ngx_http_v2_module.c
+++ b/src/http/v2/ngx_http_v2_module.c
@@ -80,6 +80,13 @@ static ngx_command_t  ngx_http_v2_commands[] = {
       offsetof(ngx_http_v2_srv_conf_t, enable),
       NULL },
 
+    { ngx_string("http2_rfc9218_priority"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_v2_srv_conf_t, rfc9218_priority),
+      NULL },
+
     { ngx_string("http2_recv_buffer_size"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_size_slot,
@@ -320,6 +327,7 @@ ngx_http_v2_create_srv_conf(ngx_conf_t *cf)
     }
 
     h2scf->enable = NGX_CONF_UNSET;
+    h2scf->rfc9218_priority = NGX_CONF_UNSET;
 
     h2scf->pool_size = NGX_CONF_UNSET_SIZE;
 
@@ -340,6 +348,7 @@ ngx_http_v2_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_http_v2_srv_conf_t *conf = child;
 
     ngx_conf_merge_value(conf->enable, prev->enable, 0);
+    ngx_conf_merge_value(conf->rfc9218_priority, prev->rfc9218_priority, 1);
 
     ngx_conf_merge_size_value(conf->pool_size, prev->pool_size, 4096);
 


### PR DESCRIPTION
- **Add RFC9218 priority types and parser**
- **HTTP/2: add RFC9218 priority fields to structures**
- **HTTP/2: add http2_rfc9218_priority directive**
- **HTTP/2: send SETTINGS_NO_RFC7540_PRIORITIES**
- **HTTP/2: parse Priority request header**
- **HTTP/2: handle PRIORITY_UPDATE frames**
- **HTTP/2: implement RFC9218 priority-based scheduling**
- **HTTP/2: merge upstream Priority header for proxied requests**
