### PR TITLE
Revert "HTTP/2: fixed overlapping memcpy in CONTINUATION frames"

### DIFF
--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1967,7 +1967,7 @@ ngx_http_v2_handle_continuation(ngx_http_v2_connection_t *h2c, u_char *pos,
     p = pos;
     pos += NGX_HTTP_V2_FRAME_HEADER_SIZE;
 
-    ngx_memmove(pos, p, len);
+    ngx_memcpy(pos, p, len);
 
     len = ngx_http_v2_parse_length(head);
 


### PR DESCRIPTION
```
Revert "HTTP/2: fixed overlapping memcpy in CONTINUATION frames"

This reverts commit 2d71bdcf8b34d9a44608920e34f2d031b3a938b6.

This is actually unnecessary. Thanks to Valentin Bartenev for the
analysis

1. ngx_http_v2_handle_continuation() handles split HPACK integers at
   frame boundaries
2. HPACK integers are max 4 bytes (NGX_HTTP_V2_INT_OCTETS)
3. The function is only called when length < 4 (i.e., 1-3 bytes remain)
4. The copy destination is offset by 9 bytes (frame header size)

Since 3 < 9, source and destination never overlap.
```
