### PR TITLE
HTTP/2: implement RFC 9218 Extensible Prioritization Scheme for HTTP

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -77,7 +77,8 @@ if [ $HTTP = YES ]; then
                          src/http/ngx_http_variables.h \
                          src/http/ngx_http_script.h \
                          src/http/ngx_http_upstream.h \
-                         src/http/ngx_http_upstream_round_robin.h"
+                         src/http/ngx_http_upstream_round_robin.h \
+                         src/http/ngx_http_priority.h"
         ngx_module_srcs="src/http/ngx_http.c \
                          src/http/ngx_http_core_module.c \
                          src/http/ngx_http_special_response.c \
@@ -88,7 +89,8 @@ if [ $HTTP = YES ]; then
                          src/http/ngx_http_variables.c \
                          src/http/ngx_http_script.c \
                          src/http/ngx_http_upstream.c \
-                         src/http/ngx_http_upstream_round_robin.c"
+                         src/http/ngx_http_upstream_round_robin.c \
+                         src/http/ngx_http_priority.c"
         ngx_module_libs=
         ngx_module_link=YES
 

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -36,6 +36,7 @@ typedef u_char *(*ngx_http_log_handler_pt)(ngx_http_request_t *r,
 #include <ngx_http_upstream.h>
 #include <ngx_http_upstream_round_robin.h>
 #include <ngx_http_core_module.h>
+#include <ngx_http_priority.h>
 
 #if (NGX_HTTP_V2)
 #include <ngx_http_v2.h>

--- a/src/http/ngx_http_priority.c
+++ b/src/http/ngx_http_priority.c
@@ -1,0 +1,323 @@
+
+/*
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <ngx_http_priority.h>
+
+
+/*
+ * Parse RFC9218 Priority header value.
+ *
+ * The value is a Structured Fields Dictionary (RFC8941) containing:
+ *   - u: Integer 0-7 (urgency)
+ *   - i: Boolean (incremental)
+ *
+ * This is a simplified parser that handles the common formats:
+ *   "u=5"
+ *   "u=5, i"
+ *   "u=5, i=?1"
+ *   "i, u=3"
+ *
+ * Per RFC9218 Section 4, unknown parameters and out-of-range values
+ * are ignored, and defaults are used instead.
+ */
+
+
+static ngx_int_t
+ngx_http_priority_parse_int(u_char **pos, u_char *end, ngx_int_t *value)
+{
+    u_char      *p;
+    ngx_int_t    n, cutoff, cutlim, d;
+    ngx_uint_t   negative;
+
+    p = *pos;
+    negative = 0;
+
+    if (p >= end) {
+        return NGX_ERROR;
+    }
+
+    if (*p == '-') {
+        negative = 1;
+        p++;
+    }
+
+    if (p >= end || *p < '0' || *p > '9') {
+        return NGX_ERROR;
+    }
+
+    /*
+     * Use pre-check to avoid signed overflow.
+     * cutoff is the largest value before overflow on next digit.
+     */
+    cutoff = NGX_MAX_INT_T_VALUE / 10;
+    cutlim = NGX_MAX_INT_T_VALUE % 10;
+
+    n = 0;
+
+    while (p < end && *p >= '0' && *p <= '9') {
+        d = *p - '0';
+
+        if (n > cutoff || (n == cutoff && d > cutlim)) {
+            return NGX_ERROR;
+        }
+
+        n = n * 10 + d;
+        p++;
+    }
+
+    *pos = p;
+    *value = negative ? -n : n;
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_http_priority_skip_ows(u_char **pos, u_char *end)
+{
+    u_char  *p;
+
+    p = *pos;
+
+    while (p < end && (*p == ' ' || *p == '\t')) {
+        p++;
+    }
+
+    *pos = p;
+}
+
+
+ngx_int_t
+ngx_http_priority_parse(ngx_str_t *value, ngx_http_priority_t *p)
+{
+    u_char     *pos, *end;
+    ngx_int_t   n;
+
+    /* Initialize with defaults */
+    ngx_http_priority_init(p);
+
+    if (value == NULL || value->len == 0) {
+        return NGX_OK;
+    }
+
+    pos = value->data;
+    end = pos + value->len;
+
+    while (pos < end) {
+        ngx_http_priority_skip_ows(&pos, end);
+
+        if (pos >= end) {
+            break;
+        }
+
+        /* Parse parameter key */
+        if (pos + 1 < end && pos[1] == '=') {
+            /* Key=Value format */
+
+            if (*pos == 'u' || *pos == 'U') {
+                /* urgency parameter: u=<integer> */
+                pos += 2;  /* skip "u=" */
+
+                if (ngx_http_priority_parse_int(&pos, end, &n) == NGX_OK) {
+                    if (n >= NGX_HTTP_PRIORITY_URGENCY_MIN
+                        && n <= NGX_HTTP_PRIORITY_URGENCY_MAX)
+                    {
+                        p->urgency = (ngx_uint_t) n;
+                        p->urgency_set = 1;
+                        p->valid = 1;
+                    }
+                    /* Out of range values are ignored per RFC9218 */
+                }
+
+                /* Skip any trailing junk to next delimiter */
+                while (pos < end && *pos != ',' && *pos != ';') {
+                    pos++;
+                }
+
+            } else if (*pos == 'i' || *pos == 'I') {
+                /* incremental parameter: i=?0 or i=?1 */
+                pos += 2;  /* skip "i=" */
+
+                if (pos < end && *pos == '?') {
+                    pos++;
+
+                    if (pos < end) {
+                        if (*pos == '1') {
+                            p->incremental = 1;
+                            p->incremental_set = 1;
+                            p->valid = 1;
+                            pos++;
+                        } else if (*pos == '0') {
+                            p->incremental = 0;
+                            p->incremental_set = 1;
+                            p->valid = 1;
+                            pos++;
+                        }
+                    }
+                }
+
+                /* Skip any trailing junk to next delimiter */
+                while (pos < end && *pos != ',' && *pos != ';') {
+                    pos++;
+                }
+
+            } else {
+                /* Unknown parameter - skip value */
+                while (pos < end && *pos != ',' && *pos != ';') {
+                    pos++;
+                }
+            }
+
+        } else if (*pos == 'i' || *pos == 'I') {
+            /*
+             * Bare "i" means incremental=true (Structured Fields Boolean)
+             * This is the common shorthand form
+             */
+            pos++;
+
+            /* Check it's not followed by alphanumeric (part of longer key) */
+            if (pos >= end || *pos == ',' || *pos == ' ' || *pos == '\t'
+                || *pos == ';')
+            {
+                p->incremental = 1;
+                p->incremental_set = 1;
+                p->valid = 1;
+            } else {
+                /* Part of a longer key - skip it */
+                while (pos < end && *pos != ',' && *pos != ';') {
+                    pos++;
+                }
+            }
+
+        } else {
+            /* Unknown parameter - skip to next */
+            while (pos < end && *pos != ',' && *pos != ';') {
+                pos++;
+            }
+        }
+
+        /* Skip to next parameter */
+        ngx_http_priority_skip_ows(&pos, end);
+
+        if (pos < end && (*pos == ',' || *pos == ';')) {
+            pos++;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+void
+ngx_http_priority_merge(ngx_http_priority_t *result,
+    ngx_http_priority_t *client, ngx_http_priority_t *server)
+{
+    /*
+     * Per RFC9218 Section 8:
+     * "The absence of a priority parameter in an HTTP response indicates
+     * the server's disinterest in changing the client-provided value."
+     *
+     * Only override parameters that the server explicitly provided.
+     */
+
+    /* Start with client values */
+    result->urgency = client->urgency;
+    result->incremental = client->incremental;
+    result->valid = client->valid;
+    result->urgency_set = client->urgency_set;
+    result->incremental_set = client->incremental_set;
+
+    /* Override only parameters the server explicitly set */
+    if (server->urgency_set) {
+        result->urgency = server->urgency;
+        result->urgency_set = 1;
+        result->valid = 1;
+    }
+
+    if (server->incremental_set) {
+        result->incremental = server->incremental;
+        result->incremental_set = 1;
+        result->valid = 1;
+    }
+}
+
+
+ngx_int_t
+ngx_http_priority_compare(ngx_http_priority_t *a, ngx_http_priority_t *b)
+{
+    /*
+     * RFC9218 priority comparison for scheduling.
+     *
+     * Returns:
+     *   < 0 if a should be sent before b
+     *   > 0 if b should be sent before a
+     *   = 0 if equal priority (caller handles tie-breaking)
+     *
+     * Ordering rules:
+     *   1. Lower urgency value = higher priority
+     *   2. At same urgency: non-incremental before incremental
+     *      (non-incremental resources should complete quickly)
+     */
+
+    /* Primary: compare urgency (lower = higher priority) */
+    if (a->urgency < b->urgency) {
+        return -1;
+    }
+
+    if (a->urgency > b->urgency) {
+        return 1;
+    }
+
+    /*
+     * Same urgency: non-incremental streams should be sent first
+     * so they complete quickly. Incremental streams can wait and
+     * be interleaved later.
+     */
+    if (!a->incremental && b->incremental) {
+        return -1;  /* a (non-incr) before b (incr) */
+    }
+
+    if (a->incremental && !b->incremental) {
+        return 1;   /* b (non-incr) before a (incr) */
+    }
+
+    return 0;  /* Same urgency and same incremental status */
+}
+
+
+u_char *
+ngx_http_priority_format(u_char *buf, ngx_http_priority_t *p)
+{
+    /*
+     * Format priority as RFC9218/RFC8941 Structured Fields Dictionary.
+     *
+     * Output formats:
+     *   "u=0"     - urgency only (non-default)
+     *   "u=0, i"  - urgency and incremental
+     *   "i"       - incremental only (default urgency)
+     *
+     * If urgency is default (3) and incremental is false, returns empty.
+     */
+
+    u_char  *start = buf;
+
+    if (p->urgency != NGX_HTTP_PRIORITY_DEFAULT_URGENCY) {
+        buf = ngx_sprintf(buf, "u=%ui", p->urgency);
+    }
+
+    if (p->incremental) {
+        if (buf != start) {
+            *buf++ = ',';
+            *buf++ = ' ';
+        }
+        *buf++ = 'i';
+    }
+
+    return buf;
+}

--- a/src/http/ngx_http_priority.c
+++ b/src/http/ngx_http_priority.c
@@ -1,0 +1,379 @@
+
+/*
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <ngx_http_priority.h>
+
+
+/*
+ * Parse RFC9218 Priority header value.
+ *
+ * The value is a Structured Fields Dictionary (RFC8941) containing:
+ *   - u: Integer 0-7 (urgency)
+ *   - i: Boolean (incremental)
+ *
+ * This is a simplified parser that handles the common formats:
+ *   "u=5"
+ *   "u=5, i"
+ *   "u=5, i=?1"
+ *   "i, u=3"
+ *
+ * Per RFC9218 Section 4, unknown parameters and out-of-range values
+ * are ignored, and defaults are used instead.
+ */
+
+
+static ngx_int_t
+ngx_http_priority_parse_int(u_char **pos, u_char *end, ngx_int_t *value)
+{
+    u_char      *p;
+    ngx_int_t    n, cutoff, cutlim, d;
+    ngx_uint_t   negative;
+
+    p = *pos;
+    negative = 0;
+
+    if (p >= end) {
+        return NGX_ERROR;
+    }
+
+    if (*p == '-') {
+        negative = 1;
+        p++;
+    }
+
+    if (p >= end || *p < '0' || *p > '9') {
+        return NGX_ERROR;
+    }
+
+    /*
+     * Use pre-check to avoid signed overflow.
+     * cutoff is the largest value before overflow on next digit.
+     */
+    cutoff = NGX_MAX_INT_T_VALUE / 10;
+    cutlim = NGX_MAX_INT_T_VALUE % 10;
+
+    n = 0;
+
+    while (p < end && *p >= '0' && *p <= '9') {
+        d = *p - '0';
+
+        if (n > cutoff || (n == cutoff && d > cutlim)) {
+            return NGX_ERROR;
+        }
+
+        n = n * 10 + d;
+        p++;
+    }
+
+    *pos = p;
+    *value = negative ? -n : n;
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_http_priority_skip_ows(u_char **pos, u_char *end)
+{
+    u_char  *p;
+
+    p = *pos;
+
+    while (p < end && (*p == ' ' || *p == '\t')) {
+        p++;
+    }
+
+    *pos = p;
+}
+
+
+/*
+ * Advance to the next Structured Fields Dictionary member boundary, i.e.
+ * the next top-level ',' or parameter-introducing ';'.
+ *
+ * Per RFC 8941, a member value or parameter value may be a String enclosed
+ * in double quotes, within which ',' and ';' are literal data and a
+ * backslash escapes the following character (only '"' and '\' may be
+ * escaped).  Skipping on a raw ',' / ';' scan (ignoring quoting) would
+ * split a value such as x="a,u=0" at the embedded comma and then misparse
+ * the "u=0" tail as a top-level urgency member, applying a priority the
+ * peer never signaled. Honour quoted strings here so member boundaries are
+ * detected correctly.
+ */
+static void
+ngx_http_priority_skip_member(u_char **pos, u_char *end)
+{
+    u_char      *p, ch;
+    ngx_uint_t   quoted, escaped;
+
+    p = *pos;
+    quoted = 0;
+    escaped = 0;
+
+    while (p < end) {
+        ch = *p;
+
+        if (quoted) {
+
+            if (escaped) {
+                escaped = 0;
+
+            } else if (ch == '\\') {
+                escaped = 1;
+
+            } else if (ch == '"') {
+                quoted = 0;
+            }
+
+            p++;
+            continue;
+        }
+
+        if (ch == '"') {
+            quoted = 1;
+            p++;
+            continue;
+        }
+
+        if (ch == ',' || ch == ';') {
+            break;
+        }
+
+        p++;
+    }
+
+    *pos = p;
+}
+
+
+ngx_int_t
+ngx_http_priority_parse(ngx_str_t *value, ngx_http_priority_t *p)
+{
+    u_char     *pos, *end;
+    ngx_int_t   n;
+
+    /* Initialize with defaults */
+    ngx_http_priority_init(p);
+
+    if (value == NULL || value->len == 0) {
+        return NGX_OK;
+    }
+
+    pos = value->data;
+    end = pos + value->len;
+
+    while (pos < end) {
+        ngx_http_priority_skip_ows(&pos, end);
+
+        if (pos >= end) {
+            break;
+        }
+
+        /* Parse parameter key */
+        if (pos + 1 < end && pos[1] == '=') {
+            /* Key=Value format */
+
+            if (*pos == 'u' || *pos == 'U') {
+                /* urgency parameter: u=<integer> */
+                pos += 2;  /* skip "u=" */
+
+                if (ngx_http_priority_parse_int(&pos, end, &n) == NGX_OK) {
+                    if (n >= NGX_HTTP_PRIORITY_URGENCY_MIN
+                        && n <= NGX_HTTP_PRIORITY_URGENCY_MAX)
+                    {
+                        p->urgency = (ngx_uint_t) n;
+                        p->urgency_set = 1;
+                        p->valid = 1;
+                    }
+                    /* Out of range values are ignored per RFC9218 */
+                }
+
+                /* Skip any trailing junk to next delimiter */
+                ngx_http_priority_skip_member(&pos, end);
+
+            } else if (*pos == 'i' || *pos == 'I') {
+                /* incremental parameter: i=?0 or i=?1 */
+                pos += 2;  /* skip "i=" */
+
+                if (pos < end && *pos == '?') {
+                    pos++;
+
+                    if (pos < end) {
+                        if (*pos == '1') {
+                            p->incremental = 1;
+                            p->incremental_set = 1;
+                            p->valid = 1;
+                            pos++;
+                        } else if (*pos == '0') {
+                            p->incremental = 0;
+                            p->incremental_set = 1;
+                            p->valid = 1;
+                            pos++;
+                        }
+                    }
+                }
+
+                /* Skip any trailing junk to next delimiter */
+                ngx_http_priority_skip_member(&pos, end);
+
+            } else {
+                /* Unknown parameter - skip value */
+                ngx_http_priority_skip_member(&pos, end);
+            }
+
+        } else if (*pos == 'i' || *pos == 'I') {
+            /*
+             * Bare "i" means incremental=true (Structured Fields Boolean)
+             * This is the common shorthand form
+             */
+            pos++;
+
+            /* Check it's not followed by alphanumeric (part of longer key) */
+            if (pos >= end || *pos == ',' || *pos == ' ' || *pos == '\t'
+                || *pos == ';')
+            {
+                p->incremental = 1;
+                p->incremental_set = 1;
+                p->valid = 1;
+            } else {
+                /* Part of a longer key - skip it */
+                ngx_http_priority_skip_member(&pos, end);
+            }
+
+        } else {
+            /* Unknown parameter - skip to next */
+            ngx_http_priority_skip_member(&pos, end);
+        }
+
+        /* Skip to next parameter */
+        ngx_http_priority_skip_ows(&pos, end);
+
+        if (pos < end && (*pos == ',' || *pos == ';')) {
+            pos++;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+void
+ngx_http_priority_merge(ngx_http_priority_t *result,
+    ngx_http_priority_t *client, ngx_http_priority_t *server)
+{
+    /*
+     * Per RFC9218 Section 8:
+     * "The absence of a priority parameter in an HTTP response indicates
+     * the server's disinterest in changing the client-provided value."
+     *
+     * Only override parameters that the server explicitly provided.
+     */
+
+    /* Start with client values */
+    result->urgency = client->urgency;
+    result->incremental = client->incremental;
+    result->valid = client->valid;
+    result->urgency_set = client->urgency_set;
+    result->incremental_set = client->incremental_set;
+
+    /* Override only parameters the server explicitly set */
+    if (server->urgency_set) {
+        result->urgency = server->urgency;
+        result->urgency_set = 1;
+        result->valid = 1;
+    }
+
+    if (server->incremental_set) {
+        result->incremental = server->incremental;
+        result->incremental_set = 1;
+        result->valid = 1;
+    }
+}
+
+
+void
+ngx_http_priority_state_update(ngx_http_priority_state_t *ps)
+{
+    ngx_http_priority_merge(&ps->effective, &ps->client, &ps->server);
+}
+
+
+ngx_int_t
+ngx_http_priority_compare(ngx_http_priority_t *a, ngx_http_priority_t *b)
+{
+    /*
+     * RFC9218 priority comparison for scheduling.
+     *
+     * Returns:
+     *   < 0 if a should be sent before b
+     *   > 0 if b should be sent before a
+     *   = 0 if equal priority (caller handles tie-breaking)
+     *
+     * Ordering rules:
+     *   1. Lower urgency value = higher priority
+     *   2. At same urgency: non-incremental before incremental
+     *      (non-incremental resources should complete quickly)
+     */
+
+    /* Primary: compare urgency (lower = higher priority) */
+    if (a->urgency < b->urgency) {
+        return -1;
+    }
+
+    if (a->urgency > b->urgency) {
+        return 1;
+    }
+
+    /*
+     * Same urgency: non-incremental streams should be sent first
+     * so they complete quickly. Incremental streams can wait and
+     * be interleaved later.
+     */
+    if (!a->incremental && b->incremental) {
+        return -1;  /* a (non-incr) before b (incr) */
+    }
+
+    if (a->incremental && !b->incremental) {
+        return 1;   /* b (non-incr) before a (incr) */
+    }
+
+    return 0;  /* Same urgency and same incremental status */
+}
+
+
+u_char *
+ngx_http_priority_format(u_char *buf, ngx_http_priority_t *p)
+{
+    /*
+     * Format priority as RFC9218/RFC8941 Structured Fields Dictionary.
+     *
+     * Output formats:
+     *   "u=0"     - urgency only (non-default)
+     *   "u=0, i"  - urgency and incremental
+     *   "i"       - incremental only (default urgency)
+     *
+     * If urgency is default (3) and incremental is false, returns empty.
+     */
+
+    u_char  *start = buf;
+
+    if (p->urgency != NGX_HTTP_PRIORITY_DEFAULT_URGENCY) {
+        buf = ngx_sprintf(buf, "u=%ui", p->urgency);
+    }
+
+    if (p->incremental) {
+        if (buf != start) {
+            *buf++ = ',';
+            *buf++ = ' ';
+        }
+        *buf++ = 'i';
+    }
+
+    return buf;
+}

--- a/src/http/ngx_http_priority.h
+++ b/src/http/ngx_http_priority.h
@@ -1,0 +1,96 @@
+
+/*
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#ifndef _NGX_HTTP_PRIORITY_H_INCLUDED_
+#define _NGX_HTTP_PRIORITY_H_INCLUDED_
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+
+
+/*
+ * RFC9218: Extensible Prioritization Scheme for HTTP
+ *
+ * Priority parameters:
+ *   - urgency (u): Integer 0-7, lower is more urgent, default 3
+ *   - incremental (i): Boolean, whether response can be processed
+ *                      incrementally, default false
+ */
+
+
+#define NGX_HTTP_PRIORITY_DEFAULT_URGENCY     3
+#define NGX_HTTP_PRIORITY_URGENCY_MIN         0
+#define NGX_HTTP_PRIORITY_URGENCY_MAX         7
+
+#define NGX_HTTP_PRIORITY_URGENCY_BACKGROUND  7
+
+
+typedef struct {
+    ngx_uint_t   urgency;          /* 0-7, default 3, lower = more urgent */
+    unsigned     incremental:1;    /* default 0 (false) */
+    unsigned     valid:1;          /* 1 if any parameter explicitly set */
+    unsigned     urgency_set:1;    /* 1 if urgency explicitly set */
+    unsigned     incremental_set:1;/* 1 if incremental explicitly set */
+} ngx_http_priority_t;
+
+
+/*
+ * Initialize priority to default values (u=3, i=false)
+ */
+#define ngx_http_priority_init(p)                                             \
+    do {                                                                      \
+        (p)->urgency = NGX_HTTP_PRIORITY_DEFAULT_URGENCY;                     \
+        (p)->incremental = 0;                                                 \
+        (p)->valid = 0;                                                       \
+        (p)->urgency_set = 0;                                                 \
+        (p)->incremental_set = 0;                                             \
+    } while (0)
+
+
+/*
+ * Parse RFC9218 Priority header value (Structured Fields Dictionary).
+ *
+ * Format: "u=<0-7>, i" or "u=<0-7>" or "i" or empty
+ * Examples:
+ *   "u=0"       -> urgency=0, incremental=false
+ *   "u=5, i"    -> urgency=5, incremental=true
+ *   "i"         -> urgency=3 (default), incremental=true
+ *   "u=3, i=?1" -> urgency=3, incremental=true
+ *
+ * Invalid or out-of-range values are ignored (defaults preserved).
+ */
+ngx_int_t ngx_http_priority_parse(ngx_str_t *value, ngx_http_priority_t *p);
+
+
+/*
+ * Merge server-provided priority with client priority per RFC9218 Section 8.
+ * Server values override client values when present.
+ */
+void ngx_http_priority_merge(ngx_http_priority_t *result,
+    ngx_http_priority_t *client, ngx_http_priority_t *server);
+
+
+/*
+ * Compare two priorities for scheduling.
+ * Returns:
+ *   < 0 if a has higher priority (lower urgency, should be sent first)
+ *   > 0 if b has higher priority
+ *   = 0 if equal priority
+ */
+ngx_int_t ngx_http_priority_compare(ngx_http_priority_t *a,
+    ngx_http_priority_t *b);
+
+
+/*
+ * Format priority as a header value (RFC8941 Structured Fields Dictionary).
+ * Returns pointer to the character after the last written byte.
+ * Writes at most 6 bytes ("u=7, i"). Caller must NUL-terminate if needed.
+ */
+u_char *ngx_http_priority_format(u_char *buf, ngx_http_priority_t *p);
+
+
+#endif /* _NGX_HTTP_PRIORITY_H_INCLUDED_ */

--- a/src/http/ngx_http_priority.h
+++ b/src/http/ngx_http_priority.h
@@ -1,0 +1,132 @@
+
+/*
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#ifndef _NGX_HTTP_PRIORITY_H_INCLUDED_
+#define _NGX_HTTP_PRIORITY_H_INCLUDED_
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+
+
+/*
+ * RFC9218: Extensible Prioritization Scheme for HTTP
+ *
+ * Priority parameters:
+ *   - urgency (u): Integer 0-7, lower is more urgent, default 3
+ *   - incremental (i): Boolean, whether response can be processed
+ *                      incrementally, default false
+ */
+
+
+#define NGX_HTTP_PRIORITY_DEFAULT_URGENCY     3
+#define NGX_HTTP_PRIORITY_URGENCY_MIN         0
+#define NGX_HTTP_PRIORITY_URGENCY_MAX         7
+
+#define NGX_HTTP_PRIORITY_URGENCY_BACKGROUND  7
+
+
+typedef struct {
+    ngx_uint_t   urgency;          /* 0-7, default 3, lower = more urgent */
+    unsigned     incremental:1;    /* default 0 (false) */
+    unsigned     valid:1;          /* 1 if any parameter explicitly set */
+    unsigned     urgency_set:1;    /* 1 if urgency explicitly set */
+    unsigned     incremental_set:1;/* 1 if incremental explicitly set */
+} ngx_http_priority_t;
+
+
+/*
+ * Initialize priority to default values (u=3, i=false)
+ */
+#define ngx_http_priority_init(p)                                             \
+    do {                                                                      \
+        (p)->urgency = NGX_HTTP_PRIORITY_DEFAULT_URGENCY;                     \
+        (p)->incremental = 0;                                                 \
+        (p)->valid = 0;                                                       \
+        (p)->urgency_set = 0;                                                 \
+        (p)->incremental_set = 0;                                             \
+    } while (0)
+
+
+/*
+ * Per-stream priority state.  RFC 9218 priority is derived from two
+ * independent inputs that can each change at any time: the client's request
+ * (its Priority request header and any later PRIORITY_UPDATE frames) and the
+ * server's response hint (an upstream Priority response header, RFC 9218
+ * Section 8).  Keeping them separate lets the effective, scheduled priority
+ * be recomputed by merging the two whenever either input changes -- so a
+ * later client PRIORITY_UPDATE no longer discards a previously merged server
+ * hint, and vice versa.  "effective" is the merged result actually used for
+ * scheduling and pushed to the transport.
+ */
+typedef struct {
+    ngx_http_priority_t   client;
+    ngx_http_priority_t   server;
+    ngx_http_priority_t   effective;
+} ngx_http_priority_state_t;
+
+
+/*
+ * Initialize all three priority slots to defaults.
+ */
+#define ngx_http_priority_state_init(ps)                                      \
+    do {                                                                      \
+        ngx_http_priority_init(&(ps)->client);                               \
+        ngx_http_priority_init(&(ps)->server);                               \
+        ngx_http_priority_init(&(ps)->effective);                            \
+    } while (0)
+
+
+/*
+ * Parse RFC9218 Priority header value (Structured Fields Dictionary).
+ *
+ * Format: "u=<0-7>, i" or "u=<0-7>" or "i" or empty
+ * Examples:
+ *   "u=0"       -> urgency=0, incremental=false
+ *   "u=5, i"    -> urgency=5, incremental=true
+ *   "i"         -> urgency=3 (default), incremental=true
+ *   "u=3, i=?1" -> urgency=3, incremental=true
+ *
+ * Invalid or out-of-range values are ignored (defaults preserved).
+ */
+ngx_int_t ngx_http_priority_parse(ngx_str_t *value, ngx_http_priority_t *p);
+
+
+/*
+ * Merge server-provided priority with client priority per RFC9218 Section 8.
+ * Server values override client values when present.
+ */
+void ngx_http_priority_merge(ngx_http_priority_t *result,
+    ngx_http_priority_t *client, ngx_http_priority_t *server);
+
+
+/*
+ * Recompute ps->effective by merging the current client and server inputs.
+ * Call after updating either ps->client or ps->server.
+ */
+void ngx_http_priority_state_update(ngx_http_priority_state_t *ps);
+
+
+/*
+ * Compare two priorities for scheduling.
+ * Returns:
+ *   < 0 if a has higher priority (lower urgency, should be sent first)
+ *   > 0 if b has higher priority
+ *   = 0 if equal priority
+ */
+ngx_int_t ngx_http_priority_compare(ngx_http_priority_t *a,
+    ngx_http_priority_t *b);
+
+
+/*
+ * Format priority as a header value (RFC8941 Structured Fields Dictionary).
+ * Returns pointer to the character after the last written byte.
+ * Writes at most 6 bytes ("u=7, i"). Caller must NUL-terminate if needed.
+ */
+u_char *ngx_http_priority_format(u_char *buf, ngx_http_priority_t *p);
+
+
+#endif /* _NGX_HTTP_PRIORITY_H_INCLUDED_ */

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -139,6 +139,8 @@ static ngx_int_t
     ngx_table_elt_t *h, ngx_uint_t offset);
 static ngx_int_t ngx_http_upstream_process_vary(ngx_http_request_t *r,
     ngx_table_elt_t *h, ngx_uint_t offset);
+static ngx_int_t ngx_http_upstream_process_priority(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset);
 static ngx_int_t ngx_http_upstream_copy_header_line(ngx_http_request_t *r,
     ngx_table_elt_t *h, ngx_uint_t offset);
 static ngx_int_t
@@ -335,6 +337,10 @@ static ngx_http_upstream_header_t  ngx_http_upstream_headers_in[] = {
                  ngx_http_upstream_ignore_header_line, 0,
                  ngx_http_upstream_copy_header_line,
                  offsetof(ngx_http_headers_out_t, content_encoding), 0 },
+
+    { ngx_string("Priority"),
+                 ngx_http_upstream_process_priority, 0,
+                 ngx_http_upstream_copy_header_line, 0, 0 },
 
     { ngx_null_string, NULL, 0, NULL, 0, 0 }
 };
@@ -5587,6 +5593,57 @@ ngx_http_upstream_process_vary(ngx_http_request_t *r,
     }
 
     r->cache->vary = vary;
+    }
+#endif
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_process_priority(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset)
+{
+#if (NGX_HTTP_V2)
+    ngx_http_priority_t    server_priority;
+    ngx_http_v2_stream_t  *stream;
+
+    /*
+     * RFC9218 Section 8: Intermediaries can combine server priority hints
+     * with client priority.  When the upstream sends a Priority header,
+     * merge it with the client's requested priority and update the header
+     * to reflect the merged value per RFC9218 Section 5.4.
+     */
+
+    stream = r->stream;
+
+    if (stream != NULL) {
+        if (ngx_http_priority_parse(&h->value, &server_priority) == NGX_OK
+            && server_priority.valid)
+        {
+            ngx_http_priority_merge(&stream->priority,
+                                    &stream->priority,
+                                    &server_priority);
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http2 upstream priority merged: u=%ui i=%ui",
+                           stream->priority.urgency,
+                           stream->priority.incremental);
+
+            /*
+             * Update header value to reflect merged priority.
+             * Buffer needs space for "u=N, i" (max 6 bytes) plus NUL.
+             */
+            h->value.data = ngx_pnalloc(r->pool, 7);
+            if (h->value.data == NULL) {
+                return NGX_ERROR;
+            }
+
+            h->value.len = ngx_http_priority_format(h->value.data,
+                                                    &stream->priority)
+                           - h->value.data;
+            h->value.data[h->value.len] = '\0';
+        }
     }
 #endif
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -139,6 +139,8 @@ static ngx_int_t
     ngx_table_elt_t *h, ngx_uint_t offset);
 static ngx_int_t ngx_http_upstream_process_vary(ngx_http_request_t *r,
     ngx_table_elt_t *h, ngx_uint_t offset);
+static ngx_int_t ngx_http_upstream_process_priority(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset);
 static ngx_int_t ngx_http_upstream_copy_header_line(ngx_http_request_t *r,
     ngx_table_elt_t *h, ngx_uint_t offset);
 static ngx_int_t
@@ -335,6 +337,10 @@ static ngx_http_upstream_header_t  ngx_http_upstream_headers_in[] = {
                  ngx_http_upstream_ignore_header_line, 0,
                  ngx_http_upstream_copy_header_line,
                  offsetof(ngx_http_headers_out_t, content_encoding), 0 },
+
+    { ngx_string("Priority"),
+                 ngx_http_upstream_process_priority, 0,
+                 ngx_http_upstream_copy_header_line, 0, 0 },
 
     { ngx_null_string, NULL, 0, NULL, 0, 0 }
 };
@@ -5587,6 +5593,59 @@ ngx_http_upstream_process_vary(ngx_http_request_t *r,
     }
 
     r->cache->vary = vary;
+    }
+#endif
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_process_priority(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset)
+{
+#if (NGX_HTTP_V2)
+    ngx_http_priority_t    server_priority;
+    ngx_http_v2_stream_t  *stream;
+
+    /*
+     * RFC9218 Section 8: Intermediaries can combine server priority hints
+     * with client priority.  When the upstream sends a Priority header,
+     * record it as the stream's server priority and recompute the effective
+     * priority by merging it with the client's requested value, then update
+     * the header to reflect the merged value per RFC9218 Section 5.4.  The
+     * client and server inputs are kept separately so a later client
+     * PRIORITY_UPDATE does not discard this server hint.
+     */
+
+    stream = r->stream;
+
+    if (stream != NULL) {
+        if (ngx_http_priority_parse(&h->value, &server_priority) == NGX_OK
+            && server_priority.valid)
+        {
+            stream->priority.server = server_priority;
+            ngx_http_priority_state_update(&stream->priority);
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http2 upstream priority merged: u=%ui i=%ui",
+                           stream->priority.effective.urgency,
+                           stream->priority.effective.incremental);
+
+            /*
+             * Update header value to reflect merged priority.
+             * Buffer needs space for "u=N, i" (max 6 bytes) plus NUL.
+             */
+            h->value.data = ngx_pnalloc(r->pool, 7);
+            if (h->value.data == NULL) {
+                return NGX_ERROR;
+            }
+
+            h->value.len = ngx_http_priority_format(h->value.data,
+                                                    &stream->priority.effective)
+                           - h->value.data;
+            h->value.data[h->value.len] = '\0';
+        }
     }
 #endif
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -86,6 +86,8 @@ static u_char *ngx_http_v2_handle_continuation(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end, ngx_http_v2_handler_pt handler);
 static u_char *ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
+static u_char *ngx_http_v2_state_priority_update(ngx_http_v2_connection_t *h2c,
+    u_char *pos, u_char *end);
 static u_char *ngx_http_v2_state_rst_stream(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
 static u_char *ngx_http_v2_state_settings(ngx_http_v2_connection_t *h2c,
@@ -907,6 +909,11 @@ ngx_http_v2_state_head(ngx_http_v2_connection_t *h2c, u_char *pos, u_char *end)
                    "http2 frame type:%ui f:%Xd l:%uz sid:%ui",
                    type, h2c->state.flags, h2c->state.length, h2c->state.sid);
 
+    /* RFC9218: Handle PRIORITY_UPDATE frame (type 0x10) */
+    if (type == NGX_HTTP_V2_PRIORITY_UPDATE_FRAME) {
+        return ngx_http_v2_state_priority_update(h2c, pos, end);
+    }
+
     if (type >= NGX_HTTP_V2_FRAME_STATES) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
                       "client sent frame with unknown type %ui", type);
@@ -1338,6 +1345,42 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     node->stream = stream;
 
+    /*
+     * RFC9218: Apply any pending priority updates for this stream.
+     * PRIORITY_UPDATE frames may arrive before HEADERS.
+     */
+    if (h2c->pending_priorities) {
+        ngx_uint_t                       i, n;
+        ngx_http_v2_pending_priority_t  *pp;
+
+        pp = h2c->pending_priorities->elts;
+        n = h2c->pending_priorities->nelts;
+
+        for (i = 0; i < n; i++) {
+            if (pp[i].sid == node->id) {
+                stream->priority = pp[i].priority;
+
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                               "http2 applied pending priority for stream %ui: "
+                               "u=%ui", node->id, stream->priority.urgency);
+
+                /* Remove entry: swap with last and decrement count */
+                n--;
+                if (i < n) {
+                    pp[i] = pp[n];
+                }
+                h2c->pending_priorities->nelts = n;
+                break;
+            }
+        }
+    }
+
+    /*
+     * RFC9218: Even when RFC9218 is enabled, we still need to set up the
+     * node tree structure for proper node lifecycle management (the closed
+     * queue uses the node's queue member). We just don't use the dependency
+     * tree for scheduling.
+     */
     if (priority || node->parent == NULL) {
         node->weight = weight;
         ngx_http_v2_set_dependency(h2c, node, depend, excl);
@@ -1832,15 +1875,23 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
         && ngx_memcmp(header->name.data, priority_name.data,
                       priority_name.len) == 0)
     {
-        if (ngx_http_priority_parse(&header->value,
-                                    &h2c->state.stream->priority) == NGX_OK)
-        {
+        ngx_http_priority_t  tmp;
+
+        ngx_http_priority_parse(&header->value, &tmp);
+
+        /*
+         * Only apply if value is empty (explicit reset) or at least one
+         * parameter was recognized.  This prevents malformed values from
+         * clobbering valid priorities set via PRIORITY_UPDATE.
+         */
+        if (header->value.len == 0 || tmp.valid) {
+            h2c->state.stream->priority = tmp;
+
             ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                            "http2 priority header: u=%ui, i=%ui",
                            h2c->state.stream->priority.urgency,
                            h2c->state.stream->priority.incremental);
         }
-        /* Malformed priority values use defaults per RFC9218 */
     }
 
     if (header->name.len == cookie.len
@@ -2026,13 +2077,6 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
     }
 
-    if (--h2c->priority_limit == 0) {
-        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
-                      "client sent too many PRIORITY frames");
-
-        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
-    }
-
     if (end - pos < NGX_HTTP_V2_PRIORITY_SIZE) {
         return ngx_http_v2_state_save(h2c, pos, end,
                                       ngx_http_v2_state_priority);
@@ -2066,6 +2110,35 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
     }
 
+    /*
+     * RFC9218: When RFC9218 is enabled, ignore PRIORITY frames after
+     * validating them. Protocol errors are still detected.
+     *
+     * Only ignore after settings_ack, since the client may have sent
+     * PRIORITY frames before receiving our SETTINGS with NO_RFC7540_PRIORITIES.
+     *
+     * Ignored frames still count against priority_limit for flood protection.
+     */
+    if (h2c->settings_ack) {
+        if (--h2c->priority_limit == 0) {
+            ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                          "client sent too many PRIORITY frames");
+            return ngx_http_v2_connection_error(h2c,
+                                                NGX_HTTP_V2_ENHANCE_YOUR_CALM);
+        }
+
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                       "http2 PRIORITY frame ignored (RFC9218 mode)");
+        return ngx_http_v2_state_complete(h2c, pos, end);
+    }
+
+    if (--h2c->priority_limit == 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent too many PRIORITY frames");
+
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
+    }
+
     node = ngx_http_v2_get_node_by_id(h2c, h2c->state.sid, 1);
 
     if (node == NULL) {
@@ -2087,6 +2160,178 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     ngx_http_v2_set_dependency(h2c, node, depend, excl);
 
+    return ngx_http_v2_state_complete(h2c, pos, end);
+}
+
+
+static u_char *
+ngx_http_v2_state_priority_update(ngx_http_v2_connection_t *h2c, u_char *pos,
+    u_char *end)
+{
+    size_t                           len;
+    ngx_str_t                        value;
+    ngx_uint_t                       i, sid;
+    ngx_http_v2_node_t              *node;
+    ngx_http_priority_t              priority;
+    ngx_http_v2_stream_t            *stream;
+    ngx_http_v2_srv_conf_t          *h2scf;
+    ngx_http_v2_pending_priority_t  *pp;
+
+    /*
+     * RFC9218: PRIORITY_UPDATE frame format:
+     *   - Prioritized Stream ID (31 bits)
+     *   - Priority Field Value (variable length)
+     *
+     * Must be sent on stream 0, for client-initiated streams only.
+     */
+
+    if (h2c->state.sid != 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent PRIORITY_UPDATE frame on non-zero stream");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
+    }
+
+    if (h2c->state.length < 4) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent PRIORITY_UPDATE frame too short");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
+    }
+
+    len = h2c->state.length;
+
+    if ((size_t) (end - pos) < len) {
+        /*
+         * Frame is fragmented.  Only buffer if it fits in state buffer,
+         * otherwise skip to avoid overflow.
+         */
+        if (len > NGX_HTTP_V2_STATE_BUFFER_SIZE) {
+            if (--h2c->priority_limit == 0) {
+                ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                              "client sent too many PRIORITY_UPDATE frames");
+                return ngx_http_v2_connection_error(h2c,
+                                                NGX_HTTP_V2_ENHANCE_YOUR_CALM);
+            }
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                           "http2 PRIORITY_UPDATE frame too large to buffer: "
+                           "%uz", len);
+            return ngx_http_v2_state_skip(h2c, pos, end);
+        }
+
+        return ngx_http_v2_state_save(h2c, pos, end,
+                                      ngx_http_v2_state_priority_update);
+    }
+
+    if (--h2c->priority_limit == 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent too many PRIORITY_UPDATE frames");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
+    }
+
+    /* Parse Prioritized Stream ID (first 4 bytes, top bit reserved) */
+    sid = ngx_http_v2_parse_uint32(pos) & 0x7fffffff;
+    pos += 4;
+    len -= 4;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 PRIORITY_UPDATE frame for stream %ui, len=%uz",
+                   sid, len);
+
+    /* Must be odd (client-initiated) */
+    if (sid == 0 || (sid & 1) == 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent PRIORITY_UPDATE for invalid stream %ui",
+                      sid);
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
+    }
+
+    /* Parse Priority Field Value */
+    value.data = pos;
+    value.len = len;
+
+    ngx_http_priority_parse(&value, &priority);
+
+    /*
+     * Only apply if value is empty (explicit reset) or at least one
+     * parameter was recognized.  This prevents malformed values from
+     * clobbering previously set valid priorities.
+     */
+    if (value.len != 0 && !priority.valid) {
+        goto done;
+    }
+
+    node = ngx_http_v2_get_node_by_id(h2c, sid, 0);
+
+    if (node && node->stream) {
+        /* Stream exists, apply priority immediately */
+        stream = node->stream;
+        stream->priority = priority;
+
+        ngx_log_debug3(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                       "http2 PRIORITY_UPDATE applied to stream %ui: "
+                       "u=%ui, i=%ui",
+                       sid, stream->priority.urgency,
+                       stream->priority.incremental);
+
+    } else if (sid > h2c->last_sid) {
+        /*
+         * Stream doesn't exist yet (sid > last_sid), buffer the priority.
+         * If sid <= last_sid, the stream already existed and is now closed,
+         * so there's no point buffering since it will never be created again.
+         */
+        h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                             ngx_http_v2_module);
+
+        if (h2c->pending_priorities == NULL) {
+            h2c->pending_priorities = ngx_array_create(h2c->pool, 4,
+                                        sizeof(ngx_http_v2_pending_priority_t));
+            if (h2c->pending_priorities == NULL) {
+                return ngx_http_v2_connection_error(h2c,
+                                                    NGX_HTTP_V2_INTERNAL_ERROR);
+            }
+        }
+
+        /* Check if we already have a pending priority for this stream */
+        pp = h2c->pending_priorities->elts;
+        for (i = 0; i < h2c->pending_priorities->nelts; i++) {
+            if (pp[i].sid == sid) {
+                /* Update existing entry */
+                pp[i].priority = priority;
+
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                               "http2 PRIORITY_UPDATE updated pending for "
+                               "stream %ui: u=%ui",
+                               sid, pp[i].priority.urgency);
+                goto done;
+            }
+        }
+
+        /* Cap pending priorities at max_concurrent_streams */
+        if (h2c->pending_priorities->nelts >= h2scf->concurrent_streams) {
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                           "http2 PRIORITY_UPDATE ignored, pending limit "
+                           "reached for stream %ui", sid);
+            goto done;
+        }
+
+        /* Add new pending entry */
+        pp = ngx_array_push(h2c->pending_priorities);
+        if (pp == NULL) {
+            return ngx_http_v2_connection_error(h2c,
+                                                NGX_HTTP_V2_INTERNAL_ERROR);
+        }
+
+        pp->sid = sid;
+        pp->priority = priority;
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                       "http2 PRIORITY_UPDATE buffered for stream "
+                       "%ui: u=%ui", sid, pp->priority.urgency);
+    }
+
+done:
+
+    pos += h2c->state.length - 4;
     return ngx_http_v2_state_complete(h2c, pos, end);
 }
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1721,6 +1721,7 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
     ngx_http_core_main_conf_t  *cmcf;
 
     static ngx_str_t cookie = ngx_string("cookie");
+    static ngx_str_t priority_name = ngx_string("priority");
 
     header = &h2c->state.header;
 
@@ -1817,6 +1818,29 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
 
             return ngx_http_v2_state_header_complete(h2c, pos, end);
         }
+    }
+
+    /*
+     * RFC9218: Handle Priority request header for extensible priorities.
+     * Parse and store the priority parameters in the stream, but continue
+     * normal header processing so the header is visible to variables and
+     * forwarding.
+     *
+     * Parse the Priority header for RFC9218 extensible priorities.
+     */
+    if (header->name.len == priority_name.len
+        && ngx_memcmp(header->name.data, priority_name.data,
+                      priority_name.len) == 0)
+    {
+        if (ngx_http_priority_parse(&header->value,
+                                    &h2c->state.stream->priority) == NGX_OK)
+        {
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http2 priority header: u=%ui, i=%ui",
+                           h2c->state.stream->priority.urgency,
+                           h2c->state.stream->priority.incremental);
+        }
+        /* Malformed priority values use defaults per RFC9218 */
     }
 
     if (header->name.len == cookie.len

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -47,8 +47,6 @@
 
 #define NGX_HTTP_V2_FRAME_BUFFER_SIZE            24
 
-#define NGX_HTTP_V2_ROOT                         (void *) -1
-
 
 static void ngx_http_v2_read_handler(ngx_event_t *rev);
 static void ngx_http_v2_write_handler(ngx_event_t *wev);
@@ -288,7 +286,6 @@ ngx_http_v2_init(ngx_event_t *rev)
     h2c->state.handler = ngx_http_v2_state_preface;
 
     ngx_queue_init(&h2c->waiting);
-    ngx_queue_init(&h2c->dependencies);
     ngx_queue_init(&h2c->closed);
 
     c->data = h2c;
@@ -1300,11 +1297,6 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
     }
 
-    if (node->parent) {
-        ngx_queue_remove(&node->reuse);
-        h2c->closed_nodes--;
-    }
-
     stream = ngx_http_v2_create_stream(h2c);
     if (stream == NULL) {
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
@@ -2032,7 +2024,7 @@ static u_char *
 ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
     u_char *end)
 {
-    ngx_uint_t  depend, dependency, excl, weight;
+    ngx_uint_t  depend;
 
     if (h2c->state.length != NGX_HTTP_V2_PRIORITY_SIZE) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
@@ -2047,18 +2039,13 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
                                       ngx_http_v2_state_priority);
     }
 
-    dependency = ngx_http_v2_parse_uint32(pos);
-
-    depend = dependency & 0x7fffffff;
-    excl = dependency >> 31;
-    weight = pos[4] + 1;
+    depend = ngx_http_v2_parse_uint32(pos) & 0x7fffffff;
 
     pos += NGX_HTTP_V2_PRIORITY_SIZE;
 
-    ngx_log_debug4(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
-                   "http2 PRIORITY frame sid:%ui "
-                   "depends on %ui excl:%ui weight:%ui",
-                   h2c->state.sid, depend, excl, weight);
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 PRIORITY frame sid:%ui ignored",
+                   h2c->state.sid);
 
     if (h2c->state.sid == 0) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
@@ -2075,18 +2062,11 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
     }
 
-    /*
-     * RFC9218: PRIORITY frames are ignored.  Protocol errors are still
-     * detected above.  Flood protection via priority_limit.
-     */
     if (--h2c->priority_limit == 0) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
                       "client sent too many PRIORITY frames");
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
     }
-
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
-                   "http2 PRIORITY frame ignored (RFC9218)");
 
     return ngx_http_v2_state_complete(h2c, pos, end);
 }
@@ -3372,8 +3352,6 @@ ngx_http_v2_get_node_by_id(ngx_http_v2_connection_t *h2c, ngx_uint_t sid,
 
     node->id = sid;
 
-    ngx_queue_init(&node->children);
-
     node->index = h2c->streams_index[index];
     h2c->streams_index[index] = node;
 
@@ -3384,12 +3362,8 @@ ngx_http_v2_get_node_by_id(ngx_http_v2_connection_t *h2c, ngx_uint_t sid,
 static ngx_http_v2_node_t *
 ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
 {
-    ngx_queue_t             *q;
-    ngx_http_v2_node_t      *node, **next, *n;
-    ngx_http_v2_srv_conf_t  *h2scf;
-
-    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
-                                         ngx_http_v2_module);
+    ngx_queue_t         *q;
+    ngx_http_v2_node_t  *node;
 
     h2c->closed_nodes--;
 
@@ -3398,19 +3372,6 @@ ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
     ngx_queue_remove(q);
 
     node = ngx_queue_data(q, ngx_http_v2_node_t, reuse);
-
-    next = &h2c->streams_index[ngx_http_v2_index(h2scf, node->id)];
-
-    for ( ;; ) {
-        n = *next;
-
-        if (n == node) {
-            *next = n->index;
-            break;
-        }
-
-        next = &n->index;
-    }
 
     ngx_memzero(node, sizeof(ngx_http_v2_node_t));
 
@@ -4735,7 +4696,8 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
     ngx_pool_t                *pool;
     ngx_event_t               *ev;
     ngx_connection_t          *fc;
-    ngx_http_v2_node_t        *node;
+    ngx_http_v2_node_t        *node, **next, *n;
+    ngx_http_v2_srv_conf_t    *h2scf;
     ngx_http_v2_connection_t  *h2c;
 
     h2c = stream->connection;
@@ -4779,6 +4741,23 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
     }
 
     node->stream = NULL;
+
+    /* Remove node from streams_index before adding to closed queue */
+    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                         ngx_http_v2_module);
+
+    next = &h2c->streams_index[ngx_http_v2_index(h2scf, node->id)];
+
+    for ( ;; ) {
+        n = *next;
+
+        if (n == node) {
+            *next = n->index;
+            break;
+        }
+
+        next = &n->index;
+    }
 
     ngx_queue_insert_tail(&h2c->closed, &node->reuse);
     h2c->closed_nodes++;

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -179,9 +179,6 @@ static void ngx_http_v2_finalize_connection(ngx_http_v2_connection_t *h2c,
 
 static ngx_int_t ngx_http_v2_adjust_windows(ngx_http_v2_connection_t *h2c,
     ssize_t delta);
-static void ngx_http_v2_set_dependency(ngx_http_v2_connection_t *h2c,
-    ngx_http_v2_node_t *node, ngx_uint_t depend, ngx_uint_t exclusive);
-static void ngx_http_v2_node_children_update(ngx_http_v2_node_t *node);
 
 static void ngx_http_v2_pool_cleanup(void *data);
 
@@ -1172,8 +1169,7 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
     u_char *end)
 {
     size_t                     size;
-    ngx_uint_t                 padded, priority, depend, dependency, excl,
-                               weight;
+    ngx_uint_t                 padded, priority;
     ngx_uint_t                 status;
     ngx_http_v2_node_t        *node;
     ngx_http_v2_stream_t      *stream;
@@ -1238,37 +1234,18 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
         h2c->state.length -= h2c->state.padding;
     }
 
-    depend = 0;
-    excl = 0;
-    weight = NGX_HTTP_V2_DEFAULT_WEIGHT;
-
     if (priority) {
-        dependency = ngx_http_v2_parse_uint32(pos);
-
-        depend = dependency & 0x7fffffff;
-        excl = dependency >> 31;
-        weight = pos[4] + 1;
-
+        /* Skip RFC7540 priority data; RFC9218 uses Priority header instead */
         pos += sizeof(uint32_t) + 1;
     }
 
-    ngx_log_debug4(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
-                   "http2 HEADERS frame sid:%ui "
-                   "depends on %ui excl:%ui weight:%ui",
-                   h2c->state.sid, depend, excl, weight);
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 HEADERS frame sid:%ui", h2c->state.sid);
 
     if (h2c->state.sid % 2 == 0 || h2c->state.sid <= h2c->last_sid) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
                       "client sent HEADERS frame with incorrect identifier "
                       "%ui, the last was %ui", h2c->state.sid, h2c->last_sid);
-
-        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
-    }
-
-    if (depend == h2c->state.sid) {
-        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
-                      "client sent HEADERS frame for stream %ui "
-                      "with incorrect dependency", h2c->state.sid);
 
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
     }
@@ -1373,17 +1350,6 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
                 break;
             }
         }
-    }
-
-    /*
-     * RFC9218: Even when RFC9218 is enabled, we still need to set up the
-     * node tree structure for proper node lifecycle management (the closed
-     * queue uses the node's queue member). We just don't use the dependency
-     * tree for scheduling.
-     */
-    if (priority || node->parent == NULL) {
-        node->weight = weight;
-        ngx_http_v2_set_dependency(h2c, node, depend, excl);
     }
 
     clcf = ngx_http_get_module_loc_conf(h2c->http_connection->conf_ctx,
@@ -3418,9 +3384,8 @@ ngx_http_v2_get_node_by_id(ngx_http_v2_connection_t *h2c, ngx_uint_t sid,
 static ngx_http_v2_node_t *
 ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
 {
-    ngx_uint_t               weight;
-    ngx_queue_t             *q, *children;
-    ngx_http_v2_node_t      *node, **next, *n, *parent, *child;
+    ngx_queue_t             *q;
+    ngx_http_v2_node_t      *node, **next, *n;
     ngx_http_v2_srv_conf_t  *h2scf;
 
     h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
@@ -3446,49 +3411,6 @@ ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
 
         next = &n->index;
     }
-
-    ngx_queue_remove(&node->queue);
-
-    weight = 0;
-
-    for (q = ngx_queue_head(&node->children);
-         q != ngx_queue_sentinel(&node->children);
-         q = ngx_queue_next(q))
-    {
-        child = ngx_queue_data(q, ngx_http_v2_node_t, queue);
-        weight += child->weight;
-    }
-
-    parent = node->parent;
-
-    for (q = ngx_queue_head(&node->children);
-         q != ngx_queue_sentinel(&node->children);
-         q = ngx_queue_next(q))
-    {
-        child = ngx_queue_data(q, ngx_http_v2_node_t, queue);
-        child->parent = parent;
-        child->weight = node->weight * child->weight / weight;
-
-        if (child->weight == 0) {
-            child->weight = 1;
-        }
-    }
-
-    if (parent == NGX_HTTP_V2_ROOT) {
-        node->rank = 0;
-        node->rel_weight = 1.0;
-
-        children = &h2c->dependencies;
-
-    } else {
-        node->rank = parent->rank;
-        node->rel_weight = parent->rel_weight;
-
-        children = &parent->children;
-    }
-
-    ngx_http_v2_node_children_update(node);
-    ngx_queue_add(children, &node->children);
 
     ngx_memzero(node, sizeof(ngx_http_v2_node_t));
 
@@ -5206,117 +5128,6 @@ ngx_http_v2_adjust_windows(ngx_http_v2_connection_t *h2c, ssize_t delta)
     }
 
     return NGX_OK;
-}
-
-
-static void
-ngx_http_v2_set_dependency(ngx_http_v2_connection_t *h2c,
-    ngx_http_v2_node_t *node, ngx_uint_t depend, ngx_uint_t exclusive)
-{
-    ngx_queue_t         *children, *q;
-    ngx_http_v2_node_t  *parent, *child, *next;
-
-    parent = depend ? ngx_http_v2_get_node_by_id(h2c, depend, 0) : NULL;
-
-    if (parent == NULL) {
-        parent = NGX_HTTP_V2_ROOT;
-
-        if (depend != 0) {
-            exclusive = 0;
-        }
-
-        node->rank = 1;
-        node->rel_weight = (1.0 / 256) * node->weight;
-
-        children = &h2c->dependencies;
-
-    } else {
-        if (node->parent != NULL) {
-
-            for (next = parent->parent;
-                 next != NGX_HTTP_V2_ROOT && next->rank >= node->rank;
-                 next = next->parent)
-            {
-                if (next != node) {
-                    continue;
-                }
-
-                ngx_queue_remove(&parent->queue);
-                ngx_queue_insert_after(&node->queue, &parent->queue);
-
-                parent->parent = node->parent;
-
-                if (node->parent == NGX_HTTP_V2_ROOT) {
-                    parent->rank = 1;
-                    parent->rel_weight = (1.0 / 256) * parent->weight;
-
-                } else {
-                    parent->rank = node->parent->rank + 1;
-                    parent->rel_weight = (node->parent->rel_weight / 256)
-                                         * parent->weight;
-                }
-
-                if (!exclusive) {
-                    ngx_http_v2_node_children_update(parent);
-                }
-
-                break;
-            }
-        }
-
-        node->rank = parent->rank + 1;
-        node->rel_weight = (parent->rel_weight / 256) * node->weight;
-
-        if (parent->stream == NULL) {
-            ngx_queue_remove(&parent->reuse);
-            ngx_queue_insert_tail(&h2c->closed, &parent->reuse);
-        }
-
-        children = &parent->children;
-    }
-
-    if (exclusive) {
-        for (q = ngx_queue_head(children);
-             q != ngx_queue_sentinel(children);
-             q = ngx_queue_next(q))
-        {
-            child = ngx_queue_data(q, ngx_http_v2_node_t, queue);
-            child->parent = node;
-        }
-
-        ngx_queue_add(&node->children, children);
-        ngx_queue_init(children);
-    }
-
-    if (node->parent != NULL) {
-        ngx_queue_remove(&node->queue);
-    }
-
-    ngx_queue_insert_tail(children, &node->queue);
-
-    node->parent = parent;
-
-    ngx_http_v2_node_children_update(node);
-}
-
-
-static void
-ngx_http_v2_node_children_update(ngx_http_v2_node_t *node)
-{
-    ngx_queue_t         *q;
-    ngx_http_v2_node_t  *child;
-
-    for (q = ngx_queue_head(&node->children);
-         q != ngx_queue_sentinel(&node->children);
-         q = ngx_queue_next(q))
-    {
-        child = ngx_queue_data(q, ngx_http_v2_node_t, queue);
-
-        child->rank = node->rank + 1;
-        child->rel_weight = (node->rel_weight / 256) * child->weight;
-
-        ngx_http_v2_node_children_update(child);
-    }
 }
 
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -38,11 +38,12 @@
 #define NGX_HTTP_V2_SETTINGS_PARAM_SIZE          6
 
 /* settings fields */
-#define NGX_HTTP_V2_HEADER_TABLE_SIZE_SETTING    0x1
-#define NGX_HTTP_V2_ENABLE_PUSH_SETTING          0x2
-#define NGX_HTTP_V2_MAX_STREAMS_SETTING          0x3
-#define NGX_HTTP_V2_INIT_WINDOW_SIZE_SETTING     0x4
-#define NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING       0x5
+#define NGX_HTTP_V2_HEADER_TABLE_SIZE_SETTING      0x1
+#define NGX_HTTP_V2_ENABLE_PUSH_SETTING            0x2
+#define NGX_HTTP_V2_MAX_STREAMS_SETTING            0x3
+#define NGX_HTTP_V2_INIT_WINDOW_SIZE_SETTING       0x4
+#define NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING         0x5
+#define NGX_HTTP_V2_NO_RFC7540_PRIORITIES_SETTING  0x9
 
 #define NGX_HTTP_V2_FRAME_BUFFER_SIZE            24
 
@@ -2735,7 +2736,14 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
         return NGX_ERROR;
     }
 
-    len = NGX_HTTP_V2_SETTINGS_PARAM_SIZE * 3;
+    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                         ngx_http_v2_module);
+
+    /*
+     * Settings: MAX_STREAMS, INIT_WINDOW_SIZE, MAX_FRAME_SIZE,
+     * NO_RFC7540_PRIORITIES
+     */
+    len = NGX_HTTP_V2_SETTINGS_PARAM_SIZE * 4;
 
     buf = ngx_create_temp_buf(h2c->pool, NGX_HTTP_V2_FRAME_HEADER_SIZE + len);
     if (buf == NULL) {
@@ -2763,9 +2771,6 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
 
     buf->last = ngx_http_v2_write_sid(buf->last, 0);
 
-    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
-                                         ngx_http_v2_module);
-
     buf->last = ngx_http_v2_write_uint16(buf->last,
                                          NGX_HTTP_V2_MAX_STREAMS_SETTING);
     buf->last = ngx_http_v2_write_uint32(buf->last,
@@ -2779,6 +2784,14 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
                                          NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING);
     buf->last = ngx_http_v2_write_uint32(buf->last,
                                          NGX_HTTP_V2_MAX_FRAME_SIZE);
+
+    /* RFC9218: Signal that we use extensible priorities */
+    buf->last = ngx_http_v2_write_uint16(buf->last,
+                                NGX_HTTP_V2_NO_RFC7540_PRIORITIES_SETTING);
+    buf->last = ngx_http_v2_write_uint32(buf->last, 1);
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 RFC9218 extensible priorities enabled");
 
     ngx_http_v2_queue_blocked_frame(h2c, frame);
 
@@ -3105,6 +3118,9 @@ ngx_http_v2_create_stream(ngx_http_v2_connection_t *h2c)
 
     stream->request = r;
     stream->connection = h2c;
+
+    /* RFC9218: Initialize with default priority */
+    ngx_http_priority_init(&stream->priority);
 
     h2scf = ngx_http_get_module_srv_conf(r, ngx_http_v2_module);
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -2066,8 +2066,7 @@ static u_char *
 ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
     u_char *end)
 {
-    ngx_uint_t           depend, dependency, excl, weight;
-    ngx_http_v2_node_t  *node;
+    ngx_uint_t  depend, dependency, excl, weight;
 
     if (h2c->state.length != NGX_HTTP_V2_PRIORITY_SIZE) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
@@ -2111,54 +2110,17 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
     }
 
     /*
-     * RFC9218: When RFC9218 is enabled, ignore PRIORITY frames after
-     * validating them. Protocol errors are still detected.
-     *
-     * Only ignore after settings_ack, since the client may have sent
-     * PRIORITY frames before receiving our SETTINGS with NO_RFC7540_PRIORITIES.
-     *
-     * Ignored frames still count against priority_limit for flood protection.
+     * RFC9218: PRIORITY frames are ignored.  Protocol errors are still
+     * detected above.  Flood protection via priority_limit.
      */
-    if (h2c->settings_ack) {
-        if (--h2c->priority_limit == 0) {
-            ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
-                          "client sent too many PRIORITY frames");
-            return ngx_http_v2_connection_error(h2c,
-                                                NGX_HTTP_V2_ENHANCE_YOUR_CALM);
-        }
-
-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
-                       "http2 PRIORITY frame ignored (RFC9218 mode)");
-        return ngx_http_v2_state_complete(h2c, pos, end);
-    }
-
     if (--h2c->priority_limit == 0) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
                       "client sent too many PRIORITY frames");
-
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
     }
 
-    node = ngx_http_v2_get_node_by_id(h2c, h2c->state.sid, 1);
-
-    if (node == NULL) {
-        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
-    }
-
-    node->weight = weight;
-
-    if (node->stream == NULL) {
-        if (node->parent == NULL) {
-            h2c->closed_nodes++;
-
-        } else {
-            ngx_queue_remove(&node->reuse);
-        }
-
-        ngx_queue_insert_tail(&h2c->closed, &node->reuse);
-    }
-
-    ngx_http_v2_set_dependency(h2c, node, depend, excl);
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 PRIORITY frame ignored (RFC9218)");
 
     return ngx_http_v2_state_complete(h2c, pos, end);
 }

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1721,6 +1721,7 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
     ngx_http_core_main_conf_t  *cmcf;
 
     static ngx_str_t cookie = ngx_string("cookie");
+    static ngx_str_t priority_name = ngx_string("priority");
 
     header = &h2c->state.header;
 
@@ -1816,6 +1817,38 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
                           "client sent invalid header: \"%V\"", &header->name);
 
             return ngx_http_v2_state_header_complete(h2c, pos, end);
+        }
+    }
+
+    /*
+     * RFC9218: Handle Priority request header for extensible priorities.
+     * Parse and store the priority parameters in the stream, but continue
+     * normal header processing so the header is visible to variables and
+     * forwarding.
+     *
+     * Parse the Priority header for RFC9218 extensible priorities.
+     */
+    if (header->name.len == priority_name.len
+        && ngx_memcmp(header->name.data, priority_name.data,
+                      priority_name.len) == 0)
+    {
+        ngx_http_priority_t  tmp;
+
+        ngx_http_priority_parse(&header->value, &tmp);
+
+        /*
+         * Only apply if the value is empty (an explicit reset) or at least
+         * one parameter was recognized.  This prevents a malformed value from
+         * clobbering a priority already set for this stream.
+         */
+        if (header->value.len == 0 || tmp.valid) {
+            h2c->state.stream->priority.client = tmp;
+            ngx_http_priority_state_update(&h2c->state.stream->priority);
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http2 priority header: u=%ui, i=%ui",
+                           h2c->state.stream->priority.effective.urgency,
+                           h2c->state.stream->priority.effective.incremental);
         }
     }
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -47,8 +47,6 @@
 
 #define NGX_HTTP_V2_FRAME_BUFFER_SIZE            24
 
-#define NGX_HTTP_V2_ROOT                         (void *) -1
-
 
 static void ngx_http_v2_read_handler(ngx_event_t *rev);
 static void ngx_http_v2_write_handler(ngx_event_t *wev);
@@ -288,7 +286,6 @@ ngx_http_v2_init(ngx_event_t *rev)
     h2c->state.handler = ngx_http_v2_state_preface;
 
     ngx_queue_init(&h2c->waiting);
-    ngx_queue_init(&h2c->dependencies);
     ngx_queue_init(&h2c->closed);
 
     c->data = h2c;
@@ -1298,11 +1295,6 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     if (node == NULL) {
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
-    }
-
-    if (node->parent) {
-        ngx_queue_remove(&node->reuse);
-        h2c->closed_nodes--;
     }
 
     stream = ngx_http_v2_create_stream(h2c);
@@ -3365,8 +3357,6 @@ ngx_http_v2_get_node_by_id(ngx_http_v2_connection_t *h2c, ngx_uint_t sid,
 
     node->id = sid;
 
-    ngx_queue_init(&node->children);
-
     node->index = h2c->streams_index[index];
     h2c->streams_index[index] = node;
 
@@ -3377,12 +3367,8 @@ ngx_http_v2_get_node_by_id(ngx_http_v2_connection_t *h2c, ngx_uint_t sid,
 static ngx_http_v2_node_t *
 ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
 {
-    ngx_queue_t             *q;
-    ngx_http_v2_node_t      *node, **next, *n;
-    ngx_http_v2_srv_conf_t  *h2scf;
-
-    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
-                                         ngx_http_v2_module);
+    ngx_queue_t         *q;
+    ngx_http_v2_node_t  *node;
 
     h2c->closed_nodes--;
 
@@ -3391,19 +3377,6 @@ ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
     ngx_queue_remove(q);
 
     node = ngx_queue_data(q, ngx_http_v2_node_t, reuse);
-
-    next = &h2c->streams_index[ngx_http_v2_index(h2scf, node->id)];
-
-    for ( ;; ) {
-        n = *next;
-
-        if (n == node) {
-            *next = n->index;
-            break;
-        }
-
-        next = &n->index;
-    }
 
     ngx_memzero(node, sizeof(ngx_http_v2_node_t));
 
@@ -4728,7 +4701,8 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
     ngx_pool_t                *pool;
     ngx_event_t               *ev;
     ngx_connection_t          *fc;
-    ngx_http_v2_node_t        *node;
+    ngx_http_v2_node_t        *node, **next, *n;
+    ngx_http_v2_srv_conf_t    *h2scf;
     ngx_http_v2_connection_t  *h2c;
 
     h2c = stream->connection;
@@ -4772,6 +4746,23 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
     }
 
     node->stream = NULL;
+
+    /* Remove node from streams_index before adding to closed queue */
+    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                         ngx_http_v2_module);
+
+    next = &h2c->streams_index[ngx_http_v2_index(h2scf, node->id)];
+
+    for ( ;; ) {
+        n = *next;
+
+        if (n == node) {
+            *next = n->index;
+            break;
+        }
+
+        next = &n->index;
+    }
 
     ngx_queue_insert_tail(&h2c->closed, &node->reuse);
     h2c->closed_nodes++;

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -179,9 +179,6 @@ static void ngx_http_v2_finalize_connection(ngx_http_v2_connection_t *h2c,
 
 static ngx_int_t ngx_http_v2_adjust_windows(ngx_http_v2_connection_t *h2c,
     ssize_t delta);
-static void ngx_http_v2_set_dependency(ngx_http_v2_connection_t *h2c,
-    ngx_http_v2_node_t *node, ngx_uint_t depend, ngx_uint_t exclusive);
-static void ngx_http_v2_node_children_update(ngx_http_v2_node_t *node);
 
 static void ngx_http_v2_pool_cleanup(void *data);
 
@@ -1172,8 +1169,7 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
     u_char *end)
 {
     size_t                     size;
-    ngx_uint_t                 padded, priority, depend, dependency, excl,
-                               weight;
+    ngx_uint_t                 padded, priority;
     ngx_uint_t                 status;
     ngx_http_v2_node_t        *node;
     ngx_http_v2_stream_t      *stream;
@@ -1238,37 +1234,18 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
         h2c->state.length -= h2c->state.padding;
     }
 
-    depend = 0;
-    excl = 0;
-    weight = NGX_HTTP_V2_DEFAULT_WEIGHT;
-
     if (priority) {
-        dependency = ngx_http_v2_parse_uint32(pos);
-
-        depend = dependency & 0x7fffffff;
-        excl = dependency >> 31;
-        weight = pos[4] + 1;
-
+        /* Skip RFC7540 priority data; RFC9218 uses Priority header instead */
         pos += sizeof(uint32_t) + 1;
     }
 
-    ngx_log_debug4(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
-                   "http2 HEADERS frame sid:%ui "
-                   "depends on %ui excl:%ui weight:%ui",
-                   h2c->state.sid, depend, excl, weight);
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 HEADERS frame sid:%ui", h2c->state.sid);
 
     if (h2c->state.sid % 2 == 0 || h2c->state.sid <= h2c->last_sid) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
                       "client sent HEADERS frame with incorrect identifier "
                       "%ui, the last was %ui", h2c->state.sid, h2c->last_sid);
-
-        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
-    }
-
-    if (depend == h2c->state.sid) {
-        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
-                      "client sent HEADERS frame for stream %ui "
-                      "with incorrect dependency", h2c->state.sid);
 
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
     }
@@ -1375,17 +1352,6 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
                 break;
             }
         }
-    }
-
-    /*
-     * RFC9218: Even when RFC9218 is enabled, we still need to set up the
-     * node tree structure for proper node lifecycle management (the closed
-     * queue uses the node's queue member). We just don't use the dependency
-     * tree for scheduling.
-     */
-    if (priority || node->parent == NULL) {
-        node->weight = weight;
-        ngx_http_v2_set_dependency(h2c, node, depend, excl);
     }
 
     clcf = ngx_http_get_module_loc_conf(h2c->http_connection->conf_ctx,
@@ -3411,9 +3377,8 @@ ngx_http_v2_get_node_by_id(ngx_http_v2_connection_t *h2c, ngx_uint_t sid,
 static ngx_http_v2_node_t *
 ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
 {
-    ngx_uint_t               weight;
-    ngx_queue_t             *q, *children;
-    ngx_http_v2_node_t      *node, **next, *n, *parent, *child;
+    ngx_queue_t             *q;
+    ngx_http_v2_node_t      *node, **next, *n;
     ngx_http_v2_srv_conf_t  *h2scf;
 
     h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
@@ -3439,49 +3404,6 @@ ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
 
         next = &n->index;
     }
-
-    ngx_queue_remove(&node->queue);
-
-    weight = 0;
-
-    for (q = ngx_queue_head(&node->children);
-         q != ngx_queue_sentinel(&node->children);
-         q = ngx_queue_next(q))
-    {
-        child = ngx_queue_data(q, ngx_http_v2_node_t, queue);
-        weight += child->weight;
-    }
-
-    parent = node->parent;
-
-    for (q = ngx_queue_head(&node->children);
-         q != ngx_queue_sentinel(&node->children);
-         q = ngx_queue_next(q))
-    {
-        child = ngx_queue_data(q, ngx_http_v2_node_t, queue);
-        child->parent = parent;
-        child->weight = node->weight * child->weight / weight;
-
-        if (child->weight == 0) {
-            child->weight = 1;
-        }
-    }
-
-    if (parent == NGX_HTTP_V2_ROOT) {
-        node->rank = 0;
-        node->rel_weight = 1.0;
-
-        children = &h2c->dependencies;
-
-    } else {
-        node->rank = parent->rank;
-        node->rel_weight = parent->rel_weight;
-
-        children = &parent->children;
-    }
-
-    ngx_http_v2_node_children_update(node);
-    ngx_queue_add(children, &node->children);
 
     ngx_memzero(node, sizeof(ngx_http_v2_node_t));
 
@@ -5199,117 +5121,6 @@ ngx_http_v2_adjust_windows(ngx_http_v2_connection_t *h2c, ssize_t delta)
     }
 
     return NGX_OK;
-}
-
-
-static void
-ngx_http_v2_set_dependency(ngx_http_v2_connection_t *h2c,
-    ngx_http_v2_node_t *node, ngx_uint_t depend, ngx_uint_t exclusive)
-{
-    ngx_queue_t         *children, *q;
-    ngx_http_v2_node_t  *parent, *child, *next;
-
-    parent = depend ? ngx_http_v2_get_node_by_id(h2c, depend, 0) : NULL;
-
-    if (parent == NULL) {
-        parent = NGX_HTTP_V2_ROOT;
-
-        if (depend != 0) {
-            exclusive = 0;
-        }
-
-        node->rank = 1;
-        node->rel_weight = (1.0 / 256) * node->weight;
-
-        children = &h2c->dependencies;
-
-    } else {
-        if (node->parent != NULL) {
-
-            for (next = parent->parent;
-                 next != NGX_HTTP_V2_ROOT && next->rank >= node->rank;
-                 next = next->parent)
-            {
-                if (next != node) {
-                    continue;
-                }
-
-                ngx_queue_remove(&parent->queue);
-                ngx_queue_insert_after(&node->queue, &parent->queue);
-
-                parent->parent = node->parent;
-
-                if (node->parent == NGX_HTTP_V2_ROOT) {
-                    parent->rank = 1;
-                    parent->rel_weight = (1.0 / 256) * parent->weight;
-
-                } else {
-                    parent->rank = node->parent->rank + 1;
-                    parent->rel_weight = (node->parent->rel_weight / 256)
-                                         * parent->weight;
-                }
-
-                if (!exclusive) {
-                    ngx_http_v2_node_children_update(parent);
-                }
-
-                break;
-            }
-        }
-
-        node->rank = parent->rank + 1;
-        node->rel_weight = (parent->rel_weight / 256) * node->weight;
-
-        if (parent->stream == NULL) {
-            ngx_queue_remove(&parent->reuse);
-            ngx_queue_insert_tail(&h2c->closed, &parent->reuse);
-        }
-
-        children = &parent->children;
-    }
-
-    if (exclusive) {
-        for (q = ngx_queue_head(children);
-             q != ngx_queue_sentinel(children);
-             q = ngx_queue_next(q))
-        {
-            child = ngx_queue_data(q, ngx_http_v2_node_t, queue);
-            child->parent = node;
-        }
-
-        ngx_queue_add(&node->children, children);
-        ngx_queue_init(children);
-    }
-
-    if (node->parent != NULL) {
-        ngx_queue_remove(&node->queue);
-    }
-
-    ngx_queue_insert_tail(children, &node->queue);
-
-    node->parent = parent;
-
-    ngx_http_v2_node_children_update(node);
-}
-
-
-static void
-ngx_http_v2_node_children_update(ngx_http_v2_node_t *node)
-{
-    ngx_queue_t         *q;
-    ngx_http_v2_node_t  *child;
-
-    for (q = ngx_queue_head(&node->children);
-         q != ngx_queue_sentinel(&node->children);
-         q = ngx_queue_next(q))
-    {
-        child = ngx_queue_data(q, ngx_http_v2_node_t, queue);
-
-        child->rank = node->rank + 1;
-        child->rel_weight = (node->rel_weight / 256) * child->weight;
-
-        ngx_http_v2_node_children_update(child);
-    }
 }
 
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -2069,8 +2069,7 @@ static u_char *
 ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
     u_char *end)
 {
-    ngx_uint_t           depend, dependency, excl, weight;
-    ngx_http_v2_node_t  *node;
+    ngx_uint_t  depend;
 
     if (h2c->state.length != NGX_HTTP_V2_PRIORITY_SIZE) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
@@ -2080,30 +2079,18 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
     }
 
-    if (--h2c->priority_limit == 0) {
-        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
-                      "client sent too many PRIORITY frames");
-
-        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
-    }
-
     if (end - pos < NGX_HTTP_V2_PRIORITY_SIZE) {
         return ngx_http_v2_state_save(h2c, pos, end,
                                       ngx_http_v2_state_priority);
     }
 
-    dependency = ngx_http_v2_parse_uint32(pos);
-
-    depend = dependency & 0x7fffffff;
-    excl = dependency >> 31;
-    weight = pos[4] + 1;
+    depend = ngx_http_v2_parse_uint32(pos) & 0x7fffffff;
 
     pos += NGX_HTTP_V2_PRIORITY_SIZE;
 
-    ngx_log_debug4(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
-                   "http2 PRIORITY frame sid:%ui "
-                   "depends on %ui excl:%ui weight:%ui",
-                   h2c->state.sid, depend, excl, weight);
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 PRIORITY frame sid:%ui ignored",
+                   h2c->state.sid);
 
     if (h2c->state.sid == 0) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
@@ -2120,26 +2107,11 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
     }
 
-    node = ngx_http_v2_get_node_by_id(h2c, h2c->state.sid, 1);
-
-    if (node == NULL) {
-        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
+    if (--h2c->priority_limit == 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent too many PRIORITY frames");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
     }
-
-    node->weight = weight;
-
-    if (node->stream == NULL) {
-        if (node->parent == NULL) {
-            h2c->closed_nodes++;
-
-        } else {
-            ngx_queue_remove(&node->reuse);
-        }
-
-        ngx_queue_insert_tail(&h2c->closed, &node->reuse);
-    }
-
-    ngx_http_v2_set_dependency(h2c, node, depend, excl);
 
     return ngx_http_v2_state_complete(h2c, pos, end);
 }

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -38,11 +38,12 @@
 #define NGX_HTTP_V2_SETTINGS_PARAM_SIZE          6
 
 /* settings fields */
-#define NGX_HTTP_V2_HEADER_TABLE_SIZE_SETTING    0x1
-#define NGX_HTTP_V2_ENABLE_PUSH_SETTING          0x2
-#define NGX_HTTP_V2_MAX_STREAMS_SETTING          0x3
-#define NGX_HTTP_V2_INIT_WINDOW_SIZE_SETTING     0x4
-#define NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING       0x5
+#define NGX_HTTP_V2_HEADER_TABLE_SIZE_SETTING      0x1
+#define NGX_HTTP_V2_ENABLE_PUSH_SETTING            0x2
+#define NGX_HTTP_V2_MAX_STREAMS_SETTING            0x3
+#define NGX_HTTP_V2_INIT_WINDOW_SIZE_SETTING       0x4
+#define NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING         0x5
+#define NGX_HTTP_V2_NO_RFC7540_PRIORITIES_SETTING  0x9
 
 #define NGX_HTTP_V2_FRAME_BUFFER_SIZE            24
 
@@ -2735,7 +2736,14 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
         return NGX_ERROR;
     }
 
-    len = NGX_HTTP_V2_SETTINGS_PARAM_SIZE * 3;
+    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                         ngx_http_v2_module);
+
+    /*
+     * Settings: MAX_STREAMS, INIT_WINDOW_SIZE, MAX_FRAME_SIZE,
+     * NO_RFC7540_PRIORITIES
+     */
+    len = NGX_HTTP_V2_SETTINGS_PARAM_SIZE * 4;
 
     buf = ngx_create_temp_buf(h2c->pool, NGX_HTTP_V2_FRAME_HEADER_SIZE + len);
     if (buf == NULL) {
@@ -2763,9 +2771,6 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
 
     buf->last = ngx_http_v2_write_sid(buf->last, 0);
 
-    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
-                                         ngx_http_v2_module);
-
     buf->last = ngx_http_v2_write_uint16(buf->last,
                                          NGX_HTTP_V2_MAX_STREAMS_SETTING);
     buf->last = ngx_http_v2_write_uint32(buf->last,
@@ -2779,6 +2784,14 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
                                          NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING);
     buf->last = ngx_http_v2_write_uint32(buf->last,
                                          NGX_HTTP_V2_MAX_FRAME_SIZE);
+
+    /* RFC9218: Signal that we use extensible priorities */
+    buf->last = ngx_http_v2_write_uint16(buf->last,
+                                NGX_HTTP_V2_NO_RFC7540_PRIORITIES_SETTING);
+    buf->last = ngx_http_v2_write_uint32(buf->last, 1);
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 RFC9218 extensible priorities enabled");
 
     ngx_http_v2_queue_blocked_frame(h2c, frame);
 
@@ -3105,6 +3118,9 @@ ngx_http_v2_create_stream(ngx_http_v2_connection_t *h2c)
 
     stream->request = r;
     stream->connection = h2c;
+
+    /* RFC9218: Initialize with default priority */
+    ngx_http_priority_state_init(&stream->priority);
 
     h2scf = ngx_http_get_module_srv_conf(r, ngx_http_v2_module);
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -86,6 +86,8 @@ static u_char *ngx_http_v2_handle_continuation(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end, ngx_http_v2_handler_pt handler);
 static u_char *ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
+static u_char *ngx_http_v2_state_priority_update(ngx_http_v2_connection_t *h2c,
+    u_char *pos, u_char *end);
 static u_char *ngx_http_v2_state_rst_stream(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
 static u_char *ngx_http_v2_state_settings(ngx_http_v2_connection_t *h2c,
@@ -907,6 +909,11 @@ ngx_http_v2_state_head(ngx_http_v2_connection_t *h2c, u_char *pos, u_char *end)
                    "http2 frame type:%ui f:%Xd l:%uz sid:%ui",
                    type, h2c->state.flags, h2c->state.length, h2c->state.sid);
 
+    /* RFC9218: Handle PRIORITY_UPDATE frame (type 0x10) */
+    if (type == NGX_HTTP_V2_PRIORITY_UPDATE_FRAME) {
+        return ngx_http_v2_state_priority_update(h2c, pos, end);
+    }
+
     if (type >= NGX_HTTP_V2_FRAME_STATES) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
                       "client sent frame with unknown type %ui", type);
@@ -1338,6 +1345,44 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     node->stream = stream;
 
+    /*
+     * RFC9218: Apply any pending priority updates for this stream.
+     * PRIORITY_UPDATE frames may arrive before HEADERS.
+     */
+    if (h2c->pending_priorities) {
+        ngx_uint_t                       i, n;
+        ngx_http_v2_pending_priority_t  *pp;
+
+        pp = h2c->pending_priorities->elts;
+        n = h2c->pending_priorities->nelts;
+
+        for (i = 0; i < n; i++) {
+            if (pp[i].sid == node->id) {
+                stream->priority.client = pp[i].priority;
+                ngx_http_priority_state_update(&stream->priority);
+
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                               "http2 applied pending priority for stream %ui: "
+                               "u=%ui", node->id,
+                               stream->priority.effective.urgency);
+
+                /* Remove entry: swap with last and decrement count */
+                n--;
+                if (i < n) {
+                    pp[i] = pp[n];
+                }
+                h2c->pending_priorities->nelts = n;
+                break;
+            }
+        }
+    }
+
+    /*
+     * RFC9218: Even when RFC9218 is enabled, we still need to set up the
+     * node tree structure for proper node lifecycle management (the closed
+     * queue uses the node's queue member). We just don't use the dependency
+     * tree for scheduling.
+     */
     if (priority || node->parent == NULL) {
         node->weight = weight;
         ngx_http_v2_set_dependency(h2c, node, depend, excl);
@@ -2096,6 +2141,180 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     ngx_http_v2_set_dependency(h2c, node, depend, excl);
 
+    return ngx_http_v2_state_complete(h2c, pos, end);
+}
+
+
+static u_char *
+ngx_http_v2_state_priority_update(ngx_http_v2_connection_t *h2c, u_char *pos,
+    u_char *end)
+{
+    size_t                           len;
+    ngx_str_t                        value;
+    ngx_uint_t                       i, sid;
+    ngx_http_v2_node_t              *node;
+    ngx_http_priority_t              priority;
+    ngx_http_v2_stream_t            *stream;
+    ngx_http_v2_srv_conf_t          *h2scf;
+    ngx_http_v2_pending_priority_t  *pp;
+
+    /*
+     * RFC9218: PRIORITY_UPDATE frame format:
+     *   - Prioritized Stream ID (31 bits)
+     *   - Priority Field Value (variable length)
+     *
+     * Must be sent on stream 0, for client-initiated streams only.
+     */
+
+    if (h2c->state.sid != 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent PRIORITY_UPDATE frame on non-zero stream");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
+    }
+
+    if (h2c->state.length < 4) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent PRIORITY_UPDATE frame too short");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
+    }
+
+    len = h2c->state.length;
+
+    if ((size_t) (end - pos) < len) {
+        /*
+         * Frame is fragmented.  Only buffer if it fits in state buffer,
+         * otherwise skip to avoid overflow.
+         */
+        if (len > NGX_HTTP_V2_STATE_BUFFER_SIZE) {
+            if (--h2c->priority_limit == 0) {
+                ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                              "client sent too many PRIORITY_UPDATE frames");
+                return ngx_http_v2_connection_error(h2c,
+                                                NGX_HTTP_V2_ENHANCE_YOUR_CALM);
+            }
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                           "http2 PRIORITY_UPDATE frame too large to buffer: "
+                           "%uz", len);
+            return ngx_http_v2_state_skip(h2c, pos, end);
+        }
+
+        return ngx_http_v2_state_save(h2c, pos, end,
+                                      ngx_http_v2_state_priority_update);
+    }
+
+    if (--h2c->priority_limit == 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent too many PRIORITY_UPDATE frames");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
+    }
+
+    /* Parse Prioritized Stream ID (first 4 bytes, top bit reserved) */
+    sid = ngx_http_v2_parse_uint32(pos) & 0x7fffffff;
+    pos += 4;
+    len -= 4;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 PRIORITY_UPDATE frame for stream %ui, len=%uz",
+                   sid, len);
+
+    /* Must be odd (client-initiated) */
+    if (sid == 0 || (sid & 1) == 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent PRIORITY_UPDATE for invalid stream %ui",
+                      sid);
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
+    }
+
+    /* Parse Priority Field Value */
+    value.data = pos;
+    value.len = len;
+
+    ngx_http_priority_parse(&value, &priority);
+
+    /*
+     * A PRIORITY_UPDATE frame communicates a complete set of priority
+     * parameters (RFC 9218 Section 7): an omitted parameter is a signal to
+     * use its default, and an empty value is an explicit reset to the
+     * defaults.  ngx_http_priority_parse() has already seeded priority with
+     * those defaults, so it is applied as-is -- a value whose only members
+     * are unknown extensions still resets the recognized parameters to their
+     * defaults rather than retaining a stale prior signal.
+     */
+
+    node = ngx_http_v2_get_node_by_id(h2c, sid, 0);
+
+    if (node && node->stream) {
+        /* Stream exists, apply priority immediately */
+        stream = node->stream;
+        stream->priority.client = priority;
+        ngx_http_priority_state_update(&stream->priority);
+
+        ngx_log_debug3(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                       "http2 PRIORITY_UPDATE applied to stream %ui: "
+                       "u=%ui, i=%ui",
+                       sid, stream->priority.effective.urgency,
+                       stream->priority.effective.incremental);
+
+    } else if (sid > h2c->last_sid) {
+        /*
+         * Stream doesn't exist yet (sid > last_sid), buffer the priority.
+         * If sid <= last_sid, the stream already existed and is now closed,
+         * so there's no point buffering since it will never be created again.
+         */
+        h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                             ngx_http_v2_module);
+
+        if (h2c->pending_priorities == NULL) {
+            h2c->pending_priorities = ngx_array_create(h2c->pool, 4,
+                                        sizeof(ngx_http_v2_pending_priority_t));
+            if (h2c->pending_priorities == NULL) {
+                return ngx_http_v2_connection_error(h2c,
+                                                    NGX_HTTP_V2_INTERNAL_ERROR);
+            }
+        }
+
+        /* Check if we already have a pending priority for this stream */
+        pp = h2c->pending_priorities->elts;
+        for (i = 0; i < h2c->pending_priorities->nelts; i++) {
+            if (pp[i].sid == sid) {
+                /* Update existing entry */
+                pp[i].priority = priority;
+
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                               "http2 PRIORITY_UPDATE updated pending for "
+                               "stream %ui: u=%ui",
+                               sid, pp[i].priority.urgency);
+                goto done;
+            }
+        }
+
+        /* Cap pending priorities at max_concurrent_streams */
+        if (h2c->pending_priorities->nelts >= h2scf->concurrent_streams) {
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                           "http2 PRIORITY_UPDATE ignored, pending limit "
+                           "reached for stream %ui", sid);
+            goto done;
+        }
+
+        /* Add new pending entry */
+        pp = ngx_array_push(h2c->pending_priorities);
+        if (pp == NULL) {
+            return ngx_http_v2_connection_error(h2c,
+                                                NGX_HTTP_V2_INTERNAL_ERROR);
+        }
+
+        pp->sid = sid;
+        pp->priority = priority;
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                       "http2 PRIORITY_UPDATE buffered for stream "
+                       "%ui: u=%ui", sid, pp->priority.urgency);
+    }
+
+done:
+
+    pos += h2c->state.length - 4;
     return ngx_http_v2_state_complete(h2c, pos, end);
 }
 

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -27,16 +27,17 @@
 #define NGX_HTTP_V2_FRAME_HEADER_SIZE    9
 
 /* frame types */
-#define NGX_HTTP_V2_DATA_FRAME           0x0
-#define NGX_HTTP_V2_HEADERS_FRAME        0x1
-#define NGX_HTTP_V2_PRIORITY_FRAME       0x2
-#define NGX_HTTP_V2_RST_STREAM_FRAME     0x3
-#define NGX_HTTP_V2_SETTINGS_FRAME       0x4
-#define NGX_HTTP_V2_PUSH_PROMISE_FRAME   0x5
-#define NGX_HTTP_V2_PING_FRAME           0x6
-#define NGX_HTTP_V2_GOAWAY_FRAME         0x7
-#define NGX_HTTP_V2_WINDOW_UPDATE_FRAME  0x8
-#define NGX_HTTP_V2_CONTINUATION_FRAME   0x9
+#define NGX_HTTP_V2_DATA_FRAME             0x00
+#define NGX_HTTP_V2_HEADERS_FRAME          0x01
+#define NGX_HTTP_V2_PRIORITY_FRAME         0x02
+#define NGX_HTTP_V2_RST_STREAM_FRAME       0x03
+#define NGX_HTTP_V2_SETTINGS_FRAME         0x04
+#define NGX_HTTP_V2_PUSH_PROMISE_FRAME     0x05
+#define NGX_HTTP_V2_PING_FRAME             0x06
+#define NGX_HTTP_V2_GOAWAY_FRAME           0x07
+#define NGX_HTTP_V2_WINDOW_UPDATE_FRAME    0x08
+#define NGX_HTTP_V2_CONTINUATION_FRAME     0x09
+#define NGX_HTTP_V2_PRIORITY_UPDATE_FRAME  0x10
 
 /* frame flags */
 #define NGX_HTTP_V2_NO_FLAG              0x00

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -50,8 +50,6 @@
 #define NGX_HTTP_V2_MAX_WINDOW           ((1U << 31) - 1)
 #define NGX_HTTP_V2_DEFAULT_WINDOW       65535
 
-#define NGX_HTTP_V2_DEFAULT_WEIGHT       16
-
 
 typedef struct ngx_http_v2_connection_s   ngx_http_v2_connection_t;
 typedef struct ngx_http_v2_node_s         ngx_http_v2_node_t;
@@ -168,7 +166,6 @@ struct ngx_http_v2_connection_s {
 
     ngx_http_v2_out_frame_t         *last_out;
 
-    ngx_queue_t                      dependencies;
     ngx_queue_t                      closed;
 
     ngx_uint_t                       closed_nodes;
@@ -189,13 +186,7 @@ struct ngx_http_v2_connection_s {
 struct ngx_http_v2_node_s {
     ngx_uint_t                       id;
     ngx_http_v2_node_t              *index;
-    ngx_http_v2_node_t              *parent;
-    ngx_queue_t                      queue;
-    ngx_queue_t                      children;
     ngx_queue_t                      reuse;
-    ngx_uint_t                       rank;
-    ngx_uint_t                       weight;
-    double                           rel_weight;
     ngx_http_v2_stream_t            *stream;
 };
 

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -258,11 +258,49 @@ struct ngx_http_v2_out_frame_s {
 };
 
 
+/*
+ * Compare two streams for scheduling order.
+ *
+ * Returns 1 if existing stream 's' should come before 'stream' (break),
+ * returns 0 if search should continue.
+ *
+ * Uses RFC9218 urgency-based scheduling.
+ * Lower urgency value (0-7) = higher priority.
+ * At same urgency, non-incremental before incremental.
+ * At same urgency and incremental, lower stream ID wins (FIFO order).
+ */
+static ngx_inline ngx_uint_t
+ngx_http_v2_stream_comes_before(ngx_http_v2_connection_t *h2c,
+    ngx_http_v2_stream_t *s, ngx_http_v2_stream_t *stream)
+{
+    ngx_int_t  cmp;
+
+    /* RFC9218 urgency-based scheduling */
+    cmp = ngx_http_priority_compare(&s->priority, &stream->priority);
+
+    if (cmp < 0) {
+        return 1;
+    }
+
+    if (cmp == 0) {
+        /* Same priority: lower stream ID wins */
+        if (s->node->id <= stream->node->id) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
 static ngx_inline void
 ngx_http_v2_queue_frame(ngx_http_v2_connection_t *h2c,
     ngx_http_v2_out_frame_t *frame)
 {
+    ngx_http_v2_stream_t      *s, *fs;
     ngx_http_v2_out_frame_t  **out;
+
+    fs = frame->stream;
 
     for (out = &h2c->last_out; *out; out = &(*out)->next) {
 
@@ -270,11 +308,9 @@ ngx_http_v2_queue_frame(ngx_http_v2_connection_t *h2c,
             break;
         }
 
-        if ((*out)->stream->node->rank < frame->stream->node->rank
-            || ((*out)->stream->node->rank == frame->stream->node->rank
-                && (*out)->stream->node->rel_weight
-                   >= frame->stream->node->rel_weight))
-        {
+        s = (*out)->stream;
+
+        if (ngx_http_v2_stream_comes_before(h2c, s, fs)) {
             break;
         }
     }

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -61,6 +61,16 @@ typedef u_char *(*ngx_http_v2_handler_pt) (ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
 
 
+/*
+ * RFC9218: Pending priority update for streams not yet created.
+ * PRIORITY_UPDATE frames may arrive before the HEADERS frame.
+ */
+typedef struct {
+    ngx_uint_t                       sid;
+    ngx_http_priority_t              priority;
+} ngx_http_v2_pending_priority_t;
+
+
 typedef struct {
     ngx_flag_t                       enable;
     size_t                           pool_size;
@@ -169,6 +179,9 @@ struct ngx_http_v2_connection_s {
     unsigned                         table_update:1;
     unsigned                         blocked:1;
     unsigned                         goaway:1;
+
+    /* RFC9218 Extensible Priorities */
+    ngx_array_t                     *pending_priorities;
 };
 
 
@@ -223,6 +236,9 @@ struct ngx_http_v2_stream_s {
     unsigned                         rst_sent:1;
     unsigned                         no_flow_control:1;
     unsigned                         skip_data:1;
+
+    /* RFC9218 Extensible Priorities */
+    ngx_http_priority_t              priority;
 };
 
 

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -61,6 +61,16 @@ typedef u_char *(*ngx_http_v2_handler_pt) (ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
 
 
+/*
+ * RFC9218: Pending priority update for streams not yet created.
+ * PRIORITY_UPDATE frames may arrive before the HEADERS frame.
+ */
+typedef struct {
+    ngx_uint_t                       sid;
+    ngx_http_priority_t              priority;
+} ngx_http_v2_pending_priority_t;
+
+
 typedef struct {
     ngx_flag_t                       enable;
     size_t                           pool_size;
@@ -169,6 +179,9 @@ struct ngx_http_v2_connection_s {
     unsigned                         table_update:1;
     unsigned                         blocked:1;
     unsigned                         goaway:1;
+
+    /* RFC9218 Extensible Priorities */
+    ngx_array_t                     *pending_priorities;
 };
 
 
@@ -223,6 +236,9 @@ struct ngx_http_v2_stream_s {
     unsigned                         rst_sent:1;
     unsigned                         no_flow_control:1;
     unsigned                         skip_data:1;
+
+    /* RFC9218 Extensible Priorities */
+    ngx_http_priority_state_t        priority;
 };
 
 

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -258,11 +258,50 @@ struct ngx_http_v2_out_frame_s {
 };
 
 
+/*
+ * Compare two streams for scheduling order.
+ *
+ * Returns 1 if existing stream 's' should come before 'stream' (break),
+ * returns 0 if search should continue.
+ *
+ * Uses RFC9218 urgency-based scheduling.
+ * Lower urgency value (0-7) = higher priority.
+ * At same urgency, non-incremental before incremental.
+ * At same urgency and incremental, lower stream ID wins (FIFO order).
+ */
+static ngx_inline ngx_uint_t
+ngx_http_v2_stream_comes_before(ngx_http_v2_connection_t *h2c,
+    ngx_http_v2_stream_t *s, ngx_http_v2_stream_t *stream)
+{
+    ngx_int_t  cmp;
+
+    /* RFC9218 urgency-based scheduling */
+    cmp = ngx_http_priority_compare(&s->priority.effective,
+                                    &stream->priority.effective);
+
+    if (cmp < 0) {
+        return 1;
+    }
+
+    if (cmp == 0) {
+        /* Same priority: lower stream ID wins */
+        if (s->node->id <= stream->node->id) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
 static ngx_inline void
 ngx_http_v2_queue_frame(ngx_http_v2_connection_t *h2c,
     ngx_http_v2_out_frame_t *frame)
 {
+    ngx_http_v2_stream_t      *s, *fs;
     ngx_http_v2_out_frame_t  **out;
+
+    fs = frame->stream;
 
     for (out = &h2c->last_out; *out; out = &(*out)->next) {
 
@@ -270,11 +309,9 @@ ngx_http_v2_queue_frame(ngx_http_v2_connection_t *h2c,
             break;
         }
 
-        if ((*out)->stream->node->rank < frame->stream->node->rank
-            || ((*out)->stream->node->rank == frame->stream->node->rank
-                && (*out)->stream->node->rel_weight
-                   >= frame->stream->node->rel_weight))
-        {
+        s = (*out)->stream;
+
+        if (ngx_http_v2_stream_comes_before(h2c, s, fs)) {
             break;
         }
     }

--- a/src/http/v2/ngx_http_v2_filter_module.c
+++ b/src/http/v2/ngx_http_v2_filter_module.c
@@ -1446,10 +1446,7 @@ ngx_http_v2_waiting_queue(ngx_http_v2_connection_t *h2c,
     {
         s = ngx_queue_data(q, ngx_http_v2_stream_t, queue);
 
-        if (s->node->rank < stream->node->rank
-            || (s->node->rank == stream->node->rank
-                && s->node->rel_weight >= stream->node->rel_weight))
-        {
+        if (ngx_http_v2_stream_comes_before(h2c, s, stream)) {
             break;
         }
     }


### PR DESCRIPTION
```
First, lets deal with the elephant in the room. This patchset was
produced with AI. Specifically *initially* with Claude Opus 4.5 via
gh-copilot(1).

As well as calling it out here. I had it replace the Co-authored-by: tag
it added (that tag is for humans) to each commit with

  Assisted-by: opencode:claude-opus-4.8

as inspired by the Linux Kernel.
<https://docs.kernel.org/process/coding-assistants.html#attribution>

I believe this is important for several reasons, including outright
rejection due to use of AI and for future archaeology.

While the code was mostly written by AI, it was done so with a certain
amount of prodding and guidance from myself. It has been through several
rounds of copilot review as can be viewed here
<https://github.com/ac000/nginx/pull/2>
 
This series implements RFC 9218 "Extensible Prioritization Scheme for
HTTP" for the HTTP/2 module.

As noted above, this is just for HTTP/2. If this is successfully merged
then I will look at the HTTP/3 implementation.

RFC 9218 replaces the complex tree-based priority scheme from RFC 7540 in
favour of a simpler, more practical system using two parameters:

  - urgency (u): Integer 0-7, lower values are more urgent (default: 3)
  - incremental (i): Boolean indicating progressive rendering (default:
    false)

Clients signal priority via the "Priority" request header or
PRIORITY_UPDATE frames, using RFC 8941 Structured Fields syntax:

  Priority: u=1
  Priority: u=3, i
  Priority: u=5, i=?0

Key implementation details:

  - New shared priority parser (ngx_http_priority.c) is a strict
    RFC 8941 Structured Fields parser: a malformed field is ignored in
    its entirety (RFC 8941, Section 4.2), and the RFC 9218, Section 4,
    leniency (unknown members, out-of-range or wrong-typed values) is
    applied only after a successful parse
  - SETTINGS_NO_RFC7540_PRIORITIES (0x9) advertised to clients, and its
    received value validated (RFC 9218, Section 2.1)
  - RFC 7540 PRIORITY frames ignored (validated for framing errors only)
  - PRIORITY_UPDATE frames (0x10) supported, with buffering on the
    stream node for frames that arrive before the stream is opened
  - Priority signals convey a complete set of parameters (RFC 9218,
    Section 7): parameters omitted from a PRIORITY_UPDATE reset to
    their defaults rather than retaining previously signalled values;
    a PRIORITY_UPDATE frame overrides the Priority header
  - The Priority request header combines all field lines before parsing
    (RFC 8941, Section 4.2)
  - Frame scheduling orders streams by urgency, then non-incremental
    ahead of incremental, then by stream id (request order)
  - RFC 9218 is unconditionally enabled (no directive)
  - Server-side Priority headers (RFC 9218, Section 8) supported: an
    upstream response Priority header is merged with the client
    priority to influence how this hop schedules the stream; the
    forwarded header is left unchanged
  - RFC 7540 priority handling code removed (dependency tree, weights)

The series is structured for bisectability; every commit compiles on
its own and is a self-contained, reviewable unit. Fields are added in
the commit that first uses them, PRIORITY_UPDATE lands before the
Priority header (so the header can defer to a frame per RFC 9218,
Section 7), and the switch to RFC 9218 and the removal of the RFC 7540
tree are one atomic step so no intermediate state consults a
half-removed tree:

   1. Add RFC 9218 priority types and parser
   2. HTTP/2: switch to RFC 9218 priorities
   3. HTTP/2: handle PRIORITY_UPDATE frames
   4. HTTP/2: parse Priority request header
   5. HTTP/2: merge upstream Priority header for proxied requests

Testing:

All existing HTTP/2 tests pass. A new h2_rfc9218.t test file validates
the feature, has been posted to the nginx-tests repository
<https://github.com/nginx/nginx-tests/pull/69> (the h2_priority.t test
file which tested RFC 7540 priorities has been removed).

  Example nginx configuration:

    http {
        http2 on;

        server {
            listen 8443 ssl;
            ...

            # Server-side priority hints (RFC 9218 Section 8) for intermediaries
            location /critical.css {
                add_header Priority "u=0";
                ...
            }
            location /analytics.js {
                add_header Priority "u=6, i";
                ...
            }
        }
    }

  Example nghttp commands demonstrating priority:

    # Request with high priority (u=1)
    $ nghttp -nv --extpri="u=1" https://localhost:8443/large.bin

    # Request with low priority and incremental
    $ nghttp -nv --extpri="u=5, i" https://localhost:8443/stream.txt

    # Multiple requests with different priorities (high priority completes first)
    $ nghttp -nv --no-dep \
        --extpri="u=5" https://localhost:8443/low.bin \
        --extpri="u=1" https://localhost:8443/high.bin

  To observe priority effects, constrain loopback bandwidth so that
  the connection is congested (run as root):

    # Limit loopback to 50mbit/s
    $ sudo tc qdisc add dev lo root handle 1: htb default 12
    $ sudo tc class add dev lo parent 1: classid 1:12 htb rate 50mbit

    # Remove the limit afterwards
    $ sudo tc qdisc del dev lo root

  A self-contained demo (config, test resources and helper scripts) is
  available at:

    <https://github.com/ac000/nginx-rfc9218-demo>

Benchmark results:

  Test: Two concurrent 10MB downloads, loopback shaped to 50Mbit/s (htb)
        File A requested FIRST, File B requested SECOND

  Without priority hints (default u=3):

    File A (low.bin):   2.56s  <-- first-requested completes first
    File B (high.bin):  3.42s

  With RFC 9218 priorities (A=u=5 low priority, B=u=1 high priority):

    File B (high.bin):  2.57s  <-- high priority completes first
    File A (low.bin):   3.42s

  Result: RFC 9218 priorities allow the high-priority request to complete
          ~850ms faster than the first-requested low-priority resource,
          even though it was initiated second.

  With bandwidth constraints, higher priority (lower urgency) streams
  complete before lower priority streams.

Limitations:

  RFC 9218, Section 10, recommends that non-incremental responses at the
  same urgency level be served one by one, in request order, rather than
  interleaved. The current implementation provides priority ordering via
  queue placement but does not enforce strict sequential delivery, as
  this would require blocking mechanisms that conflict with nginx's
  event-driven architecture. In practice, urgency-based ordering
  provides the primary benefit.

References:

  - RFC 9218: <https://www.rfc-editor.org/rfc/rfc9218>
  - RFC 8941: <https://www.rfc-editor.org/rfc/rfc8941> (Structured Fields)
  - Demo: <https://github.com/ac000/nginx-rfc9218-demo>

 auto/modules                            |   3 +-
 auto/sources                            |   3 +
 src/http/ngx_http_priority.c            | 575 ++++++++++++++++++++++++++++++++
 src/http/ngx_http_priority.h            |  44 +++
 src/http/ngx_http_upstream.c            |  46 +++
 src/http/v2/ngx_http_v2.c               | 532 ++++++++++++++++-------------
 src/http/v2/ngx_http_v2.h               |  71 ++--
 src/http/v2/ngx_http_v2_filter_module.c |   5 +-
 8 files changed, 1009 insertions(+), 270 deletions(-)
 create mode 100644 src/http/ngx_http_priority.c
 create mode 100644 src/http/ngx_http_priority.h

-- 

```