### PR TITLE
Core: validate detected cache line size.

### DIFF
--- a/src/os/unix/ngx_posix_init.c
+++ b/src/os/unix/ngx_posix_init.c
@@ -77,6 +77,12 @@ ngx_os_init(ngx_log_t *log)
 
     ngx_cpuinfo();
 
+    if (ngx_cacheline_size < 32
+        || (ngx_cacheline_size & (ngx_cacheline_size - 1)) != 0)
+    {
+        ngx_cacheline_size = NGX_CPU_CACHE_LINE;
+    }
+
     if (getrlimit(RLIMIT_NOFILE, &rlmt) == -1) {
         ngx_log_error(NGX_LOG_ALERT, log, errno,
                       "getrlimit(RLIMIT_NOFILE) failed");


### PR DESCRIPTION
Some systems may report an invalid positive value for sysconf(_SC_LEVEL1_DCACHE_LINESIZE), such as 1.  This value is later used as ngx_cacheline_size, including as a hash bucket size and an alignment value, which can make default configuration testing fail with errors such as:

could not build ssi_command_hash, you should increase ssi_command_hash_bucket_size: 1

Ignore detected cache line sizes that are too small or not a power of two. Fall back to NGX_CPU_CACHE_LINE.

## Problem

Briefly describe the issue or feature being addressed.

## Solution

Explain your approach and any important design decisions.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1555

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
