### PR TITLE
Darwin: removed never-defined ngx_darwin_kern_osreldate declaration.

### DIFF
--- a/src/os/unix/ngx_darwin.h
+++ b/src/os/unix/ngx_darwin.h
@@ -13,7 +13,6 @@ void ngx_debug_init(void);
 ngx_chain_t *ngx_darwin_sendfile_chain(ngx_connection_t *c, ngx_chain_t *in,
     off_t limit);
 
-extern int       ngx_darwin_kern_osreldate;
 extern int       ngx_darwin_hw_ncpu;
 extern u_long    ngx_darwin_net_inet_tcp_sendspace;
 


### PR DESCRIPTION
The variable was declared extern in ngx_darwin.h since Darwin support was split out in 2008 (749449097), but was never defined nor referenced. It was a leftover from the FreeBSD template; FreeBSD uses its own separate symbol ngx_freebsd_kern_osreldate, which is unaffected.

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)