### PR TITLE
FreeBSD: removed handling of long-EOL FreeBSD versions.

### DIFF
--- a/src/event/modules/ngx_kqueue_module.c
+++ b/src/event/modules/ngx_kqueue_module.c
@@ -438,8 +438,7 @@ ngx_kqueue_set_event(ngx_event_t *ev, ngx_int_t filter, ngx_uint_t flags)
     if (filter == EVFILT_VNODE) {
         kev->fflags = NOTE_DELETE|NOTE_WRITE|NOTE_EXTEND
                                  |NOTE_ATTRIB|NOTE_RENAME
-#if (__FreeBSD__ == 4 && __FreeBSD_version >= 430000)                         \
-     || __FreeBSD_version >= 500018
+#if (__FreeBSD__)
                                  |NOTE_REVOKE
 #endif
                       ;

--- a/src/os/unix/ngx_freebsd.h
+++ b/src/os/unix/ngx_freebsd.h
@@ -17,7 +17,6 @@ extern int         ngx_freebsd_kern_osreldate;
 extern int         ngx_freebsd_hw_ncpu;
 extern u_long      ngx_freebsd_net_inet_tcp_sendspace;
 
-extern ngx_uint_t  ngx_freebsd_sendfile_nbytes_bug;
 extern ngx_uint_t  ngx_freebsd_use_tcp_nopush;
 extern ngx_uint_t  ngx_debug_malloc;
 

--- a/src/os/unix/ngx_freebsd_config.h
+++ b/src/os/unix/ngx_freebsd_config.h
@@ -52,24 +52,6 @@
 #include <dlfcn.h>
 
 
-#if __FreeBSD_version < 400017
-
-/*
- * FreeBSD 3.x has no CMSG_SPACE() and CMSG_LEN() and has the broken CMSG_DATA()
- */
-
-#undef  CMSG_SPACE
-#define CMSG_SPACE(l)       (ALIGN(sizeof(struct cmsghdr)) + ALIGN(l))
-
-#undef  CMSG_LEN
-#define CMSG_LEN(l)         (ALIGN(sizeof(struct cmsghdr)) + (l))
-
-#undef  CMSG_DATA
-#define CMSG_DATA(cmsg)     ((u_char *)(cmsg) + ALIGN(sizeof(struct cmsghdr)))
-
-#endif
-
-
 #include <ngx_auto_config.h>
 
 
@@ -92,10 +74,6 @@
 
 #include <aio.h>
 typedef struct aiocb  ngx_aiocb_t;
-
-#if (__FreeBSD_version < 700005 && !defined __DragonFly__)
-#define sival_ptr     sigval_ptr
-#endif
 
 #endif
 
@@ -123,7 +101,6 @@ typedef struct aiocb  ngx_aiocb_t;
 
 
 extern char **environ;
-extern char  *malloc_options;
 
 
 #endif /* _NGX_FREEBSD_CONFIG_H_INCLUDED_ */

--- a/src/os/unix/ngx_freebsd_init.c
+++ b/src/os/unix/ngx_freebsd_init.c
@@ -21,7 +21,6 @@ u_long  ngx_freebsd_net_inet_tcp_sendspace;
 int     ngx_freebsd_machdep_hlt_logical_cpus;
 
 
-ngx_uint_t  ngx_freebsd_sendfile_nbytes_bug;
 ngx_uint_t  ngx_freebsd_use_tcp_nopush;
 
 ngx_uint_t  ngx_debug_malloc;
@@ -78,12 +77,6 @@ ngx_debug_init(void)
 {
 #if (NGX_DEBUG_MALLOC)
 
-#if __FreeBSD_version >= 500014 && __FreeBSD_version < 1000011
-    _malloc_options = "J";
-#elif __FreeBSD_version < 500014
-    malloc_options = "J";
-#endif
-
     ngx_debug_malloc = 1;
 
 #else
@@ -101,7 +94,6 @@ ngx_debug_init(void)
 ngx_int_t
 ngx_os_specific_init(ngx_log_t *log)
 {
-    int         version;
     size_t      size;
     ngx_err_t   err;
     ngx_uint_t  i;
@@ -141,48 +133,7 @@ ngx_os_specific_init(ngx_log_t *log)
         return NGX_ERROR;
     }
 
-    version = ngx_freebsd_kern_osreldate;
-
-
-#if (NGX_HAVE_SENDFILE)
-
-    /*
-     * The determination of the sendfile() "nbytes bug" is complex enough.
-     * There are two sendfile() syscalls: a new #393 has no bug while
-     * an old #336 has the bug in some versions and has not in others.
-     * Besides libc_r wrapper also emulates the bug in some versions.
-     * There is no way to say exactly if syscall #336 in FreeBSD circa 4.6
-     * has the bug.  We use the algorithm that is correct at least for
-     * RELEASEs and for syscalls only (not libc_r wrapper).
-     *
-     * 4.6.1-RELEASE and below have the bug
-     * 4.6.2-RELEASE and above have the new syscall
-     *
-     * We detect the new sendfile() syscall available at the compile time
-     * to allow an old binary to run correctly on an updated FreeBSD system.
-     */
-
-#if (__FreeBSD__ == 4 && __FreeBSD_version >= 460102)                         \
-     || __FreeBSD_version == 460002 || __FreeBSD_version >= 500039
-
-    /* a new syscall without the bug */
-
-    ngx_freebsd_sendfile_nbytes_bug = 0;
-
-#else
-
-    /* an old syscall that may have the bug */
-
-    ngx_freebsd_sendfile_nbytes_bug = 1;
-
-#endif
-
-#endif /* NGX_HAVE_SENDFILE */
-
-
-    if ((version < 500000 && version >= 440003) || version >= 500017) {
-        ngx_freebsd_use_tcp_nopush = 1;
-    }
+    ngx_freebsd_use_tcp_nopush = 1;
 
 
     for (i = 0; sysctls[i].name; i++) {
@@ -211,12 +162,6 @@ ngx_os_specific_init(ngx_log_t *log)
 
     } else {
         ngx_ncpu = ngx_freebsd_hw_ncpu;
-    }
-
-    if (version < 600008 && ngx_freebsd_kern_ipc_somaxconn > 32767) {
-        ngx_log_error(NGX_LOG_ALERT, log, 0,
-                      "sysctl kern.ipc.somaxconn must be less than 32768");
-        return NGX_ERROR;
     }
 
     ngx_tcp_nodelay_and_tcp_nopush = 1;

--- a/src/os/unix/ngx_freebsd_sendfile_chain.c
+++ b/src/os/unix/ngx_freebsd_sendfile_chain.c
@@ -163,13 +163,11 @@ ngx_freebsd_sendfile_chain(ngx_connection_t *c, ngx_chain_t *in, off_t limit)
             hdtr.trl_cnt = trailer.count;
 
             /*
-             * the "nbytes bug" of the old sendfile() syscall:
-             * http://bugs.freebsd.org/33771
+             * the header is passed to sendfile() via sf_hdtr and its
+             * size is not counted in the nbytes argument
              */
 
-            if (!ngx_freebsd_sendfile_nbytes_bug) {
-                header.size = 0;
-            }
+            header.size = 0;
 
             sent = 0;
 


### PR DESCRIPTION
All currently supported FreeBSD branches are 13.x and later; every remaining conditional below is unreachable there and is removed:

- 3.x CMSG_SPACE()/CMSG_LEN()/CMSG_DATA() fallbacks (< 400017);
- the pre-7.0 sival_ptr/sigval_ptr rename (< 700005);
- the sendfile() "nbytes bug" detection: the old syscall #336 that miscounted header bytes is gone, so ngx_freebsd_sendfile_nbytes_bug was always 0 and header.size is now reset unconditionally;
- the malloc_options/_malloc_options debug tunables, removed from the base system in 10.0 (>= 500014 && < 1000011, and < 500014);
- the always-true TCP_NOPUSH osreldate test, now unconditional;
- the kern.ipc.somaxconn < 32768 check for pre-6.0 (< 600008).

The NOTE_REVOKE kqueue flag keeps its platform gate, reduced to "#if (__FreeBSD__)" since the version arithmetic only excluded non-FreeBSD BSDs.

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [ ] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)
