### PR TITLE
Strip fragments from URIs

### DIFF
--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -1392,6 +1392,8 @@ ngx_http_parse_complex_uri(ngx_http_request_t *r, ngx_uint_t merge_slashes)
                 r->args_start = p;
                 goto args;
             case '#':
+                *--p = '\0';
+                r->uri_end = p;
                 goto done;
             case '.':
                 r->uri_ext = u + 1;
@@ -1439,6 +1441,8 @@ ngx_http_parse_complex_uri(ngx_http_request_t *r, ngx_uint_t merge_slashes)
                 r->args_start = p;
                 goto args;
             case '#':
+                *--p = '\0';
+                r->uri_end = p;
                 goto done;
             case '+':
                 r->plus_in_uri = 1;
@@ -1483,6 +1487,8 @@ ngx_http_parse_complex_uri(ngx_http_request_t *r, ngx_uint_t merge_slashes)
                 goto args;
             case '#':
                 u--;
+                *--p = '\0';
+                r->uri_end = p;
                 goto done;
             case '+':
                 r->plus_in_uri = 1;
@@ -1528,6 +1534,8 @@ ngx_http_parse_complex_uri(ngx_http_request_t *r, ngx_uint_t merge_slashes)
                     goto args;
                 }
                 if (ch == '#') {
+                    *--p = '\0';
+                    r->uri_end = p;
                     goto done;
                 }
                 state = sw_slash;
@@ -1652,7 +1660,9 @@ args:
             continue;
         }
 
-        r->args.len = p - 1 - r->args_start;
+        *--p = '\0';
+        r->uri_end = p;
+        r->args.len = p - r->args_start;
         r->args.data = r->args_start;
         r->args_start = NULL;
 


### PR DESCRIPTION
## Problem

Fragments should never be sent by a client.  If a server does get them, it should either reject them or ignore them.  This chooses the "ignore" option, though rejecting is even easier.

## Solution

This removes fragments from URLs, making them unavailable even to modules.

## Testing

Matching tests at nginx/nginx-tests#70.

- [ ] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1500

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

NGINX now ignores all fragments in request URIs.  They are no longer included in `$request_uri`, and are not available to NGINX modules.  Correct clients do not send fragments in request URIs and are unaffected.