### PR TITLE
Events: Remove mandary events block in configuration file

### DIFF
--- a/src/event/ngx_event.c
+++ b/src/event/ngx_event.c
@@ -433,15 +433,60 @@ static char *
 ngx_event_init_conf(ngx_cycle_t *cycle, void *conf)
 {
 #if (NGX_HAVE_REUSEPORT)
-    ngx_uint_t        i;
     ngx_core_conf_t  *ccf;
     ngx_listening_t  *ls;
 #endif
 
+    ngx_uint_t          i;
+    void             ***ecf;
+    ngx_event_module_t *m;
+
     if (ngx_get_conf(cycle->conf_ctx, ngx_events_module) == NULL) {
-        ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,
-                      "no \"events\" section in configuration");
-        return NGX_CONF_ERROR;
+
+        ecf = ngx_pcalloc(cycle->pool, sizeof(void *));
+        if (ecf == NULL){
+            return NGX_CONF_ERROR;
+        }
+
+        cycle->conf_ctx[ngx_events_module.index] = ecf;
+
+        ngx_event_max_module = ngx_count_modules(cycle, NGX_EVENT_MODULE);
+
+        *ecf = ngx_pcalloc(cycle->pool, ngx_event_max_module * sizeof(void *));
+        if (*ecf == NULL){
+          return NGX_CONF_ERROR;
+        }
+
+        for (i = 0; cycle->modules[i]; i++) {
+            if (cycle->modules[i]->type != NGX_EVENT_MODULE) {
+                continue;
+            }
+
+            m = cycle->modules[i]->ctx;
+
+            if (m->create_conf) {
+                (*ecf)[cycle->modules[i]->ctx_index] =
+                                                     m->create_conf(cycle);
+                if ((*ecf)[cycle->modules[i]->ctx_index] == NULL) {
+                    return NGX_CONF_ERROR;
+                }
+            }
+        }
+
+        for (i = 0; cycle->modules[i]; i++) {
+            if (cycle->modules[i]->type != NGX_EVENT_MODULE) {
+                continue;
+            }
+
+            m = cycle->modules[i]->ctx;
+
+            if (m->init_conf) {
+                if (m->init_conf(cycle,
+                            (*ecf)[cycle->modules[i]->ctx_index]) != NGX_CONF_OK){
+                    return NGX_CONF_ERROR;
+                }
+            }
+        }
     }
 
     if (cycle->connection_n < cycle->listening.nelts + 1) {


### PR DESCRIPTION
## Problem

Currently `events` block is mandatory in the configuration file, even if it is empty. Without it, nginx refuses to start with the following error:
```
nginx: [emerg] no "events" section in configuration
```

## Solution

`ngx_event_init_conf()` has the following check:
```
if (ngx_get_conf(cycle->conf_ctx, ngx_events_module) == NULL) {
    ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,
                  "no \"events\" section in configuration");
    return NGX_CONF_ERROR;
}
```
Instead of failing here, context is initialized for `ngx_events_module` and its submodules. 
`create_conf()` and `init_conf()` are called for all events with type `NGX_EVENT_MODULE`.
If context was set and events modules were initialized previously by `ngx_conf_parse()` --> `ngx_events_block()` this step is skipped.


## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1532 

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

Empty `events` block is no longer mandatory in configuration file.
