### PR TITLE
Upstream keepalive: kept idle connection on data ready.

### DIFF
--- a/src/http/modules/ngx_http_upstream_keepalive_module.c
+++ b/src/http/modules/ngx_http_upstream_keepalive_module.c
@@ -413,7 +413,19 @@ ngx_http_upstream_keepalive_close_handler(ngx_event_t *ev)
 
     n = recv(c->fd, buf, 1, MSG_PEEK);
 
-    if (n == -1 && ngx_socket_errno == NGX_EAGAIN) {
+    /*
+     * Data on an idle pooled upstream connection is unexpected for
+     * HTTP/1.1 but normal for HTTP/2-based upstreams (grpc_pass),
+     * where the peer sends SETTINGS, PING, and WINDOW_UPDATE frames
+     * on otherwise-idle connections.  Since this module is protocol-
+     * agnostic, keep the connection pooled whenever the peek returns
+     * data or EAGAIN; peer-side close (n == 0) and hard errors still
+     * evict the entry.  A stray byte on an HTTP/1.1 connection will
+     * surface as an invalid response on the next request rather than
+     * causing a premature close of a healthy connection.
+     */
+
+    if (n > 0 || (n == -1 && ngx_socket_errno == NGX_EAGAIN)) {
         ev->ready = 0;
 
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {


### PR DESCRIPTION
## Summary

Fix the upstream keepalive close handler so that an idle pooled connection is not evicted when the peer sends unsolicited bytes.  This resolves premature upstream connection tear-downs on HTTP/2-based upstreams (`grpc_pass`), where the peer routinely sends SETTINGS, PING, and WINDOW_UPDATE frames on otherwise-idle connections.

Closes issue #929.

## Problem

Reported in #929 and independently confirmed by a second user in the same thread: with `grpc_pass` and gRPC keepalive PINGs on the upstream side, nginx tears down its pooled upstream connections a few seconds after their first server-initiated control frame arrives.  The reporter's diagnostic pointed straight at `ngx_http_upstream_keepalive_close_handler()` in `src/http/modules/ngx_http_upstream_keepalive_module.c`.

## Root Cause

`ngx_http_upstream_keepalive_close_handler()` is the read handler installed on a pooled upstream connection while it is idle in the pool.  It performs a `recv(MSG_PEEK)` on the socket to distinguish three cases:

- `n == -1 && errno == EAGAIN` — spurious wakeup, keep the connection.
- `n == 0` — peer closed, evict.
- Any other result — treated as an error and evicted via `goto close;`.

The last bucket incorrectly includes `n > 0` — the case where the peer sent real bytes.  For HTTP/1.1 upstreams this is unusual but tolerable; for HTTP/2-based upstreams it is the normal steady-state behavior (control frames on idle streams), so every such frame closes a perfectly healthy pooled connection.

The main upstream module already handles this correctly in `ngx_http_upstream_check_broken_connection()` (`src/http/ngx_http_upstream.c`), which treats `n > 0` as "connection still alive, return".

## Implementation

One-line condition change plus a comment explaining the HTTP/1.1 vs HTTP/2 distinction.  Change `n == -1 && EAGAIN` to `n > 0 || (n == -1 && EAGAIN)`.  Peer-side close (`n == 0`) and hard errors continue to evict.

```diff
-    if (n == -1 && ngx_socket_errno == NGX_EAGAIN) {
+    if (n > 0 || (n == -1 && ngx_socket_errno == NGX_EAGAIN)) {
```

The module is deliberately protocol-agnostic (it is shared by `proxy_pass`, `fastcgi_pass`, `grpc_pass`, `memcached`, etc.), so the fix stays inside this file and does not thread an HTTP/2 flag through the upstream layer.

### HTTP/1.1 behaviour

Previously, a stray byte on an idle HTTP/1.1 pooled connection silently evicted it.  With the fix, the byte becomes the first byte of the next response, fails HTTP/1.1 parsing, and the request is retried through the normal `proxy_next_upstream` path.  This is strictly better failure surfacing — one logged failed request instead of a silent kill of a misbehaving server's connection.

## Tests

Added regression test [`upstream_keepalive_data.t`](https://github.com/nginx/nginx-tests/pull/new/fix/upstream-keepalive-929) in the companion `nginx-tests` PR.  A Perl mock backend serves one HTTP/1.1 keepalive response, then writes a single stray byte on the idle socket after nginx has returned it to the pool.  The test asserts that the backend accepts **exactly one** TCP connection across two client requests.

Verified locally:

- **Without this patch**: `upstream_keepalive_data.t` fails — backend records 2 accepts (pool evicted).
- **With this patch**: `upstream_keepalive_data.t` passes.
- **Regression sweep**: `upstream_keepalive.t`, `fastcgi_keepalive.t`, `proxy_keepalive.t`, and the new test all pass (77/77 subtests).

## Performance

No hot-path impact.  The added branch is one extra comparison in the close handler, which fires at most once per pooled idle connection per event.

## Compatibility

- Behaviour on `n == 0` (peer close) and hard socket errors is unchanged.
- Behaviour on `EAGAIN` is unchanged.
- Only new behaviour: an HTTP/1.1 upstream that sends unsolicited bytes on an idle pooled connection will now surface a failed request (via the standard upstream retry path) instead of silently closing the connection.  This is a strictly more diagnosable failure mode.

Reported-by: leaner1000 in #929
Confirmed-by: thebitbrine in #929

/cc @hongzhidao — you asked the reporter for a repro on the original ticket; the reporter never followed up and the issue went stale, but the code path they pointed at is genuinely wrong.  Fix + regression test attached.