### PR TITLE
Fixing issue 1522 HTTP/1.1 chunked request body bypasses client_max_body_size

### DIFF
--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -850,6 +850,7 @@ ngx_http_discard_request_body_filter(ngx_http_request_t *r, ngx_buf_t *b)
     ngx_int_t                  rc;
     ngx_http_request_body_t   *rb;
     ngx_http_core_srv_conf_t  *cscf;
+    ngx_http_core_loc_conf_t  *clcf;
 
     if (r->headers_in.chunked) {
 
@@ -870,6 +871,8 @@ ngx_http_discard_request_body_filter(ngx_http_request_t *r, ngx_buf_t *b)
             r->request_body = rb;
         }
 
+        clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
         for ( ;; ) {
 
             rc = ngx_http_parse_chunked(r, b, rb->chunked, 0);
@@ -877,6 +880,20 @@ ngx_http_discard_request_body_filter(ngx_http_request_t *r, ngx_buf_t *b)
             if (rc == NGX_OK) {
 
                 /* a chunk has been parsed successfully */
+                rb->received += b->last - b->pos;
+
+                if(clcf->client_max_body_size &&
+                   rb->received > clcf->client_max_body_size) {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "client intended to send too large chunked "
+                                  "body: %O+%O bytes",
+                                  rb->received,
+                                  clcf->client_max_body_size);
+
+                    r->lingering_close = 1;
+
+                    return NGX_HTTP_REQUEST_ENTITY_TOO_LARGE;
+                }
 
                 size = b->last - b->pos;
 


### PR DESCRIPTION
## Problem

The problem is that the ```ngx_http_discard_request_body_filter``` is not taking into account of the ```client_max_body_size``` configuration. This is described in this issue:

https://github.com/nginx/nginx/issues/1522#issue-4791635918

## Solution

The solution is put a check after a chunk of data was read and compare the chunk size with the configuration maximum size.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

The test is included in the issue description but I can attach the specific files to this PR.

[poc_1522.sh](https://github.com/user-attachments/files/29766412/poc_1522.sh)
[poc_1522.py](https://github.com/user-attachments/files/29766418/poc_1522.py)

I have also run the nginx-tests perl scripts. The result was only TODO failures.

**Closes:** #1522

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

Applying this PR changes nginx behavior in the terms of checking chunked data beeing send to the server.
