### PR TITLE
HTTP/2: Reject requests with pseudo-headers after headers

### DIFF
--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1803,6 +1803,10 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
     }
 
+    if (ngx_http_v2_construct_request_line(r) != NGX_OK) {
+        goto error;
+    }
+
     if (r->invalid_header) {
         cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
 
@@ -3303,6 +3307,13 @@ ngx_http_v2_pseudo_header(ngx_http_request_t *r, ngx_http_v2_header_t *header)
     header->name.len--;
     header->name.data++;
 
+    if (r->request_line.len) {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent out of order pseudo-headers");
+
+        return NGX_DECLINED;
+    }
+
     switch (header->name.len) {
     case 4:
         if (ngx_memcmp(header->name.data, "path", sizeof("path") - 1)
@@ -3576,6 +3587,10 @@ ngx_http_v2_construct_request_line(ngx_http_request_t *r)
     u_char  *p;
 
     static const u_char ending[] = " HTTP/2.0";
+
+    if (r->request_line.len) {
+        return NGX_OK;
+    }
 
     if (r->method_name.len == 0
         || r->schema.len == 0


### PR DESCRIPTION
## Problem

[RFC 9113 §8.3](https://datatracker.ietf.org/doc/html/rfc9113#section-8.3) states:

`All pseudo-header fields MUST appear in a header section before regular header fields. A request that has any pseudo-header field that appears in a header section after a regular header field MUST be treated as malformed.`

nginx's `HTTP/2` parser (`ngx_http_v2_state_process_header()`) does not track whether a regular header has been seen. A pseudo-header (`:path`, `:method`, `:scheme`, `:authority`) appearing after a regular header (e.g. `host:`) is processed identically to one in the correct position — no error is raised.

`HTTP/3` **does** enforce the ordering via `r->request_line.len` sentinel:
```
/* ngx_http_v3_process_pseudo_header() — src/http/v3/ngx_http_v3_request.c */
if (r->request_line.len) {
    ngx_log_error(..., "client sent out of order pseudo-headers");
    goto failed;
}
```

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1526

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)