### PR TITLE
QUIC: fixed handling of HTTP/3 read-side aborts

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -1393,7 +1393,7 @@ ngx_http_upstream_check_broken_connection(ngx_http_request_t *r,
 #if (NGX_HTTP_V3)
 
     if (c->quic) {
-        if (c->write->error) {
+        if (c->read->error || c->write->error) {
             ngx_http_upstream_finalize_request(r, u,
                                                NGX_HTTP_CLIENT_CLOSED_REQUEST);
         }


### PR DESCRIPTION

`ngx_http_upstream_check_broken_connection()` has an HTTP/3 branch that finalizes the request with `NGX_HTTP_CLIENT_CLOSED_REQUEST` (499) when the client aborts, but it only checks `c->write->error`, which is set by a client `STOP_SENDING` frame (`ngx_quic_handle_stop_sending_frame()`).

A client `RESET_STREAM` frame sets `c->read->error` instead (`ngx_quic_handle_reset_stream_frame()`). That read-side abort is ignored: the request keeps waiting on the upstream and is finalized without a status when the QUIC connection is torn down, so the access log records `$status` as `"000"`.

This change checks `c->read->error` as well, matching the HTTP/2 `RST_STREAM` handling, so a request aborted with a bare `RESET_STREAM` is finalized with 499.


nginx proxies to an upstream that accepts the connection but never responds; the HTTP/3 client sends a request, then a bare `RESET_STREAM` (`H3_REQUEST_CANCELLED`) on the request stream without a `STOP_SENDING`, then closes the connection. Before the change the access log shows `000`; after it, `499`.

I could only reproduce this with Python and aioquic — curl/ngtcp2 cannot emit a bare `RESET_STREAM` without also aborting the receive side (which sends `STOP_SENDING` and hits the existing `c->write->error` path). Reproducer script in the comments below.
