### PR TITLE
HTTP: reject invalid characters in field names per RFC 9110

### DIFF
--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -3458,17 +3458,22 @@ ngx_http_grpc_validate_header_name(ngx_http_request_t *r, ngx_str_t *s)
     for (i = 0; i < s->len; i++) {
         ch = s->data[i];
 
-        if (ch == ':' && i > 0) {
-            return NGX_ERROR;
+        if ((ch >= 'a' && ch <= 'z')
+            || (ch >= '0' && ch <= '9')
+            || ch == '-' || ch == '_'
+            || ch == '!' || ch == '#' || ch == '$' || ch == '%'
+            || ch == '&' || ch == '\'' || ch == '*' || ch == '+'
+            || ch == '.' || ch == '^' || ch == '`' || ch == '|'
+            || ch == '~')
+        {
+            continue;
         }
 
-        if (ch >= 'A' && ch <= 'Z') {
-            return NGX_ERROR;
+        if (ch == ':' && i == 0) {
+            continue;
         }
 
-        if (ch <= 0x20 || ch == 0x7f) {
-            return NGX_ERROR;
-        }
+        return NGX_ERROR;
     }
 
     return NGX_OK;

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -3296,17 +3296,22 @@ ngx_http_proxy_v2_validate_header_name(ngx_http_request_t *r, ngx_str_t *s)
     for (i = 0; i < s->len; i++) {
         ch = s->data[i];
 
-        if (ch == ':' && i > 0) {
-            return NGX_ERROR;
+        if ((ch >= 'a' && ch <= 'z')
+            || (ch >= '0' && ch <= '9')
+            || ch == '-' || ch == '_'
+            || ch == '!' || ch == '#' || ch == '$' || ch == '%'
+            || ch == '&' || ch == '\'' || ch == '*' || ch == '+'
+            || ch == '.' || ch == '^' || ch == '`' || ch == '|'
+            || ch == '~')
+        {
+            continue;
         }
 
-        if (ch >= 'A' && ch <= 'Z') {
-            return NGX_ERROR;
+        if (ch == ':' && i == 0) {
+            continue;
         }
 
-        if (ch <= 0x20 || ch == 0x7f) {
-            return NGX_ERROR;
-        }
+        return NGX_ERROR;
     }
 
     return NGX_OK;

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -888,9 +888,9 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
 
     static u_char  lowcase[] =
         "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-        "\0\0\0\0\0\0\0\0\0\0\0\0\0-\0\0" "0123456789\0\0\0\0\0\0"
-        "\0abcdefghijklmnopqrstuvwxyz\0\0\0\0\0"
-        "\0abcdefghijklmnopqrstuvwxyz\0\0\0\0\0"
+        "\0!\0#$%&'\0\0*+\0-.\0" "0123456789\0\0\0\0\0\0"
+        "\0abcdefghijklmnopqrstuvwxyz\0\0\0^\0"
+        "`abcdefghijklmnopqrstuvwxyz\0|\0~\0"
         "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
         "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
         "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
@@ -950,12 +950,8 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
                     return NGX_HTTP_PARSE_INVALID_HEADER;
                 }
 
-                hash = 0;
-                i = 0;
-                r->invalid_header = 1;
-
-                break;
-
+                r->header_end = p;
+                return NGX_HTTP_PARSE_INVALID_HEADER;
             }
             break;
 
@@ -1019,9 +1015,8 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
                 return NGX_HTTP_PARSE_INVALID_HEADER;
             }
 
-            r->invalid_header = 1;
-
-            break;
+            r->header_end = p;
+            return NGX_HTTP_PARSE_INVALID_HEADER;
 
         /* space* before header value */
         case sw_space_before_value:

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3259,22 +3259,28 @@ ngx_http_v2_validate_header(ngx_http_request_t *r, ngx_http_v2_header_t *header)
         if ((ch >= 'a' && ch <= 'z')
             || (ch == '-')
             || (ch >= '0' && ch <= '9')
-            || (ch == '_' && cscf->underscores_in_headers))
+            || ch == '!' || ch == '#' || ch == '$' || ch == '%'
+            || ch == '&' || ch == '\'' || ch == '*' || ch == '+'
+            || ch == '.' || ch == '^' || ch == '`' || ch == '|'
+            || ch == '~')
         {
             continue;
         }
 
-        if (ch <= 0x20 || ch == 0x7f || ch == ':'
-            || (ch >= 'A' && ch <= 'Z'))
-        {
-            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
-                          "client sent invalid header name: \"%V\"",
-                          &header->name);
+        if (ch == '_') {
+            if (cscf->underscores_in_headers) {
+                continue;
+            }
 
-            return NGX_ERROR;
+            r->invalid_header = 1;
+            continue;
         }
 
-        r->invalid_header = 1;
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent invalid header name: \"%V\"",
+                      &header->name);
+
+        return NGX_ERROR;
     }
 
     for (i = 0; i != header->value.len; i++) {

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -719,21 +719,27 @@ ngx_http_v3_validate_header(ngx_http_request_t *r, ngx_str_t *name,
         if ((ch >= 'a' && ch <= 'z')
             || (ch == '-')
             || (ch >= '0' && ch <= '9')
-            || (ch == '_' && cscf->underscores_in_headers))
+            || ch == '!' || ch == '#' || ch == '$' || ch == '%'
+            || ch == '&' || ch == '\'' || ch == '*' || ch == '+'
+            || ch == '.' || ch == '^' || ch == '`' || ch == '|'
+            || ch == '~')
         {
             continue;
         }
 
-        if (ch <= 0x20 || ch == 0x7f || ch == ':'
-            || (ch >= 'A' && ch <= 'Z'))
-        {
-            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
-                          "client sent invalid header name: \"%V\"", name);
+        if (ch == '_') {
+            if (cscf->underscores_in_headers) {
+                continue;
+            }
 
-            return NGX_ERROR;
+            r->invalid_header = 1;
+            continue;
         }
 
-        r->invalid_header = 1;
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent invalid header name: \"%V\"", name);
+
+        return NGX_ERROR;
     }
 
     for (i = 0; i != value->len; i++) {


### PR DESCRIPTION
Updated field name validation to use the full tchar set defined in RFC 9110 Section 5.6.2 instead of accepting only alphanumeric and hyphen characters.

In the HTTP/1 parser, expanded the lowcase[] table to include all tchar characters and changed the fallthrough for non-tchar characters from a soft invalid_header flag to a hard reject.

In the HTTP/2 and HTTP/3 input validators, replaced the partial blocklist with a tchar allowlist so that non-tchar characters are rejected instead of being silently accepted.

In the gRPC and proxy_v2 upstream response parsers, switched validate_header_name() from a blocklist to a tchar allowlist to prevent invalid field names from upstream backends leaking through.

Closes: https://github.com/nginx/nginx/issues/1503

## Testing

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
