### PR TITLE
Fix setting the IPV6_DONTFRAG socket option

### DIFF
--- a/auto/unix
+++ b/auto/unix
@@ -472,7 +472,7 @@ ngx_feature_incs="#include <sys/socket.h>
                   #include <netinet/in.h>"
 ngx_feature_path=
 ngx_feature_libs=
-ngx_feature_test="setsockopt(0, IPPROTO_IP, IPV6_DONTFRAG, NULL, 0)"
+ngx_feature_test="setsockopt(0, IPPROTO_IPV6, IPV6_DONTFRAG, NULL, 0)"
 . auto/feature
 
 

--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -1099,7 +1099,7 @@ ngx_configure_listening_sockets(ngx_cycle_t *cycle)
             }
         }
 
-#elif (NGX_HAVE_IP_DONTFRAG)
+#elif (NGX_HAVE_IPV6_DONTFRAG)
 
         if (ls[i].quic && ls[i].sockaddr->sa_family == AF_INET6) {
             value = 1;


### PR DESCRIPTION
The fix includes the socket option level (IPPROTO_IPV6) in the feature test and the macro (NGX_HAVE_IPV6_DONTFRAG) in the ngx_configure_listening_sockets() function.

Reported by Eric Fortis.