### PR TITLE
HTTP: fix possible int overflow in ngx_http_mp4_crop_stts_data

### DIFF
--- a/src/http/modules/ngx_http_mp4_module.c
+++ b/src/http/modules/ngx_http_mp4_module.c
@@ -2469,7 +2469,7 @@ found:
         start_sample -= key_prefix;
 
         while (rest < key_prefix) {
-            trak->prefix += rest * duration;
+            trak->prefix += (uint64_t) rest * duration;
             key_prefix -= rest;
 
             entry--;
@@ -2480,7 +2480,7 @@ found:
             rest = count;
         }
 
-        trak->prefix += key_prefix * duration;
+        trak->prefix += (uint64_t) key_prefix * duration;
         trak->duration += trak->prefix;
         rest -= key_prefix;
 


### PR DESCRIPTION
## Problem

Found by Linux Verification Center (linuxtesting.org) with SVACE.

NO_CAST.INTEGER_OVERFLOW The value of an arithmetic expression 'rest * duration' is a subject to overflow because its operands are not cast to a larger data type before performing arithmetic.

NO_CAST.INTEGER_OVERFLOW The value of an arithmetic expression 'key_prefix * duration' is a subject to overflow because its operands are not cast to a larger data type before performing arithmetic

The variable `rest` can take values ​​ranging from 0 to several million. The variable `duration` can range from 1 to several thousand. The product `rest * duration` may exceed the maximum value for `uint32_t`, so an explicit cast to a wider data type (such as `uint64_t`) is required before performing the multiplication.

The same about `key_prefix`.

## Solution

Add an explicit cast to `uint64_t` for 2 variables.