### PR TITLE
Upstream: limit HTTP/2 response trailers

### DIFF
--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -105,6 +105,8 @@ typedef struct {
     ngx_str_t                  name;
     ngx_str_t                  value;
 
+    size_t                     trailer_limit;
+
     u_char                    *field_end;
     size_t                     field_length;
     size_t                     field_rest;
@@ -567,6 +569,8 @@ ngx_http_grpc_handler(ngx_http_request_t *r)
     ngx_http_set_ctx(r, ctx, ngx_http_grpc_module);
 
     glcf = ngx_http_get_module_loc_conf(r, ngx_http_grpc_module);
+
+    ctx->trailer_limit = glcf->upstream.buffer_size;
 
     u = r->upstream;
 
@@ -2025,6 +2029,7 @@ ngx_http_grpc_filter(void *data, ssize_t bytes)
 {
     ngx_http_grpc_ctx_t  *ctx = data;
 
+    size_t                len;
     ngx_int_t             rc;
     ngx_buf_t            *b, *buf;
     ngx_chain_t          *cl, **ll;
@@ -2342,6 +2347,16 @@ ngx_http_grpc_filter(void *data, ssize_t bytes)
                                       &ctx->name, &ctx->value);
                         return NGX_ERROR;
                     }
+
+                    len = ctx->name.len + ctx->value.len;
+
+                    if (len > ctx->trailer_limit) {
+                        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                      "upstream sent too big trailers");
+                        return NGX_ERROR;
+                    }
+
+                    ctx->trailer_limit -= len;
 
                     h = ngx_list_push(&u->headers_in.trailers);
                     if (h == NULL) {

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -76,6 +76,8 @@ typedef struct {
     ngx_str_t                      name;
     ngx_str_t                      value;
 
+    size_t                         trailer_limit;
+
     u_char                        *field_end;
     size_t                         field_length;
     size_t                         field_rest;
@@ -235,6 +237,8 @@ ngx_http_proxy_v2_handler(ngx_http_request_t *r)
     ngx_http_set_ctx(r, &ctx->ctx, ngx_http_proxy_module);
 
     plcf = ngx_http_get_module_loc_conf(r, ngx_http_proxy_module);
+
+    ctx->trailer_limit = plcf->upstream.buffer_size;
 
     plcf->upstream.preserve_output = 1;
 
@@ -2017,6 +2021,7 @@ static ngx_int_t
 ngx_http_proxy_v2_process_frames(ngx_http_request_t *r,
     ngx_http_proxy_v2_ctx_t *ctx, ngx_buf_t *b)
 {
+    size_t                len;
     ngx_int_t             rc;
     ngx_table_elt_t      *h;
     ngx_http_upstream_t  *u;
@@ -2236,6 +2241,16 @@ ngx_http_proxy_v2_process_frames(ngx_http_request_t *r,
                                       &ctx->name, &ctx->value);
                         return NGX_ERROR;
                     }
+
+                    len = ctx->name.len + ctx->value.len;
+
+                    if (len > ctx->trailer_limit) {
+                        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                      "upstream sent too big trailers");
+                        return NGX_ERROR;
+                    }
+
+                    ctx->trailer_limit -= len;
 
                     h = ngx_list_push(&u->headers_in.trailers);
                     if (h == NULL) {


### PR DESCRIPTION
Limit upstream response trailers using proxy_buffer_size and grpc_buffer_size.

## Problem

Upstream response trailer limited by proxy_buffer_size directive for proxy module. However, proxy_v2 and grpc modules, response trailers are currently collected without any size limit. As a result, upstream can send a very large number of response trailers.

## Solution

For proxy_v2, upstream response trailer size is bounded using proxy_buffer_size; for grpc, it is bounded using grpc_buffer_size. While parsing trailers, nginx tracks cumulative trailer bytes in trailer_bytes; if adding a trailer would exceed the configured limit, nginx logs an error and rejects the upstream response. 

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
