### PR TITLE
Xslt: disable loading of external entities by default

### DIFF
--- a/src/http/modules/ngx_http_xslt_filter_module.c
+++ b/src/http/modules/ngx_http_xslt_filter_module.c
@@ -382,7 +382,7 @@ ngx_http_xslt_add_chunk(ngx_http_request_t *r, ngx_http_xslt_filter_ctx_t *ctx,
             return NGX_ERROR;
         }
         xmlCtxtUseOptions(ctxt, XML_PARSE_NOENT|XML_PARSE_DTDLOAD
-                                               |XML_PARSE_NOWARNING);
+                                |XML_PARSE_NONET|XML_PARSE_NOWARNING);
 
         ctxt->sax->externalSubset = ngx_http_xslt_sax_external_subset;
         ctxt->sax->setDocumentLocator = NULL;

--- a/src/http/modules/ngx_http_xslt_filter_module.c
+++ b/src/http/modules/ngx_http_xslt_filter_module.c
@@ -11,6 +11,7 @@
 
 #include <libxml/parser.h>
 #include <libxml/tree.h>
+#include <libxml/xmlversion.h>
 #include <libxslt/xslt.h>
 #include <libxslt/xsltInternals.h>
 #include <libxslt/transform.h>
@@ -19,6 +20,10 @@
 
 #if (NGX_HAVE_EXSLT)
 #include <libexslt/exslt.h>
+#endif
+
+#if (defined LIBXML_CATALOG_ENABLED && LIBXML_VERSION < 21400)
+#include <libxml/catalog.h>
 #endif
 
 
@@ -59,6 +64,7 @@ typedef struct {
     ngx_array_t               *types_keys;
     ngx_array_t               *params;       /* ngx_http_xslt_param_t */
     ngx_flag_t                 last_modified;
+    ngx_flag_t                 external_entities;
 } ngx_http_xslt_filter_loc_conf_t;
 
 
@@ -81,6 +87,9 @@ static ngx_int_t ngx_http_xslt_add_chunk(ngx_http_request_t *r,
 
 static void ngx_http_xslt_sax_external_subset(void *data, const xmlChar *name,
     const xmlChar *externalId, const xmlChar *systemId);
+static void ngx_http_xslt_sax_entity_decl(void *data, const xmlChar *name,
+    int type, const xmlChar *publicId, const xmlChar *systemId,
+    xmlChar *content);
 static void ngx_cdecl ngx_http_xslt_sax_error(void *data, const char *msg, ...);
 
 
@@ -122,6 +131,13 @@ static ngx_command_t  ngx_http_xslt_filter_commands[] = {
       ngx_http_xslt_entities,
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
+      NULL },
+
+    { ngx_string("xml_external_entities"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_xslt_filter_loc_conf_t, external_entities),
       NULL },
 
     { ngx_string("xslt_stylesheet"),
@@ -385,6 +401,7 @@ ngx_http_xslt_add_chunk(ngx_http_request_t *r, ngx_http_xslt_filter_ctx_t *ctx,
                                 |XML_PARSE_NONET|XML_PARSE_NOWARNING);
 
         ctxt->sax->externalSubset = ngx_http_xslt_sax_external_subset;
+        ctxt->sax->entityDecl = ngx_http_xslt_sax_entity_decl;
         ctxt->sax->setDocumentLocator = NULL;
         ctxt->sax->error = ngx_http_xslt_sax_error;
         ctxt->sax->fatalError = ngx_http_xslt_sax_error;
@@ -457,6 +474,64 @@ ngx_http_xslt_sax_external_subset(void *data, const xmlChar *name,
 #endif
 
     doc->extSubset = dtd;
+}
+
+
+static void
+ngx_http_xslt_sax_entity_decl(void *data, const xmlChar *name, int type,
+    const xmlChar *publicId, const xmlChar *systemId, xmlChar *content)
+{
+    xmlParserCtxtPtr ctxt = data;
+
+    ngx_http_request_t               *r;
+    ngx_http_xslt_filter_ctx_t       *ctx;
+    ngx_http_xslt_filter_loc_conf_t  *conf;
+
+    ctx = ctxt->sax->_private;
+    r = ctx->request;
+
+    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "xslt filter entityDecl: \"%s\" \"%s\" \"%s\"",
+                   name ? name : (xmlChar *) "",
+                   publicId ? publicId : (xmlChar *) "",
+                   systemId ? systemId : (xmlChar *) "");
+
+    conf = ngx_http_get_module_loc_conf(r, ngx_http_xslt_filter_module);
+
+    if (systemId && !conf->external_entities) {
+
+        /*
+         * If external entiries in the internal DTD subset are disabled,
+         * we remove system identifiers from such entities.  This makes sure
+         * that external entities cannot be used to directly request arbitrary
+         * files, but still can be used with public identifiers, assuming these
+         * are included into XML catalogs on the system.
+         */
+
+        ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                      "xslt filter external entity ignored: "
+                      "\"%s\" \"%s\" \"%s\"",
+                      name ? name : (xmlChar *) "",
+                      publicId ? publicId : (xmlChar *) "",
+                      systemId ? systemId : (xmlChar *) "");
+
+        if (publicId) {
+            xmlSAX2EntityDecl(data, name, type, publicId, (xmlChar *) "",
+                              content);
+
+        } else if (type == XML_EXTERNAL_GENERAL_PARSED_ENTITY) {
+            xmlSAX2EntityDecl(data, name, XML_INTERNAL_GENERAL_ENTITY,
+                              NULL, NULL, (xmlChar *) "");
+
+        } else if (type == XML_EXTERNAL_PARAMETER_ENTITY) {
+            xmlSAX2EntityDecl(data, name, XML_INTERNAL_PARAMETER_ENTITY,
+                              NULL, NULL, (xmlChar *) "");
+        }
+
+        return;
+    }
+
+    xmlSAX2EntityDecl(data, name, type, publicId, systemId, content);
 }
 
 
@@ -1096,6 +1171,7 @@ ngx_http_xslt_filter_create_conf(ngx_conf_t *cf)
      */
 
     conf->last_modified = NGX_CONF_UNSET;
+    conf->external_entities = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -1128,6 +1204,7 @@ ngx_http_xslt_filter_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     }
 
     ngx_conf_merge_value(conf->last_modified, prev->last_modified, 0);
+    ngx_conf_merge_value(conf->external_entities, prev->external_entities, 0);
 
     return NGX_CONF_OK;
 }
@@ -1140,6 +1217,10 @@ ngx_http_xslt_filter_preconfiguration(ngx_conf_t *cf)
 
 #if (NGX_HAVE_EXSLT)
     exsltRegisterAll();
+#endif
+
+#if (defined LIBXML_CATALOG_ENABLED && LIBXML_VERSION < 21400)
+    xmlCatalogSetDefaults(XML_CATA_ALLOW_GLOBAL);
 #endif
 
     return NGX_OK;


### PR DESCRIPTION
### Summary

The XSLT filter module initialises its libxml2 push parser with
`XML_PARSE_NOENT | XML_PARSE_DTDLOAD` and, apart from replacing the
external DTD subset via the `externalSubset` SAX hook, does not restrict
external entity resolution. As a result, external general entities
declared in the internal DTD subset of a processed XML response
(`<!DOCTYPE d [ <!ENTITY x SYSTEM "file:///..."> ]>`) are expanded by
libxml2, which reads the referenced file or, on builds with network
support, fetches the URL — the latter able to block the worker process
for a significant time.

This is expected only for trusted input; the module documentation already
notes that the external subset cannot be used and that `xml_entities` is
the supported way to define a fixed set of entities. This change makes
that guarantee hold for the internal subset as well.

### Change

Loading of external entities declared in the internal DTD subset is now
**disabled by default** and can be re-enabled per location with
`xml_external_entities on;` where the input is known to be trusted.
Interception happens in the `entityDecl` SAX callback, which strips the
system identifier from such entities; public identifiers (system XML
catalogs) continue to work. `XML_PARSE_NONET` is additionally set to
prevent loading of external entities over the network (also removed
upstream in libxml2 2.15.0). In-document catalogs are disabled on libxml2
before 2.14.0.

Configured `xml_entities` are unaffected (loaded at configuration time as
internal entities), and existing behaviour is preserved when
`xml_external_entities on;` is set.

### Provenance

The two functional commits are from freenginx, authored by Maxim Dounin;
authorship is preserved and each carries an `Origin:` trailer linking to
the upstream changeset:

- Xslt: disabled loading of external entities over the network
  https://freenginx.org/hg/nginx/rev/081c50f47347
- Xslt: xml_external_entities directive
  https://freenginx.org/hg/nginx/rev/94dae9ab1018

### Tests

Regression coverage is submitted separately to the test suite as
nginx/nginx-tests#74, which adds `xslt_external_entities.t`. It verifies:

- a `file://` SYSTEM entity declared in the internal DTD subset is not
  loaded by default — the referenced file contents are absent from the
  response while the element itself is preserved;
- with `xml_external_entities on;` the same document loads the entity
  (the opt-in path; the same document blocked vs. loaded is the
  differential check that the default-off behaviour is what does the
  blocking);
- an `http://` SYSTEM entity is blocked by `XML_PARSE_NONET` and does not
  terminate the worker;
- predefined entities (`&lt; &gt; &amp;`) continue to work.

Verified against libxml2 2.9.13.


### Documentation

Directive documentation (English and Russian) is submitted separately:
nginx/nginx.org#291.
