### PR TITLE
Fix #1194: scope ngx_http_script_run flushes, add fastcgi bounds check

### DIFF
--- a/src/http/modules/ngx_http_fastcgi_module.c
+++ b/src/http/modules/ngx_http_fastcgi_module.c
@@ -776,7 +776,7 @@ ngx_http_fastcgi_eval(ngx_http_request_t *r, ngx_http_fastcgi_loc_conf_t *flcf)
     ngx_memzero(&url, sizeof(ngx_url_t));
 
     if (ngx_http_script_run(r, &url.url, flcf->fastcgi_lengths->elts, 0,
-                            flcf->fastcgi_values->elts)
+                            flcf->fastcgi_values->elts, NULL)
         == NULL)
     {
         return NGX_ERROR;
@@ -844,7 +844,7 @@ static ngx_int_t
 ngx_http_fastcgi_create_request(ngx_http_request_t *r)
 {
     off_t                         file_pos;
-    u_char                        ch, sep, *pos, *lowcase_key;
+    u_char                        ch, sep, *pos, *lowcase_key, *params_body;
     size_t                        size, len, key_len, val_len, padding,
                                   allocated;
     ngx_uint_t                    i, n, next, hash, skip_empty, header_params;
@@ -1051,6 +1051,8 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
                      + sizeof(ngx_http_fastcgi_begin_request_t)
                      + sizeof(ngx_http_fastcgi_header_t);
 
+    params_body = b->last;
+
 
     if (params->lengths) {
         ngx_memzero(&e, sizeof(ngx_http_script_engine_t));
@@ -1213,6 +1215,21 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
 
             continue;
         }
+    }
+
+    if ((size_t) (b->last - params_body) != len) {
+        ngx_log_error(NGX_LOG_CRIT, r->connection->log, 0,
+                      "fastcgi params size mismatch: "
+                      "length_pass=%uz fill_pass=%uz diff=%z",
+                      len, (size_t) (b->last - params_body),
+                      (ssize_t) (b->last - params_body) - (ssize_t) len);
+        return NGX_ERROR;
+    }
+
+    if (b->last > b->end) {
+        ngx_log_error(NGX_LOG_CRIT, r->connection->log, 0,
+                      "fastcgi params buffer overflow");
+        return NGX_ERROR;
     }
 
 

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -629,7 +629,7 @@ ngx_http_grpc_eval(ngx_http_request_t *r, ngx_http_grpc_ctx_t *ctx,
     ngx_memzero(&url, sizeof(ngx_url_t));
 
     if (ngx_http_script_run(r, &url.url, glcf->grpc_lengths->elts, 0,
-                            glcf->grpc_values->elts)
+                            glcf->grpc_values->elts, NULL)
         == NULL)
     {
         return NGX_ERROR;

--- a/src/http/modules/ngx_http_log_module.c
+++ b/src/http/modules/ngx_http_log_module.c
@@ -531,7 +531,7 @@ ngx_http_log_script_write(ngx_http_request_t *r, ngx_http_log_script_t *script,
     }
 
     if (ngx_http_script_run(r, &log, script->lengths->elts, 1,
-                            script->values->elts)
+                            script->values->elts, NULL)
         == NULL)
     {
         /* simulate successful logging */

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -981,7 +981,7 @@ ngx_http_proxy_eval(ngx_http_request_t *r, ngx_http_proxy_ctx_t *ctx,
     ngx_http_upstream_t  *u;
 
     if (ngx_http_script_run(r, &proxy, plcf->proxy_lengths->elts, 0,
-                            plcf->proxy_values->elts)
+                            plcf->proxy_values->elts, NULL)
         == NULL)
     {
         return NGX_ERROR;

--- a/src/http/modules/ngx_http_scgi_module.c
+++ b/src/http/modules/ngx_http_scgi_module.c
@@ -574,7 +574,7 @@ ngx_http_scgi_eval(ngx_http_request_t *r, ngx_http_scgi_loc_conf_t * scf)
     ngx_memzero(&url, sizeof(ngx_url_t));
 
     if (ngx_http_script_run(r, &url.url, scf->scgi_lengths->elts, 0,
-                            scf->scgi_values->elts)
+                            scf->scgi_values->elts, NULL)
         == NULL)
     {
         return NGX_ERROR;

--- a/src/http/modules/ngx_http_tunnel_module.c
+++ b/src/http/modules/ngx_http_tunnel_module.c
@@ -216,7 +216,7 @@ ngx_http_tunnel_eval(ngx_http_request_t *r, ngx_http_tunnel_loc_conf_t *tlcf)
     ngx_memzero(&url, sizeof(ngx_url_t));
 
     if (ngx_http_script_run(r, &url.url, tlcf->tunnel_lengths->elts, 0,
-                            tlcf->tunnel_values->elts)
+                            tlcf->tunnel_values->elts, NULL)
         == NULL)
     {
         return NGX_ERROR;

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -765,7 +765,7 @@ ngx_http_uwsgi_eval(ngx_http_request_t *r, ngx_http_uwsgi_loc_conf_t * uwcf)
     ngx_memzero(&url, sizeof(ngx_url_t));
 
     if (ngx_http_script_run(r, &url.url, uwcf->uwsgi_lengths->elts, 0,
-                            uwcf->uwsgi_values->elts)
+                            uwcf->uwsgi_values->elts, NULL)
         == NULL)
     {
         return NGX_ERROR;

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1985,7 +1985,7 @@ ngx_http_map_uri_to_path(ngx_http_request_t *r, ngx_str_t *path,
         }
 
         if (ngx_http_script_run(r, path, clcf->root_lengths->elts, reserved,
-                                clcf->root_values->elts)
+                                clcf->root_values->elts, clcf->root_flushes)
             == NULL)
         {
             return NULL;
@@ -3769,6 +3769,7 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         conf->root = prev->root;
         conf->root_lengths = prev->root_lengths;
         conf->root_values = prev->root_values;
+        conf->root_flushes = prev->root_flushes;
 
         if (prev->root.data == NULL) {
             ngx_str_set(&conf->root, "html");
@@ -4683,6 +4684,7 @@ ngx_http_core_root(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         sc.source = &clcf->root;
         sc.lengths = &clcf->root_lengths;
         sc.values = &clcf->root_values;
+        sc.flushes = &clcf->root_flushes;
         sc.complete_lengths = 1;
         sc.complete_values = 1;
 

--- a/src/http/ngx_http_core_module.h
+++ b/src/http/ngx_http_core_module.h
@@ -350,6 +350,7 @@ struct ngx_http_core_loc_conf_s {
 
     ngx_array_t  *root_lengths;
     ngx_array_t  *root_values;
+    ngx_array_t  *root_flushes;
 
     ngx_array_t  *types;
     ngx_hash_t    types_hash;

--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -615,22 +615,14 @@ invalid_variable:
 
 u_char *
 ngx_http_script_run(ngx_http_request_t *r, ngx_str_t *value,
-    void *code_lengths, size_t len, void *code_values)
+    void *code_lengths, size_t len, void *code_values,
+    ngx_array_t *flushes)
 {
-    ngx_uint_t                    i;
     ngx_http_script_code_pt       code;
     ngx_http_script_len_code_pt   lcode;
     ngx_http_script_engine_t      e;
-    ngx_http_core_main_conf_t    *cmcf;
 
-    cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
-
-    for (i = 0; i < cmcf->variables.nelts; i++) {
-        if (r->variables[i].no_cacheable) {
-            r->variables[i].valid = 0;
-            r->variables[i].not_found = 0;
-        }
-    }
+    ngx_http_script_flush_no_cacheable_variables(r, flushes);
 
     ngx_memzero(&e, sizeof(ngx_http_script_engine_t));
 

--- a/src/http/ngx_http_script.h
+++ b/src/http/ngx_http_script.h
@@ -232,7 +232,8 @@ char *ngx_http_set_predicate_slot(ngx_conf_t *cf, ngx_command_t *cmd,
 ngx_uint_t ngx_http_script_variables_count(ngx_str_t *value);
 ngx_int_t ngx_http_script_compile(ngx_http_script_compile_t *sc);
 u_char *ngx_http_script_run(ngx_http_request_t *r, ngx_str_t *value,
-    void *code_lengths, size_t reserved, void *code_values);
+    void *code_lengths, size_t reserved, void *code_values,
+    ngx_array_t *flushes);
 void ngx_http_script_flush_no_cacheable_variables(ngx_http_request_t *r,
     ngx_array_t *indices);
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -4556,7 +4556,7 @@ ngx_http_upstream_store(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
     } else {
         if (ngx_http_script_run(r, &path, u->conf->store_lengths->elts, 0,
-                                u->conf->store_values->elts)
+                                u->conf->store_values->elts, NULL)
             == NULL)
         {
             return;

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -1642,7 +1642,7 @@ ngx_http_variable_document_root(ngx_http_request_t *r,
 
     } else {
         if (ngx_http_script_run(r, &path, clcf->root_lengths->elts, 0,
-                                clcf->root_values->elts)
+                                clcf->root_values->elts, clcf->root_flushes)
             == NULL)
         {
             return NGX_ERROR;
@@ -1684,7 +1684,7 @@ ngx_http_variable_realpath_root(ngx_http_request_t *r,
 
     } else {
         if (ngx_http_script_run(r, &path, clcf->root_lengths->elts, 1,
-                                clcf->root_values->elts)
+                                clcf->root_values->elts, clcf->root_flushes)
             == NULL)
         {
             return NGX_ERROR;


### PR DESCRIPTION
Fixes nginx/nginx#1194

## Problem

`ngx_http_fastcgi_create_request()` (and scgi/uwsgi) uses a two-pass design: a length pass sums param sizes, then a fill pass writes data. When `fastcgi_param` references NOCACHEABLE variables (e.g. `$tcpinfo_rtt`) and `root` contains variables, `$document_root` / `$realpath_root` call `ngx_http_script_run()`, which blanket-flushes **all** NOCACHEABLE variables in the request. That causes variables to be re-evaluated mid-length-pass with different sizes than the fill pass, producing buffer overruns and worker SIGSEGV.

## Root cause

`ngx_http_script_run()` flushed every `NOCACHEABLE` variable on entry. `ngx_http_complex_value()` already uses scoped flush via its own `flushes` array — `ngx_http_script_run()` did not.

## Fix

1. **`ngx_http_script_run()`** — replace blanket flush with scoped `ngx_http_script_flush_no_cacheable_variables(r, flushes)`; add `flushes` parameter to the API.
2. **`root_flushes`** — compile and pass scoped flushes for variable `root` scripts used by `$document_root` and `$realpath_root`.
3. **FastCGI safety net** — detect params size mismatch and buffer overflow; return `NGX_ERROR` instead of silent heap corruption.

## Verification

Deterministic reproducer: NOCACHEABLE `$test_growing_var` (grows on 2nd handler call) + variable `root` + `$realpath_root` in `fastcgi_param`.

**Before:**
```
test_growing_var: call=1 len=4
test_growing_var: call=2 len=54
AddressSanitizer: SEGV in ngx_http_fastcgi_create_request
```

**After:**
```
test_growing_var: call=1 len=4
BUG_REPRODUCED=no
```

Also verified: `$tcpinfo_*` production config pattern, scgi/uwsgi, param order variants, try_files named location, 14-case bypass suite, 50-request stress test.

## Related

Sibling of the pull-vs-push consistency class discussed in #1194. Permanent fix direction from maintainer: avoid recursive global variable flushes (scoped flush, as `ngx_http_complex_value` does).