### PR TITLE
Configure: include crypt.h for crypt() feature tests

### DIFF
--- a/auto/unix
+++ b/auto/unix
@@ -132,7 +132,7 @@ fi
 ngx_feature="crypt()"
 ngx_feature_name="NGX_HAVE_CRYPT"
 ngx_feature_run=no
-ngx_feature_incs=
+ngx_feature_incs="$NGX_INCLUDE_CRYPT_H"
 ngx_feature_path=
 ngx_feature_libs=
 ngx_feature_test="crypt(\"test\", \"salt\");"
@@ -144,7 +144,7 @@ if [ $ngx_found = no ]; then
     ngx_feature="crypt() in libcrypt"
     ngx_feature_name="NGX_HAVE_CRYPT"
     ngx_feature_run=no
-    ngx_feature_incs=
+    ngx_feature_incs="$NGX_INCLUDE_CRYPT_H"
     ngx_feature_path=
     ngx_feature_libs=-lcrypt
     . auto/feature


### PR DESCRIPTION
In 9a4090f02ab438c47178b3b5a4c15a3c769d5027 we started guarding the use of `crypt()` with the result of the `NGX_HAVE_CRYPT` feature test. In some configurations, the `crypt()` definition is only accessible from `<crypt.h>`, so the feature test fails without the right includes. As a result, such configurations fall back to an empty implementation of `ngx_libc_crypt()`.

Fixes `auth_basic.t` on Solaris 11.4 with GCC.