### PR TITLE
HTTP cache: add sub-second cache validity support

### DIFF
--- a/src/http/ngx_http_cache.h
+++ b/src/http/ngx_http_cache.h
@@ -32,7 +32,7 @@
 
 typedef struct {
     ngx_uint_t                       status;
-    time_t                           valid;
+    ngx_msec_t                       valid;
 } ngx_http_cache_valid_t;
 
 
@@ -196,7 +196,8 @@ void ngx_http_file_cache_update(ngx_http_request_t *r, ngx_temp_file_t *tf);
 void ngx_http_file_cache_update_header(ngx_http_request_t *r);
 ngx_int_t ngx_http_cache_send(ngx_http_request_t *);
 void ngx_http_file_cache_free(ngx_http_cache_t *c, ngx_temp_file_t *tf);
-time_t ngx_http_file_cache_valid(ngx_array_t *cache_valid, ngx_uint_t status);
+ngx_msec_t ngx_http_file_cache_valid(ngx_array_t *cache_valid,
+    ngx_uint_t status);
 
 char *ngx_http_file_cache_set_slot(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);

--- a/src/http/ngx_http_file_cache.c
+++ b/src/http/ngx_http_file_cache.c
@@ -545,8 +545,9 @@ ngx_http_file_cache_read(ngx_http_request_t *r, ngx_http_cache_t *c)
     u_char                        *p;
     time_t                         now;
     ssize_t                        n;
-    ngx_str_t                     *key;
     ngx_int_t                      rc;
+    ngx_str_t                     *key;
+    ngx_time_t                    *tp;
     ngx_uint_t                     i;
     ngx_http_file_cache_t         *cache;
     ngx_http_file_cache_header_t  *h;
@@ -650,8 +651,11 @@ ngx_http_file_cache_read(ngx_http_request_t *r, ngx_http_cache_t *c)
     }
 
     now = ngx_time();
+    tp = ngx_timeofday();
 
-    if (c->valid_sec < now) {
+    if (c->valid_sec < now
+        || (c->valid_sec == now && c->valid_msec <= tp->msec))
+    {
         c->stale_updating = c->valid_sec + c->updating_sec >= now;
         c->stale_error = c->valid_sec + c->error_sec >= now;
 
@@ -900,8 +904,14 @@ ngx_http_file_cache_exists(ngx_http_file_cache_t *cache, ngx_http_cache_t *c)
         }
 
         if (fcn->error) {
+            ngx_time_t  *tp;
 
-            if (fcn->valid_sec < ngx_time()) {
+            tp = ngx_timeofday();
+
+            if (fcn->valid_sec < tp->sec
+                || (fcn->valid_sec == tp->sec
+                    && fcn->valid_msec <= tp->msec))
+            {
                 goto renew;
             }
 
@@ -2349,7 +2359,7 @@ ngx_http_file_cache_set_watermark(ngx_http_file_cache_t *cache)
 }
 
 
-time_t
+ngx_msec_t
 ngx_http_file_cache_valid(ngx_array_t *cache_valid, ngx_uint_t status)
 {
     ngx_uint_t               i;
@@ -2728,9 +2738,9 @@ ngx_http_file_cache_valid_set_slot(ngx_conf_t *cf, ngx_command_t *cmd,
 {
     char  *p = conf;
 
-    time_t                    valid;
-    ngx_str_t                *value;
     ngx_int_t                 status;
+    ngx_str_t                *value;
+    ngx_msec_t                valid;
     ngx_uint_t                i, n;
     ngx_array_t             **a;
     ngx_http_cache_valid_t   *v;
@@ -2748,8 +2758,8 @@ ngx_http_file_cache_valid_set_slot(ngx_conf_t *cf, ngx_command_t *cmd,
     value = cf->args->elts;
     n = cf->args->nelts - 1;
 
-    valid = ngx_parse_time(&value[n], 1);
-    if (valid == (time_t) NGX_ERROR) {
+    valid = ngx_parse_time(&value[n], 0);
+    if (valid == (ngx_msec_t) NGX_ERROR) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                            "invalid time value \"%V\"", &value[n]);
         return NGX_CONF_ERROR;

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -2853,8 +2853,9 @@ ngx_http_upstream_test_next(ngx_http_request_t *r, ngx_http_upstream_t *u)
         && u->cache_status == NGX_HTTP_CACHE_EXPIRED
         && u->conf->cache_revalidate)
     {
-        time_t     now, valid, updating, error;
-        ngx_int_t  rc;
+        time_t      now, valid, updating, error;
+        ngx_int_t   rc;
+        ngx_msec_t  valid_ms;
 
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                        "http upstream not modified");
@@ -2890,10 +2891,11 @@ ngx_http_upstream_test_next(ngx_http_request_t *r, ngx_http_upstream_t *u)
         }
 
         if (valid == 0) {
-            valid = ngx_http_file_cache_valid(u->conf->cache_valid,
-                                              u->headers_in.status_n);
-            if (valid) {
-                valid = now + valid;
+            valid_ms = ngx_http_file_cache_valid(u->conf->cache_valid,
+                                                 u->headers_in.status_n);
+            if (valid_ms) {
+                valid = now + valid_ms / 1000;
+                r->cache->valid_msec = valid_ms % 1000;
             }
         }
 
@@ -2983,15 +2985,18 @@ ngx_http_upstream_intercept_errors(ngx_http_request_t *r,
                 }
 
                 if (u->cacheable) {
-                    time_t  valid;
+                    time_t      valid;
+                    ngx_msec_t  valid_ms;
 
                     valid = r->cache->valid_sec;
 
                     if (valid == 0) {
-                        valid = ngx_http_file_cache_valid(u->conf->cache_valid,
-                                                          status);
-                        if (valid) {
-                            r->cache->valid_sec = ngx_time() + valid;
+                        valid_ms = ngx_http_file_cache_valid(
+                                       u->conf->cache_valid, status);
+                        if (valid_ms) {
+                            r->cache->valid_sec = ngx_time() + valid_ms / 1000;
+                            r->cache->valid_msec = valid_ms % 1000;
+                            valid = r->cache->valid_sec;
                         }
                     }
 
@@ -3420,17 +3425,20 @@ ngx_http_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
     }
 
     if (u->cacheable) {
-        time_t  now, valid;
+        time_t      now, valid;
+        ngx_msec_t  valid_ms;
 
         now = ngx_time();
 
         valid = r->cache->valid_sec;
 
         if (valid == 0) {
-            valid = ngx_http_file_cache_valid(u->conf->cache_valid,
-                                              u->headers_in.status_n);
-            if (valid) {
-                r->cache->valid_sec = now + valid;
+            valid_ms = ngx_http_file_cache_valid(u->conf->cache_valid,
+                                                 u->headers_in.status_n);
+            if (valid_ms) {
+                r->cache->valid_sec = now + valid_ms / 1000;
+                r->cache->valid_msec = valid_ms % 1000;
+                valid = r->cache->valid_sec;
             }
         }
 
@@ -4869,12 +4877,13 @@ ngx_http_upstream_finalize_request(ngx_http_request_t *r,
         if (u->cacheable) {
 
             if (rc == NGX_HTTP_BAD_GATEWAY || rc == NGX_HTTP_GATEWAY_TIME_OUT) {
-                time_t  valid;
+                ngx_msec_t  valid_ms;
 
-                valid = ngx_http_file_cache_valid(u->conf->cache_valid, rc);
+                valid_ms = ngx_http_file_cache_valid(u->conf->cache_valid, rc);
 
-                if (valid) {
-                    r->cache->valid_sec = ngx_time() + valid;
+                if (valid_ms) {
+                    r->cache->valid_sec = ngx_time() + valid_ms / 1000;
+                    r->cache->valid_msec = valid_ms % 1000;
                     r->cache->error = rc;
                 }
             }


### PR DESCRIPTION
Allow proxy_cache_valid and friends directives to accept millisecond values using the "ms" suffix (e.g. "500ms").


## Problem

Briefly describe the issue or feature being addressed.

## Solution

Explain your approach and any important design decisions.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [ ] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1156 

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
