### PR TITLE
HTTP: stop accepting invalid HTTP field values

### DIFF
--- a/src/event/ngx_event_openssl_stapling.c
+++ b/src/event/ngx_event_openssl_stapling.c
@@ -2258,6 +2258,7 @@ ngx_ssl_ocsp_parse_header_line(ngx_ssl_ocsp_ctx_t *ctx)
         case sw_space_before_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 break;
             case CR:
                 ctx->header_start = p;
@@ -2279,6 +2280,7 @@ ngx_ssl_ocsp_parse_header_line(ngx_ssl_ocsp_ctx_t *ctx)
         case sw_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 ctx->header_end = p;
                 state = sw_space_after_value;
                 break;
@@ -2296,6 +2298,7 @@ ngx_ssl_ocsp_parse_header_line(ngx_ssl_ocsp_ctx_t *ctx)
         case sw_space_after_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 break;
             case CR:
                 state = sw_almost_done;

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -3570,6 +3570,14 @@ ngx_http_grpc_validate_header_value(ngx_http_request_t *r, ngx_str_t *s)
     u_char      ch;
     ngx_uint_t  i;
 
+    if (s->len > 0
+        && (s->data[0] == ' ' || s->data[0] == '\t'
+            || s->data[s->len - 1] == ' '
+            || s->data[s->len - 1] == '\t'))
+    {
+        return NGX_ERROR;
+    }
+
     for (i = 0; i < s->len; i++) {
         ch = s->data[i];
 

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -3051,14 +3051,16 @@ ngx_http_proxy_parse_cookie(ngx_str_t *value, ngx_array_t *attrs)
             last = end;
         }
 
-        while (start < last && *start == ' ') { start++; }
+        while (start < last && (*start == ' ' || *start == '\t')) { start++; }
 
         for (p = start; p < last && *p != '='; p++) { /* void */ }
 
         name.data = start;
         name.len = p - start;
 
-        while (name.len && name.data[name.len - 1] == ' ') {
+        while (name.len && (name.data[name.len - 1] == ' '
+                            || name.data[name.len - 1] == '\t'))
+        {
             name.len--;
         }
 
@@ -3066,12 +3068,14 @@ ngx_http_proxy_parse_cookie(ngx_str_t *value, ngx_array_t *attrs)
 
             p++;
 
-            while (p < last && *p == ' ') { p++; }
+            while (p < last && (*p == ' ' || *p == '\t')) { p++; }
 
             val.data = p;
             val.len = last - val.data;
 
-            while (val.len && val.data[val.len - 1] == ' ') {
+            while (val.len && (val.data[val.len - 1] == ' '
+                               || val.data[val.len - 1] == '\t'))
+            {
                 val.len--;
             }
 

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -3397,6 +3397,14 @@ ngx_http_proxy_v2_validate_header_value(ngx_http_request_t *r, ngx_str_t *s)
     u_char      ch;
     ngx_uint_t  i;
 
+    if (s->len > 0
+        && (s->data[0] == ' ' || s->data[0] == '\t'
+            || s->data[s->len - 1] == ' '
+            || s->data[s->len - 1] == '\t'))
+    {
+        return NGX_ERROR;
+    }
+
     for (i = 0; i < s->len; i++) {
         ch = s->data[i];
 

--- a/src/http/modules/ngx_http_range_filter_module.c
+++ b/src/http/modules/ngx_http_range_filter_module.c
@@ -306,7 +306,7 @@ ngx_http_range_parse(ngx_http_request_t *r, ngx_http_range_filter_ctx_t *ctx,
         end = 0;
         suffix = 0;
 
-        while (*p == ' ') { p++; }
+        while (*p == ' ' || *p == '\t') { p++; }
 
         if (*p != '-') {
             if (*p < '0' || *p > '9') {
@@ -321,13 +321,13 @@ ngx_http_range_parse(ngx_http_request_t *r, ngx_http_range_filter_ctx_t *ctx,
                 start = start * 10 + (*p++ - '0');
             }
 
-            while (*p == ' ') { p++; }
+            while (*p == ' ' || *p == '\t') { p++; }
 
             if (*p++ != '-') {
                 return NGX_HTTP_RANGE_NOT_SATISFIABLE;
             }
 
-            while (*p == ' ') { p++; }
+            while (*p == ' ' || *p == '\t') { p++; }
 
             if (*p == ',' || *p == '\0') {
                 end = content_length;
@@ -351,7 +351,7 @@ ngx_http_range_parse(ngx_http_request_t *r, ngx_http_range_filter_ctx_t *ctx,
             end = end * 10 + (*p++ - '0');
         }
 
-        while (*p == ' ') { p++; }
+        while (*p == ' ' || *p == '\t') { p++; }
 
         if (*p != ',' && *p != '\0') {
             return NGX_HTTP_RANGE_NOT_SATISFIABLE;

--- a/src/http/modules/ngx_http_slice_filter_module.c
+++ b/src/http/modules/ngx_http_slice_filter_module.c
@@ -313,7 +313,7 @@ ngx_http_slice_parse_content_range(ngx_http_request_t *r,
     end = 0;
     complete_length = 0;
 
-    while (*p == ' ') { p++; }
+    while (*p == ' ' || *p == '\t') { p++; }
 
     if (*p < '0' || *p > '9') {
         return NGX_ERROR;
@@ -327,13 +327,13 @@ ngx_http_slice_parse_content_range(ngx_http_request_t *r,
         start = start * 10 + (*p++ - '0');
     }
 
-    while (*p == ' ') { p++; }
+    while (*p == ' ' || *p == '\t') { p++; }
 
     if (*p++ != '-') {
         return NGX_ERROR;
     }
 
-    while (*p == ' ') { p++; }
+    while (*p == ' ' || *p == '\t') { p++; }
 
     if (*p < '0' || *p > '9') {
         return NGX_ERROR;
@@ -349,13 +349,13 @@ ngx_http_slice_parse_content_range(ngx_http_request_t *r,
 
     end++;
 
-    while (*p == ' ') { p++; }
+    while (*p == ' ' || *p == '\t') { p++; }
 
     if (*p++ != '/') {
         return NGX_ERROR;
     }
 
-    while (*p == ' ') { p++; }
+    while (*p == ' ' || *p == '\t') { p++; }
 
     if (*p != '*') {
         if (*p < '0' || *p > '9') {
@@ -377,7 +377,7 @@ ngx_http_slice_parse_content_range(ngx_http_request_t *r,
         p++;
     }
 
-    while (*p == ' ') { p++; }
+    while (*p == ' ' || *p == '\t') { p++; }
 
     if (*p != '\0') {
         return NGX_ERROR;
@@ -470,7 +470,7 @@ ngx_http_slice_get_start(ngx_http_request_t *r)
         return 0;
     }
 
-    while (*p == ' ') { p++; }
+    while (*p == ' ' || *p == '\t') { p++; }
 
     if (*p == '-') {
         return 0;

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -2042,9 +2042,10 @@ ngx_http_auth_basic_user(ngx_http_request_t *r)
     encoded = h->value;
 
     if (encoded.len < sizeof("Basic ") - 1
-        || ngx_strncasecmp(encoded.data, (u_char *) "Basic ",
-                           sizeof("Basic ") - 1)
-           != 0)
+        || ngx_strncasecmp(encoded.data, (u_char *) "Basic",
+                           sizeof("Basic") - 1) != 0
+        || (encoded.data[sizeof("Basic") - 1] != ' '
+            && encoded.data[sizeof("Basic") - 1] != '\t'))
     {
         r->headers_in.user.data = (u_char *) "";
         return NGX_DECLINED;
@@ -2053,7 +2054,7 @@ ngx_http_auth_basic_user(ngx_http_request_t *r)
     encoded.len -= sizeof("Basic ") - 1;
     encoded.data += sizeof("Basic ") - 1;
 
-    while (encoded.len && encoded.data[0] == ' ') {
+    while (encoded.len && (encoded.data[0] == ' ' || encoded.data[0] == '\t')) {
         encoded.len--;
         encoded.data++;
     }
@@ -2279,7 +2280,7 @@ ngx_http_gzip_accept_encoding(ngx_str_t *ae)
             return NGX_DECLINED;
         }
 
-        if (p == start || (*(p - 1) == ',' || *(p - 1) == ' ')) {
+        if (p == start || (*(p - 1) == ',' || *(p - 1) == ' ' || *(p - 1) == '\t')) {
             break;
         }
 
@@ -2295,6 +2296,7 @@ ngx_http_gzip_accept_encoding(ngx_str_t *ae)
         case ';':
             goto quantity;
         case ' ':
+        case '\t':
             continue;
         default:
             return NGX_DECLINED;
@@ -2311,6 +2313,7 @@ quantity:
         case 'Q':
             goto equal;
         case ' ':
+        case '\t':
             continue;
         default:
             return NGX_DECLINED;
@@ -2353,7 +2356,7 @@ ngx_http_gzip_quantity(u_char *p, u_char *last)
 
     c = *p++;
 
-    if (c == ',' || c == ' ') {
+    if (c == ',' || c == ' ' || c == '\t') {
         return q;
     }
 
@@ -2366,7 +2369,7 @@ ngx_http_gzip_quantity(u_char *p, u_char *last)
     while (p < last) {
         c = *p++;
 
-        if (c == ',' || c == ' ') {
+        if (c == ',' || c == ' ' || c == '\t') {
             break;
         }
 
@@ -2875,13 +2878,13 @@ ngx_http_get_forwarded_addr_internal(ngx_http_request_t *r, ngx_addr_t *addr,
         }
 
         for (p = xff + xfflen - 1; p > xff; p--, xfflen--) {
-            if (*p != ' ' && *p != ',') {
+            if (*p != ' ' && *p != '\t' && *p != ',') {
                 break;
             }
         }
 
         for ( /* void */ ; p > xff; p--) {
-            if (*p == ' ' || *p == ',') {
+            if (*p == ' ' || *p == '\t' || *p == ',') {
                 p++;
                 break;
             }

--- a/src/http/ngx_http_file_cache.c
+++ b/src/http/ngx_http_file_cache.c
@@ -1135,11 +1135,11 @@ ngx_http_file_cache_vary(ngx_http_request_t *r, u_char *vary, size_t len,
 
     while (p < last) {
 
-        while (p < last && (*p == ' ' || *p == ',')) { p++; }
+        while (p < last && (*p == ' ' || *p == '\t' || *p == ',')) { p++; }
 
         name.data = p;
 
-        while (p < last && *p != ',' && *p != ' ') { p++; }
+        while (p < last && *p != ',' && *p != ' ' && *p != '\t') { p++; }
 
         name.len = p - name.data;
 
@@ -1241,11 +1241,11 @@ ngx_http_file_cache_vary_header(ngx_http_request_t *r, ngx_md5_t *md5,
 
         while (p < last) {
 
-            while (p < last && (*p == ' ' || *p == ',')) { p++; }
+            while (p < last && (*p == ' ' || *p == '\t' || *p == ',')) { p++; }
 
             start = p;
 
-            while (p < last && *p != ',' && *p != ' ') { p++; }
+            while (p < last && *p != ',' && *p != ' ' && *p != '\t') { p++; }
 
             len = p - start;
 

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -1027,6 +1027,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_space_before_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 break;
             case CR:
                 r->header_start = p;
@@ -1051,6 +1052,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 r->header_end = p;
                 state = sw_space_after_value;
                 break;
@@ -1071,6 +1073,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_space_after_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 break;
             case CR:
                 state = sw_almost_done;
@@ -2057,7 +2060,7 @@ ngx_http_parse_multi_header_lines_internal(ngx_http_request_t *r,
                 goto skip;
             }
 
-            for (start += name->len; start < end && *start == ' '; start++) {
+            for (start += name->len; start < end && (*start == ' ' || *start == '\t'); start++) {
                 /* void */
             }
 
@@ -2074,7 +2077,7 @@ ngx_http_parse_multi_header_lines_internal(ngx_http_request_t *r,
                 goto skip;
             }
 
-            while (start < end && *start == ' ') { start++; }
+            while (start < end && (*start == ' ' || *start == '\t')) { start++; }
 
             for (last = start; last < end && *last != sep; last++) {
                 /* void */
@@ -2094,7 +2097,7 @@ ngx_http_parse_multi_header_lines_internal(ngx_http_request_t *r,
                 }
             }
 
-            while (start < end && *start == ' ') { start++; }
+            while (start < end && (*start == ' ' || *start == '\t')) { start++; }
         }
     }
 
@@ -2125,7 +2128,7 @@ ngx_http_parse_set_cookie_lines(ngx_http_request_t *r,
             continue;
         }
 
-        for (start += name->len; start < end && *start == ' '; start++) {
+        for (start += name->len; start < end && (*start == ' ' || *start == '\t'); start++) {
             /* void */
         }
 
@@ -2134,7 +2137,7 @@ ngx_http_parse_set_cookie_lines(ngx_http_request_t *r,
             continue;
         }
 
-        while (start < end && *start == ' ') { start++; }
+        while (start < end && (*start == ' ' || *start == '\t')) { start++; }
 
         for (last = start; last < end && *last != ';'; last++) {
             /* void */

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -1210,7 +1210,7 @@ ngx_http_upstream_cache_check_range(ngx_http_request_t *r,
 
     p = h->value.data + 6;
 
-    while (*p == ' ') { p++; }
+    while (*p == ' ' || *p == '\t') { p++; }
 
     if (*p == '-') {
         return NGX_DECLINED;

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3250,6 +3250,38 @@ ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
 
 
 static ngx_int_t
+ngx_http_v2_validate_header_value(ngx_str_t *value)
+{
+    u_char     ch;
+    ngx_uint_t  i;
+
+    if (value->len == 0) {
+        return NGX_OK;
+    }
+
+    if (value->data[0] == ' ' || value->data[0] == '\t') {
+        return NGX_ERROR;
+    }
+
+    if (value->data[value->len - 1] == ' '
+        || value->data[value->len - 1] == '\t')
+    {
+        return NGX_ERROR;
+    }
+
+    for (i = 0; i < value->len; i++) {
+        ch = value->data[i];
+
+        if (ch == '\0' || ch == CR || ch == LF) {
+            return NGX_ERROR;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
 ngx_http_v2_validate_header(ngx_http_request_t *r, ngx_http_v2_header_t *header)
 {
     u_char                     ch;
@@ -3284,17 +3316,13 @@ ngx_http_v2_validate_header(ngx_http_request_t *r, ngx_http_v2_header_t *header)
         r->invalid_header = 1;
     }
 
-    for (i = 0; i != header->value.len; i++) {
-        ch = header->value.data[i];
+    if (ngx_http_v2_validate_header_value(&header->value) != NGX_OK) {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent header \"%V\" with "
+                      "invalid value: \"%V\"",
+                      &header->name, &header->value);
 
-        if (ch == '\0' || ch == LF || ch == CR) {
-            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
-                          "client sent header \"%V\" with "
-                          "invalid value: \"%V\"",
-                          &header->name, &header->value);
-
-            return NGX_ERROR;
-        }
+        return NGX_ERROR;
     }
 
     return NGX_OK;

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3284,6 +3284,21 @@ ngx_http_v2_validate_header(ngx_http_request_t *r, ngx_http_v2_header_t *header)
         r->invalid_header = 1;
     }
 
+    /* RFC 9113, 8.2.1: no leading or trailing SP (0x20) or HTAB (0x09) */
+
+    if (header->value.len > 0
+        && (header->value.data[0] == ' ' || header->value.data[0] == '\t'
+            || header->value.data[header->value.len - 1] == ' '
+            || header->value.data[header->value.len - 1] == '\t'))
+    {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent header \"%V\" with "
+                      "invalid value: \"%V\"",
+                      &header->name, &header->value);
+
+        return NGX_ERROR;
+    }
+
     for (i = 0; i != header->value.len; i++) {
         ch = header->value.data[i];
 

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -702,6 +702,55 @@ ngx_http_v3_process_header(ngx_http_request_t *r, ngx_str_t *name,
 
 
 static ngx_int_t
+ngx_http_v3_validate_header_value(ngx_str_t *value)
+{
+    ngx_uint_t  i;
+
+    /* Table values: 0 - invalid, 1 - interior only (SP, HTAB), 2 - valid. */
+
+    static u_char  classes[256] = {
+     /*  0    1    2    3    4    5    6    7    8    9    A    B    C    D    E    F  */
+        0,   0,   0,   0,   0,   0,   0,   0,   0,   1,   0,   0,   0,   0,   0,   0, /* 0x0X */
+        0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0, /* 0x1X */
+        1,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, /* 0x2X */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, /* 0x3X */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, /* 0x4X */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, /* 0x5X */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, /* 0x6X */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   0, /* 0x7X */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, /* 0x8X */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, /* 0x9X */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, /* 0xAX */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, /* 0xBX */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, /* 0xCX */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, /* 0xDX */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2, /* 0xEX */
+        2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2  /* 0xFX */
+    };
+
+    if (value->len == 0) {
+        return NGX_OK;
+    }
+
+    if (classes[value->data[0]] != 2) {
+        return NGX_ERROR;
+    }
+
+    if (classes[value->data[value->len - 1]] != 2) {
+        return NGX_ERROR;
+    }
+
+    for (i = 1; i + 1 < value->len; i++) {
+        if (classes[value->data[i]] == 0) {
+            return NGX_ERROR;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
 ngx_http_v3_validate_header(ngx_http_request_t *r, ngx_str_t *name,
     ngx_str_t *value)
 {
@@ -736,16 +785,12 @@ ngx_http_v3_validate_header(ngx_http_request_t *r, ngx_str_t *name,
         r->invalid_header = 1;
     }
 
-    for (i = 0; i != value->len; i++) {
-        ch = value->data[i];
+    if (ngx_http_v3_validate_header_value(value) != NGX_OK) {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent header \"%V\" with "
+                      "invalid value: \"%V\"", name, value);
 
-        if (ch == '\0' || ch == LF || ch == CR) {
-            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
-                          "client sent header \"%V\" with "
-                          "invalid value: \"%V\"", name, value);
-
-            return NGX_ERROR;
-        }
+        return NGX_ERROR;
     }
 
     return NGX_OK;

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -736,6 +736,20 @@ ngx_http_v3_validate_header(ngx_http_request_t *r, ngx_str_t *name,
         r->invalid_header = 1;
     }
 
+    /* RFC 9114, 10.3; RFC 9113, 8.2.1: no leading or trailing SP or HTAB */
+
+    if (value->len > 0
+        && (value->data[0] == ' ' || value->data[0] == '\t'
+            || value->data[value->len - 1] == ' '
+            || value->data[value->len - 1] == '\t'))
+    {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent header \"%V\" with "
+                      "invalid value: \"%V\"", name, value);
+
+        return NGX_ERROR;
+    }
+
     for (i = 0; i != value->len; i++) {
         ch = value->data[i];
 

--- a/src/mail/ngx_mail_auth_http_module.c
+++ b/src/mail/ngx_mail_auth_http_module.c
@@ -1006,6 +1006,7 @@ ngx_mail_auth_http_parse_header_line(ngx_mail_session_t *s,
         case sw_space_before_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 break;
             case CR:
                 ctx->header_start = p;
@@ -1027,6 +1028,7 @@ ngx_mail_auth_http_parse_header_line(ngx_mail_session_t *s,
         case sw_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 ctx->header_end = p;
                 state = sw_space_after_value;
                 break;
@@ -1044,6 +1046,7 @@ ngx_mail_auth_http_parse_header_line(ngx_mail_session_t *s,
         case sw_space_after_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 break;
             case CR:
                 state = sw_almost_done;


### PR DESCRIPTION
Both H2 (ngx_http_v2_validate_header) and H3 (ngx_http_v3_validate_header) only reject \0, CR, LF in field values. RFC 9114 §10.3 (H3 MUST) and RFC 9113 §8.2.1 (H2 SHOULD) require rejecting leading/trailing SP/HTAB and other non-field-vchar bytes.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes**: [1524](https://github.com/nginx/nginx/issues/1524)

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)
