### PR TITLE
SSL: honour server-level ssl_early_data overrides with OpenSSL

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -2119,7 +2119,20 @@ ngx_ssl_create_connection(ngx_ssl_t *ssl, ngx_connection_t *c, ngx_uint_t flags)
     sc->session_ctx = ssl->ctx;
 
 #ifdef SSL_READ_EARLY_DATA_SUCCESS
-    if (SSL_CTX_get_max_early_data(ssl->ctx)) {
+    /*
+     * On server-side connections, always attempt SSL_read_early_data():
+     * if the SNI-selected server ends up with max_early_data == 0, or
+     * no early data is offered, SSL_read_early_data() returns
+     * SSL_READ_EARLY_DATA_FINISH and we fall back to a normal
+     * handshake.  Deferring this choice to the SNI callback isn't
+     * possible because the callback runs mid-way through
+     * SSL_do_handshake().
+     *
+     * Client-side connections (e.g. proxy_pass https://) must not set
+     * this: SSL_read_early_data() is a server-only API for reading
+     * incoming 0-RTT from a peer.
+     */
+    if (!(flags & NGX_SSL_CLIENT)) {
         sc->try_early_data = 1;
     }
 #endif

--- a/src/event/quic/ngx_event_quic_ssl.c
+++ b/src/event/quic/ngx_event_quic_ssl.c
@@ -900,9 +900,12 @@ ngx_quic_init_connection(ngx_connection_t *c)
         return NGX_ERROR;
     }
 
-    if (SSL_CTX_get_max_early_data(qc->conf->ssl->ctx)) {
-        SSL_set_quic_tls_early_data_enabled(ssl_conn, 1);
-    }
+    /*
+     * Enable early data unconditionally; the per-connection
+     * max_early_data (updated in the SNI callback for the selected
+     * server) governs whether 0-RTT is actually accepted.
+     */
+    SSL_set_quic_tls_early_data_enabled(ssl_conn, 1);
 
 #else /* NGX_QUIC_BORINGSSL_API || NGX_QUIC_QUICTLS_API */
 
@@ -925,9 +928,8 @@ ngx_quic_init_connection(ngx_connection_t *c)
     }
 
 #if (NGX_QUIC_QUICTLS_API)
-    if (SSL_CTX_get_max_early_data(qc->conf->ssl->ctx)) {
-        SSL_set_quic_early_data_enabled(ssl_conn, 1);
-    }
+    /* see the SSL_set_quic_tls_early_data_enabled comment above */
+    SSL_set_quic_early_data_enabled(ssl_conn, 1);
 #endif
 
 #endif

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -1005,6 +1005,43 @@ ngx_http_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
         SSL_set_options(ssl_conn, SSL_OP_NO_RENEGOTIATION);
 #endif
 
+        /*
+         * Re-sync per-connection TLS 1.3 early data limit to match the
+         * SNI-selected server: SSL_new() copies max_early_data from the
+         * initial SSL_CTX and SSL_set_SSL_CTX() does not update it, so
+         * without this the server-level ssl_early_data setting is
+         * silently ignored (both directions: an "on" override never
+         * takes effect, and an "off" override fails to disable 0-RTT).
+         *
+         * The nginx-side try_early_data flag is intentionally not
+         * touched here: the SNI callback runs mid-handshake, and
+         * flipping the flag after ngx_ssl_handshake() has already
+         * chosen SSL_do_handshake() vs SSL_read_early_data() leads to
+         * "called a function you should not call" errors.
+         */
+
+#ifdef SSL_READ_EARLY_DATA_SUCCESS
+        {
+            uint32_t  max;
+
+            max = SSL_CTX_get_max_early_data(sscf->ssl.ctx);
+
+#if (NGX_HTTP_V3)
+            /*
+             * For QUIC, RFC 9001 requires max_early_data_size in the
+             * NewSessionTicket to be either 0 (disabled) or 0xFFFFFFFF
+             * (unlimited; QUIC's own flow control governs the actual
+             * amount). Any other value is a PROTOCOL_VIOLATION.
+             */
+            if (c->listening->quic && max != 0) {
+                max = 0xffffffff;
+            }
+#endif
+
+            SSL_set_max_early_data(ssl_conn, max);
+        }
+#endif
+
 #ifdef SSL_OP_ENABLE_MIDDLEBOX_COMPAT
 #if (NGX_HTTP_V3)
         if (c->listening->quic) {


### PR DESCRIPTION
```
SSL: honour server-level ssl_early_data overrides with OpenSSL

When nginx is built against OpenSSL, the per-server ssl_early_data
directive was silently ignored if it differed from the http-level
setting.  Both directions were affected:

- server "on" with http "off" (or unset): 0-RTT was never enabled, so
  clients could not send early data to the SNI-selected server.

- server "off" with http "on": 0-RTT was silently accepted, bypassing
  the server's explicit policy.

Two pieces of state were out of sync.  First, OpenSSL's SSL object
copies max_early_data from the initial (default) SSL_CTX in SSL_new()
and SSL_set_SSL_CTX() does not update it; the SNI callback now re-syncs
it from the selected server's SSL_CTX.  For QUIC, the value is capped to
0xFFFFFFFF as required by RFC 9001, section 4.6.1.

Second, nginx's try_early_data flag, which chooses between
SSL_do_handshake() and SSL_read_early_data() at connection creation, was
previously gated on the default SSL_CTX's max_early_data.  This decision
has to be made before any TLS bytes are consumed - it can't be deferred
to the SNI callback, which runs mid-handshake.  It is now set
unconditionally on server-side connections; when the SNI-selected server
has max_early_data == 0 or no early data is offered,
SSL_read_early_data() returns SSL_READ_EARLY_DATA_FINISH and nginx falls
back to a normal handshake.  Client-side connections (e.g.  proxy_pass
https://) are excluded since SSL_read_early_data() is a server-only
OpenSSL API.

The equivalent gates in ngx_quic_init_connection() around
SSL_set_quic_tls_early_data_enabled() (OpenSSL 3.5+ native QUIC) and
SSL_set_quic_early_data_enabled() (QuicTLS) are also removed so 0-RTT
can be enabled on any SNI-selected server.

Bug reproduced on OpenSSL 1.1.1w, 3.0.15, and 3.5.7, across both
TLS-over-TCP and HTTP/3.  Present since commit ab9038af7 ("SSL: support
for TLSv1.3 early data with OpenSSL") when the feature was first
introduced.  All changes are gated on SSL_READ_EARLY_DATA_SUCCESS or
NGX_QUIC_OPENSSL_API/NGX_QUIC_QUICTLS_API so builds against other TLS
libraries are unaffected.

Closes: https://github.com/nginx/nginx/issues/1536
Assisted-by: GitHub Copilot:claude-opus-4.7
```