### PR TITLE
QUIC: send DATA_BLOCKED and STREAM_DATA_BLOCKED frames

### DIFF
--- a/src/event/quic/ngx_event_quic.h
+++ b/src/event/quic/ngx_event_quic.h
@@ -124,6 +124,7 @@ struct ngx_quic_stream_s {
     ngx_quic_stream_recv_state_e   recv_state;
     unsigned                       cancelable:1;
     unsigned                       fin_acked:1;
+    unsigned                       blocked:1;
 };
 
 

--- a/src/event/quic/ngx_event_quic_ack.c
+++ b/src/event/quic/ngx_event_quic_ack.c
@@ -807,6 +807,17 @@ ngx_quic_resend_frames(ngx_connection_t *c, ngx_quic_send_ctx_t *ctx)
             ngx_quic_queue_frame(qc, f);
             break;
 
+        case NGX_QUIC_FT_DATA_BLOCKED:
+            if (qc->streams.send_offset < qc->streams.send_max_data) {
+                /* not blocked on MAX_DATA anymore */
+                ngx_quic_free_frame(c, f);
+                break;
+            }
+
+            f->u.data_blocked.limit = qc->streams.send_max_data;
+            ngx_quic_queue_frame(qc, f);
+            break;
+
         case NGX_QUIC_FT_MAX_STREAMS:
         case NGX_QUIC_FT_MAX_STREAMS2:
             f->u.max_streams.limit = f->u.max_streams.bidi
@@ -824,6 +835,24 @@ ngx_quic_resend_frames(ngx_connection_t *c, ngx_quic_send_ctx_t *ctx)
             }
 
             f->u.max_stream_data.limit = qs->recv_max_data;
+            ngx_quic_queue_frame(qc, f);
+            break;
+
+        case NGX_QUIC_FT_STREAM_DATA_BLOCKED:
+            qs = ngx_quic_find_stream(&qc->streams.tree,
+                                      f->u.stream_data_blocked.id);
+
+            if (qs == NULL
+                || qs->send_state != NGX_QUIC_STREAM_SEND_SEND
+                || qs->send_offset < qs->send_max_data
+                || qs->send.offset == qs->sent)
+            {
+                /* not blocked on MAX_STREAM_DATA anymore */
+                ngx_quic_free_frame(c, f);
+                break;
+            }
+
+            f->u.stream_data_blocked.limit = qs->send_max_data;
             ngx_quic_queue_frame(qc, f);
             break;
 

--- a/src/event/quic/ngx_event_quic_connection.h
+++ b/src/event/quic/ngx_event_quic_connection.h
@@ -156,6 +156,8 @@ typedef struct {
     uint64_t                          send_offset;
     uint64_t                          send_max_data;
 
+    ngx_uint_t                        blocked;  /* unsigned  blocked:1; */
+
     uint64_t                          server_max_streams_uni;
     uint64_t                          server_max_streams_bidi;
     uint64_t                          server_streams_uni;

--- a/src/event/quic/ngx_event_quic_streams.c
+++ b/src/event/quic/ngx_event_quic_streams.c
@@ -39,6 +39,7 @@ static ngx_int_t ngx_quic_control_flow(ngx_quic_stream_t *qs, uint64_t last);
 static ngx_int_t ngx_quic_update_flow(ngx_quic_stream_t *qs, uint64_t last);
 static ngx_int_t ngx_quic_update_max_stream_data(ngx_quic_stream_t *qs);
 static ngx_int_t ngx_quic_update_max_data(ngx_connection_t *c);
+static ngx_int_t ngx_quic_check_blocked(ngx_quic_stream_t *qs);
 static void ngx_quic_set_event(ngx_event_t *ev);
 
 
@@ -1054,7 +1055,7 @@ ngx_quic_stream_flush(ngx_quic_stream_t *qs)
     }
 
     if (len == 0 && !last) {
-        return NGX_OK;
+        return ngx_quic_check_blocked(qs);
     }
 
     frame = ngx_quic_alloc_frame(pc);
@@ -1082,6 +1083,10 @@ ngx_quic_stream_flush(ngx_quic_stream_t *qs)
     ngx_log_debug3(NGX_LOG_DEBUG_EVENT, pc->log, 0,
                    "quic stream id:0x%xL flush len:%O last:%ui",
                    qs->id, len, last);
+
+    if (ngx_quic_check_blocked(qs) != NGX_OK) {
+        return NGX_ERROR;
+    }
 
     if (qs->connection == NULL) {
         return ngx_quic_close_stream(qs);
@@ -1335,6 +1340,8 @@ ngx_quic_handle_max_data_frame(ngx_connection_t *c,
         return NGX_OK;
     }
 
+    qc->streams.blocked = 0;
+
     if (tree->root == tree->sentinel
         || qc->streams.send_offset < qc->streams.send_max_data)
     {
@@ -1346,7 +1353,7 @@ ngx_quic_handle_max_data_frame(ngx_connection_t *c,
     qc->streams.send_max_data = f->max_data;
     node = ngx_rbtree_min(tree->root, tree->sentinel);
 
-    while (node && qc->streams.send_offset < qc->streams.send_max_data) {
+    while (node) {
 
         qs = (ngx_quic_stream_t *) node;
         node = ngx_rbtree_next(tree, node);
@@ -1435,6 +1442,8 @@ ngx_quic_handle_max_stream_data_frame(ngx_connection_t *c,
     if (f->limit <= qs->send_max_data) {
         return NGX_OK;
     }
+
+    qs->blocked = 0;
 
     if (qs->send_offset < qs->send_max_data) {
         /* not blocked on MAX_STREAM_DATA */
@@ -1810,6 +1819,75 @@ ngx_quic_update_max_data(ngx_connection_t *c)
     frame->level = NGX_QUIC_ENCRYPTION_APPLICATION;
     frame->type = NGX_QUIC_FT_MAX_DATA;
     frame->u.max_data.max_data = qc->streams.recv_max_data;
+
+    ngx_quic_queue_frame(qc, frame);
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_quic_check_blocked(ngx_quic_stream_t *qs)
+{
+    ngx_connection_t       *pc;
+    ngx_quic_frame_t       *frame;
+    ngx_quic_connection_t  *qc;
+
+    pc = qs->parent;
+    qc = ngx_quic_get_connection(pc);
+
+    if (qs->send.offset == qs->sent) {
+        /* all buffered data has been framed */
+        return NGX_OK;
+    }
+
+    /*
+     * There is buffered data, but no flow-control credit to send it.
+     * Advertise the blocked condition (RFC 9000, Section 4.1) so a peer
+     * that lost its MAX_DATA / MAX_STREAM_DATA update has an ack-eliciting
+     * signal to retransmit it, rather than leaving the stream stalled
+     * until the idle timeout fires.  A frame is sent once per limit;
+     * the flag is reset when the peer raises the limit.
+     */
+
+    if (qc->streams.send_offset >= qc->streams.send_max_data) {
+
+        if (qc->streams.blocked) {
+            return NGX_OK;
+        }
+
+        frame = ngx_quic_alloc_frame(pc);
+        if (frame == NULL) {
+            return NGX_ERROR;
+        }
+
+        frame->type = NGX_QUIC_FT_DATA_BLOCKED;
+        frame->u.data_blocked.limit = qc->streams.send_max_data;
+
+        qc->streams.blocked = 1;
+
+    } else if (qs->send_offset >= qs->send_max_data) {
+
+        if (qs->blocked) {
+            return NGX_OK;
+        }
+
+        frame = ngx_quic_alloc_frame(pc);
+        if (frame == NULL) {
+            return NGX_ERROR;
+        }
+
+        frame->type = NGX_QUIC_FT_STREAM_DATA_BLOCKED;
+        frame->u.stream_data_blocked.id = qs->id;
+        frame->u.stream_data_blocked.limit = qs->send_max_data;
+
+        qs->blocked = 1;
+
+    } else {
+        return NGX_OK;
+    }
+
+    frame->level = NGX_QUIC_ENCRYPTION_APPLICATION;
 
     ngx_quic_queue_frame(qc, frame);
 

--- a/src/event/quic/ngx_event_quic_transport.c
+++ b/src/event/quic/ngx_event_quic_transport.c
@@ -118,6 +118,10 @@ static size_t ngx_quic_create_max_stream_data(u_char *p,
     ngx_quic_max_stream_data_frame_t *ms);
 static size_t ngx_quic_create_max_data(u_char *p,
     ngx_quic_max_data_frame_t *md);
+static size_t ngx_quic_create_data_blocked(u_char *p,
+    ngx_quic_data_blocked_frame_t *db);
+static size_t ngx_quic_create_stream_data_blocked(u_char *p,
+    ngx_quic_stream_data_blocked_frame_t *sdb);
 static size_t ngx_quic_create_path_challenge(u_char *p,
     ngx_quic_path_challenge_frame_t *pc);
 static size_t ngx_quic_create_path_response(u_char *p,
@@ -1328,6 +1332,13 @@ ngx_quic_create_frame(u_char *p, ngx_quic_frame_t *f)
     case NGX_QUIC_FT_MAX_DATA:
         return ngx_quic_create_max_data(p, &f->u.max_data);
 
+    case NGX_QUIC_FT_DATA_BLOCKED:
+        return ngx_quic_create_data_blocked(p, &f->u.data_blocked);
+
+    case NGX_QUIC_FT_STREAM_DATA_BLOCKED:
+        return ngx_quic_create_stream_data_blocked(p,
+                                                   &f->u.stream_data_blocked);
+
     case NGX_QUIC_FT_PATH_CHALLENGE:
         return ngx_quic_create_path_challenge(p, &f->u.path_challenge);
 
@@ -1884,6 +1895,51 @@ ngx_quic_create_max_data(u_char *p, ngx_quic_max_data_frame_t *md)
 
     ngx_quic_build_int(&p, NGX_QUIC_FT_MAX_DATA);
     ngx_quic_build_int(&p, md->max_data);
+
+    return p - start;
+}
+
+
+static size_t
+ngx_quic_create_data_blocked(u_char *p, ngx_quic_data_blocked_frame_t *db)
+{
+    size_t   len;
+    u_char  *start;
+
+    if (p == NULL) {
+        len = ngx_quic_varint_len(NGX_QUIC_FT_DATA_BLOCKED);
+        len += ngx_quic_varint_len(db->limit);
+        return len;
+    }
+
+    start = p;
+
+    ngx_quic_build_int(&p, NGX_QUIC_FT_DATA_BLOCKED);
+    ngx_quic_build_int(&p, db->limit);
+
+    return p - start;
+}
+
+
+static size_t
+ngx_quic_create_stream_data_blocked(u_char *p,
+    ngx_quic_stream_data_blocked_frame_t *sdb)
+{
+    size_t   len;
+    u_char  *start;
+
+    if (p == NULL) {
+        len = ngx_quic_varint_len(NGX_QUIC_FT_STREAM_DATA_BLOCKED);
+        len += ngx_quic_varint_len(sdb->id);
+        len += ngx_quic_varint_len(sdb->limit);
+        return len;
+    }
+
+    start = p;
+
+    ngx_quic_build_int(&p, NGX_QUIC_FT_STREAM_DATA_BLOCKED);
+    ngx_quic_build_int(&p, sdb->id);
+    ngx_quic_build_int(&p, sdb->limit);
 
     return p - start;
 }


### PR DESCRIPTION
## Problem

When a stream has buffered data but no flow-control credit, nginx waits for the peer's `MAX_DATA` / `MAX_STREAM_DATA` update without signalling that it is blocked. If that update is lost, the stream stalls until the idle timeout closes the connection (#1407). RFC 9000, Section 4.1, says an endpoint SHOULD send `DATA_BLOCKED` or `STREAM_DATA_BLOCKED` in this situation; both frames are ack-eliciting, giving the peer a prompt signal to retransmit the update. The frame parser already handles both frames — only the encoder was missing.

## Solution

* Add the missing encoders (RFC 9000, Sections 19.12 / 19.13).
* Queue the appropriate frame from `ngx_quic_stream_flush()` once buffered data cannot be fully framed — including in the same flush call that consumes the last credit, so the transition into the blocked state is signalled immediately.
* Deduplicate per flow-control limit: one frame per limit, re-armed when the peer raises it (flags cleared in the `MAX_DATA` / `MAX_STREAM_DATA` handlers, the only places send credit can increase).
* On loss, per RFC 9000, Section 13.3, retransmit only while still blocked, with the limit refreshed to the current value (`ngx_quic_resend_frames()`).
* `ngx_quic_handle_max_data_frame()` now flushes all streams instead of stopping once the new limit is exhausted: a stream left unflushed mid-iteration would otherwise hold buffered data with no blocked signal at the new limit; this also no longer delays FIN-only frames, which consume no flow-control credit.

## Relationship to #1492

This is a rework of the closed #1492 (branch deleted before review). Based on a patch by Christos Panagiotakis. Compared to the original patch, the emission check was moved after framing (the original only signalled on a *subsequent* flush, so a stream that writes once and then waits for drain was never signalled until shutdown), loss recovery was made conformant with RFC 9000, Section 13.3 (the original retransmitted the frames verbatim with stale limits, even when no longer blocked or the stream was gone), and the `MAX_DATA` flush-loop gap described above was closed.

Deliberately out of scope: the `quic_stream_buffer_size` default change from #1492 (an independent trade-off deserving its own discussion), and RFC 9000, Section 4.1 periodic re-send while blocked (every transient-loss path is already covered by one side's loss recovery, and unconditional periodic ack-eliciting frames would defeat the server's idle timeout).

## Testing

Functional tests are submitted separately as nginx/nginx-tests#76: they drive the server into the stream-level and connection-level blocked states using small advertised flow-control windows, assert the frames are sent with the expected limits, assert a new frame is sent after the limit is raised and exhausted again, and assert the transfer completes once enough credit is granted. The full nginx-tests suite was run against the patched build with no regressions relative to a master baseline.
