### PR TITLE
Entity tags: fixed strong comparison with weak entity tags.

### DIFF
--- a/src/http/modules/ngx_http_not_modified_filter_module.c
+++ b/src/http/modules/ngx_http_not_modified_filter_module.c
@@ -190,11 +190,18 @@ ngx_http_test_if_match(ngx_http_request_t *r, ngx_table_elt_t *header,
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http im:\"%V\" etag:%V", list, &etag);
 
-    if (weak
-        && etag.len > 2
+    if (etag.len > 2
         && etag.data[0] == 'W'
         && etag.data[1] == '/')
     {
+        if (!weak) {
+            /*
+             * RFC 9110, section 8.8.3.2: a weak entity tag can never
+             * strong-match
+             */
+            return 0;
+        }
+
         etag.len -= 2;
         etag.data += 2;
     }


### PR DESCRIPTION
## Problem

`ngx_http_test_if_match()` evaluates `If-Match` (strong comparison,
`weak == 0`) with a byte-wise comparison of the response entity tag
against the entity tags in the header. If the response entity tag is
weak (e.g., received from a cacheable upstream response), an identical
weak entity tag in `If-Match` matches byte-for-byte, and the
precondition is incorrectly considered satisfied.

RFC 9110, Section 8.8.3.2 defines strong comparison as: two entity
tags are equivalent if *both are not weak* and their opaque-tags match
character-by-character. A weak entity tag must never strong-match,
even against an identical weak entity tag.

Reproduction (nginx as caching proxy, upstream returns
`ETag: W/"weaktag"`):

```
curl -s -o /dev/null -w '%{http_code}' \
     -H 'If-Match: W/"weaktag"' http://127.0.0.1:8091/proxy/x
```

Before: `200` (precondition wrongly satisfied)
After: `412` (Precondition Failed)

## Solution

In `ngx_http_test_if_match()`, if the response entity tag is weak and
strong comparison is requested, fail the match immediately. The
opposite direction (weak entity tag in `If-Match` against a strong
response entity tag) already fails naturally on the byte-wise
comparison, and weak comparison for `If-None-Match` is unchanged, as
is `If-Match: *`.

This mirrors the treatment of weak entity tags elsewhere in nginx
(e.g., the range filter does not honour them for `If-Range`).

## Testing

Manual testing matrix (static file with strong ETag, and cacheable
proxied response with `ETag: W/"weaktag"`):

| Case | Result |
|---|---|
| strong ETag, `If-Match` matching | 200 (unchanged) |
| strong ETag, `If-Match` non-matching | 412 (unchanged) |
| strong ETag, `If-Match: W/<same>` | 412 (unchanged) |
| weak ETag, `If-Match: W/<same>` | **412 (was 200)** |
| weak ETag, `If-Match: <opaque only>` | 412 (unchanged) |
| weak ETag, `If-Match: *` | 200 (unchanged) |
| weak ETag, `If-None-Match: W/<same>` | 304 (unchanged) |
| weak ETag, `If-None-Match: <opaque>` | 304 (unchanged) |
| weak ETag, `If-None-Match: <other>` | 200 (unchanged) |

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests)):
      full suite, 492 files / 4430 tests, all pass (Linux, x86_64)

**Closes:** #716

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
      (companion nginx-tests PR: nginx/nginx-tests#77, with the fixed
      case TODO-gated on 1.31.4)
- [x] All existing tests pass
- [x] I have updated documentation where necessary (none needed)
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

`If-Match` now correctly fails (412) when the selected response has a
weak entity tag, per RFC 9110 strong comparison. Previously an
identical weak entity tag in `If-Match` was treated as a match.

