### PR TITLE
Tunnel body improvements

### DIFF
--- a/src/http/modules/ngx_http_tunnel_module.c
+++ b/src/http/modules/ngx_http_tunnel_module.c
@@ -271,7 +271,7 @@ ngx_http_tunnel_eval(ngx_http_request_t *r, ngx_http_tunnel_loc_conf_t *tlcf)
 static ngx_int_t
 ngx_http_tunnel_create_request(ngx_http_request_t *r)
 {
-    /* u->request_bufs = NULL */
+    r->upstream->request_bufs = NULL;
 
     return NGX_OK;
 }

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -845,18 +845,21 @@ ngx_http_handler(ngx_http_request_t *r)
     r->connection->log->action = NULL;
 
     if (!r->internal) {
-        switch (r->headers_in.connection_type) {
-        case 0:
-            r->keepalive = (r->http_version > NGX_HTTP_VERSION_10);
-            break;
 
-        case NGX_HTTP_CONNECTION_CLOSE:
-            r->keepalive = 0;
-            break;
+        if (r->method != NGX_HTTP_CONNECT) {
+            switch (r->headers_in.connection_type) {
+            case 0:
+                r->keepalive = (r->http_version > NGX_HTTP_VERSION_10);
+                break;
 
-        case NGX_HTTP_CONNECTION_KEEP_ALIVE:
-            r->keepalive = 1;
-            break;
+            case NGX_HTTP_CONNECTION_CLOSE:
+                r->keepalive = 0;
+                break;
+
+            case NGX_HTTP_CONNECTION_KEEP_ALIVE:
+                r->keepalive = 1;
+                break;
+            }
         }
 
         r->lingering_close = (r->headers_in.content_length_n > 0

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -2094,13 +2094,20 @@ ngx_http_process_request_header(ngx_http_request_t *r)
 
     cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
 
-    if (r->method == NGX_HTTP_CONNECT
-        && (r->http_version != NGX_HTTP_VERSION_11 || !cscf->allow_connect))
-    {
-        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
-                      "client sent CONNECT method");
-        ngx_http_finalize_request(r, NGX_HTTP_NOT_ALLOWED);
-        return NGX_ERROR;
+    if (r->method == NGX_HTTP_CONNECT) {
+        if (r->http_version != NGX_HTTP_VERSION_11 || !cscf->allow_connect) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent CONNECT method");
+            ngx_http_finalize_request(r, NGX_HTTP_NOT_ALLOWED);
+            return NGX_ERROR;
+        }
+
+        if (r->headers_in.content_length_n > 0 || r->headers_in.chunked) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent CONNECT request with body");
+            ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+            return NGX_ERROR;
+        }
     }
 
     if (r->method == NGX_HTTP_TRACE) {


### PR DESCRIPTION
The changes improve HTTP CONNECT request body handling:

- in the tunnel module, request body is always ignored
- request body with HTTP CONNECT is not allowed
- keepalive is disabled for HTTP CONNECT requests