### PR TITLE
Image filter: use received length after buffering

### DIFF
--- a/src/http/modules/ngx_http_image_filter_module.c
+++ b/src/http/modules/ngx_http_image_filter_module.c
@@ -510,6 +510,7 @@ ngx_http_image_read(ngx_http_request_t *r, ngx_chain_t *in)
 
         if (b->last_buf) {
             ctx->last = p;
+            ctx->length = p - ctx->image;
             return NGX_OK;
         }
     }


### PR DESCRIPTION
For responses without Content-Length, ctx->length initially contains the
configured buffer capacity. It remained unchanged after the body completed,
so image-size parsers and libgd could inspect bytes beyond ctx->last.

Update ctx->length to the number of bytes actually received once last_buf is
seen. The capacity remains available for bounds checking while buffering, and
all processing after completion is limited to initialized input bytes.

A local regression test against issue #1521 changes a truncated 16-byte PNG
response from stale dimensions to `{}`, while a valid close-delimited PNG
continues to report its dimensions.

Closes: https://github.com/nginx/nginx/issues/1521