### PR TITLE
Xslt: xmlCreatePushParserCtxt() error handling

### DIFF
--- a/src/core/nginx.h
+++ b/src/core/nginx.h
@@ -9,8 +9,8 @@
 #define _NGINX_H_INCLUDED_
 
 
-#define nginx_version      1031003
-#define NGINX_VERSION      "1.31.3"
+#define nginx_version      1031004
+#define NGINX_VERSION      "1.31.4"
 #define NGINX_VER          "nginx/" NGINX_VERSION
 
 #ifdef NGX_BUILD

--- a/src/http/modules/ngx_http_xslt_filter_module.c
+++ b/src/http/modules/ngx_http_xslt_filter_module.c
@@ -279,6 +279,10 @@ ngx_http_xslt_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
         if (ngx_http_xslt_add_chunk(r, ctx, cl->buf) != NGX_OK) {
 
+            if (ctx->ctxt == NULL) {
+                return ngx_http_xslt_send(r, ctx, NULL);
+            }
+
             if (ctx->ctxt->myDoc) {
 
 #if (NGX_HTTP_XSLT_REUSE_DTD)


### PR DESCRIPTION
### Summary

`ngx_http_xslt_body_filter()` could dereference a NULL pointer on the
error path when the libxml2 push parser context failed to allocate.

`ngx_http_xslt_add_chunk()` creates the parser context lazily on the
first body chunk:

```c
if (ctx->ctxt == NULL) {
    ctxt = xmlCreatePushParserCtxt(NULL, NULL, NULL, 0, NULL);
    if (ctxt == NULL) {
        ...
        return NGX_ERROR;   /* ctx->ctxt is still NULL here */
    }
    ...
    ctx->ctxt = ctxt;
}
```

When `xmlCreatePushParserCtxt()` returns NULL (allocation failure), the
function returns `NGX_ERROR` before `ctx->ctxt` is assigned. The caller's
error path then dereferenced `ctx->ctxt->myDoc`, causing a worker process
segmentation fault. (`xmlFreeParserCtxt()` itself is NULL-safe, so the
crash comes solely from the `myDoc` dereference; the guard covers both
calls regardless.)

### Fix

Guard the cleanup with a `ctx->ctxt` check.

### Impact / notes

This is reachable only when the parser-context allocation fails
(out-of-memory); the effect is a worker crash from which the master
recovers, with no memory corruption or disclosure. Reproduced by forcing
`xmlCreatePushParserCtxt()` to fail: before the change the worker exits
on signal 11, after it the request completes with a normal error response
and the worker survives. `xslt.t` continues to pass.
