### PR TITLE
Not modified filter: strong If-Match must reject weak ETags.

### DIFF
--- a/src/http/modules/ngx_http_not_modified_filter_module.c
+++ b/src/http/modules/ngx_http_not_modified_filter_module.c
@@ -190,11 +190,19 @@ ngx_http_test_if_match(ngx_http_request_t *r, ngx_table_elt_t *header,
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http im:\"%V\" etag:%V", list, &etag);
 
-    if (weak
-        && etag.len > 2
-        && etag.data[0] == 'W'
-        && etag.data[1] == '/')
-    {
+    if (etag.len > 2 && etag.data[0] == 'W' && etag.data[1] == '/') {
+
+        /*
+         * RFC 9110, 8.8.3.2: strong comparison treats a weak entity-tag
+         * as never matching, so If-Match against a weak server ETag
+         * always fails.  For If-None-Match (weak comparison) strip the
+         * "W/" prefix and continue with the opaque-tag.
+         */
+
+        if (!weak) {
+            return 0;
+        }
+
         etag.len -= 2;
         etag.data += 2;
     }


### PR DESCRIPTION
## Summary

Fix RFC 9110 Section 8.8.3.2 violation in `ngx_http_test_if_match()`: strong comparison (used by If-Match) must reject weak entity-tags on either side.

## Problem

`If-Match: W/"abc"` against a server response with `ETag: W/"abc"` returns 200 OK instead of 412 Precondition Failed. Per RFC 9110, strong comparison treats a weak entity-tag as never matching, so the precondition should fail.

## Root Cause

`ngx_http_test_if_match(r, header, weak)` only checks for the "W/" prefix when `weak==1` (If-None-Match path). When `weak==0` (If-Match path), the prefix is not stripped from either the server ETag or the client tags, so byte-identical weak tags like `W/"abc"` are compared verbatim and incorrectly match.

## Implementation

Moved the "W/" prefix detection outside the `weak` guard. When a weak entity-tag is detected and `weak==0`, the comparison immediately returns 0 (no match), consistent with RFC 9110 8.8.3.2. For `weak==1`, behavior is unchanged: the "W/" prefix is stripped and the opaque-tag is compared.

Associated test PR: nginx/nginx-tests#74

## Testing

Extended `not_modified.t` with a weak-server-ETag proxy test case. The backend returns `ETag: W/"weaktag"`; the front-end applies `If-Match: W/"weaktag"` and asserts 412 Precondition Failed.

- Without patch: 200 OK (bug — precondition passes)
- With patch: 412 Precondition Failed (correct)
- All 19 subtests pass

## Performance

No measurable impact. Constant-time prefix comparison on an existing code path.

## Compatibility

Tightens If-Match matching to comply with RFC 9110. Servers emitting weak ETags will correctly see 412 when If-Match is used.

Closes: https://github.com/nginx/nginx/issues/716