### PR TITLE
HTTP/2, HTTP/3: stripped leading and trailing whitespace from field values.

### DIFF
--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1745,6 +1745,21 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
 
         header->value.len = h2c->state.field_end - h2c->state.field_start;
         header->value.data = h2c->state.field_start;
+
+        while (header->value.len
+            && (header->value.data[0] == ' '
+                || header->value.data[0] == '\t'))
+        {
+            header->value.data++;
+            header->value.len--;
+        }
+
+        while (header->value.len
+            && (header->value.data[header->value.len - 1] == ' '
+                || header->value.data[header->value.len - 1] == '\t'))
+        {
+            header->value.len--;
+        }
     }
 
     len = header->name.len + header->value.len;

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -621,6 +621,20 @@ ngx_http_v3_process_header(ngx_http_request_t *r, ngx_str_t *name,
 
     static ngx_str_t cookie = ngx_string("cookie");
 
+    while (value->len
+        && (value->data[0] == ' ' || value->data[0] == '\t'))
+    {
+        value->data++;
+        value->len--;
+    }
+
+    while (value->len
+        && (value->data[value->len - 1] == ' '
+            || value->data[value->len - 1] == '\t'))
+    {
+        value->len--;
+    }
+
     len = name->len + value->len;
 
     if (len > r->v3_parse->header_limit) {


### PR DESCRIPTION
### Summary

HTTP/2 and HTTP/3 field values with leading or trailing whitespace
characters (SP 0x20, HTAB 0x09) are now stripped to conform with
RFC 9113 Section 8.2.2 and RFC 9114 Section 4.1.3.

### Problem

nginx accepts HTTP/2 and HTTP/3 field values containing leading or
trailing whitespace without stripping them. These values are passed
through to the backend or used as-is, which can cause interoperability
issues when different intermediaries assign different semantics to
fields with and without whitespace.

### Root Cause

The HPACK/QPACK decoders store the decoded value verbatim. Neither
ngx_http_v2_state_process_header() nor ngx_http_v3_process_header()
performed any whitespace trimming before storing the value.

### Implementation

Two changes, structurally identical:

1. **src/http/v2/ngx_http_v2.c** (commit a4611a6): In
   ngx_http_v2_state_process_header(), after assigning the decoded
   field, strip leading and trailing SP/HTAB by advancing the data
   pointer and reducing the length. The trimming is inside the
   h2c->state.parse_value block, before dynamic-table insert,
   validation, and header-limit checks, so all downstream processing
   sees the trimmed value.

2. **src/http/v3/ngx_http_v3_request.c** (commit 352f399): In
   ngx_http_v3_process_header(), trim the ngx_str_t *value in place
   at function entry, before the header-limit check and validation,
   so the trimmed length is used for all subsequent processing.

The fix is deliberately minimal -- a pair of while loops on each
side -- matching the permissive approach of stripping rather than
rejecting, consistent with nginx's general philosophy.

### Tests

Added 4 new subtests to h2_headers.t (nginx-tests companion PR):

- Leading spaces stripped ('  abc' -> 'abc')
- Trailing spaces stripped ('def  ' -> 'def')
- Both sides stripped ('  ghi  ' -> 'ghi')
- Tab characters stripped ('\tjkl\t' -> 'jkl')

Without the fix all 4 subtests fail; with the fix all 116 subtests
(112 existing + 4 new) pass.

H3 runtime testing requires QUIC-capable OpenSSL 3.2+, not available
in this test environment, but the change compiles cleanly with
NGX_HTTP_V3 enabled and follows the same logic as the H2 fix.

### Performance

Negligible. The trimming loops only iterate when whitespace is
present, which is rare in well-formed requests.

### Compatibility

This changes observable behavior: a value '  foo' previously reached
the backend as '  foo'; now it reaches as 'foo'. This is required by
the RFCs and is a strict improvement in spec conformance. Any backend
depending on leading/trailing whitespace in header values is already
non-conformant with RFC 7230 Section 3.2.

Closes issue #598.
