### PR TITLE
PCRE: saved request captures across complex value evaluation.

### DIFF
--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -62,6 +62,12 @@ ngx_http_complex_value(ngx_http_request_t *r, ngx_http_complex_value_t *val,
     ngx_http_script_code_pt       code;
     ngx_http_script_len_code_pt   lcode;
     ngx_http_script_engine_t      e;
+#if (NGX_PCRE)
+    ngx_uint_t                    save_ncaptures;
+    u_char                       *save_captures_data;
+    int                          *save_captures;
+    ngx_http_core_main_conf_t    *cmcf;
+#endif
 
     if (val->lengths == NULL) {
         *value = val->value;
@@ -69,6 +75,25 @@ ngx_http_complex_value(ngx_http_request_t *r, ngx_http_complex_value_t *val,
     }
 
     ngx_http_script_flush_complex_value(r, val);
+
+#if (NGX_PCRE)
+    save_ncaptures = r->ncaptures;
+    save_captures_data = r->captures_data;
+    save_captures = NULL;
+
+    if (r->ncaptures) {
+        cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+        save_captures = ngx_palloc(r->pool,
+                                   cmcf->ncaptures * sizeof(int));
+        if (save_captures == NULL) {
+            return NGX_ERROR;
+        }
+
+        ngx_memcpy(save_captures, r->captures,
+                   cmcf->ncaptures * sizeof(int));
+    }
+#endif
 
     ngx_memzero(&e, sizeof(ngx_http_script_engine_t));
 
@@ -82,6 +107,18 @@ ngx_http_complex_value(ngx_http_request_t *r, ngx_http_complex_value_t *val,
         lcode = *(ngx_http_script_len_code_pt *) e.ip;
         len += lcode(&e);
     }
+
+#if (NGX_PCRE)
+    r->ncaptures = save_ncaptures;
+    r->captures_data = save_captures_data;
+
+    if (save_captures) {
+        cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+        ngx_memcpy(r->captures, save_captures,
+                   cmcf->ncaptures * sizeof(int));
+    }
+#endif
 
     value->len = len;
     value->data = ngx_pnalloc(r->pool, len);
@@ -638,11 +675,41 @@ ngx_http_script_run(ngx_http_request_t *r, ngx_str_t *value,
     e.request = r;
     e.flushed = 1;
 
+#if (NGX_PCRE)
+    ngx_uint_t  save_ncaptures;
+    u_char     *save_captures_data;
+    int        *save_captures;
+
+    save_ncaptures = r->ncaptures;
+    save_captures_data = r->captures_data;
+    save_captures = NULL;
+
+    if (r->ncaptures) {
+        save_captures = ngx_palloc(r->pool,
+                                   cmcf->ncaptures * sizeof(int));
+        if (save_captures == NULL) {
+            return NULL;
+        }
+
+        ngx_memcpy(save_captures, r->captures,
+                   cmcf->ncaptures * sizeof(int));
+    }
+#endif
+
     while (*(uintptr_t *) e.ip) {
         lcode = *(ngx_http_script_len_code_pt *) e.ip;
         len += lcode(&e);
     }
 
+#if (NGX_PCRE)
+    r->ncaptures = save_ncaptures;
+    r->captures_data = save_captures_data;
+
+    if (save_captures) {
+        ngx_memcpy(r->captures, save_captures,
+                   cmcf->ncaptures * sizeof(int));
+    }
+#endif
 
     value->len = len;
     value->data = ngx_pnalloc(r->pool, len);
@@ -1170,12 +1237,55 @@ ngx_http_script_regex_start_code(ngx_http_script_engine_t *e)
         le.request = r;
         le.quote = code->redirect;
 
+#if (NGX_PCRE)
+        ngx_uint_t   save_ncaptures;
+        u_char      *save_captures_data;
+        int         *save_captures;
+
+        save_ncaptures = r->ncaptures;
+        save_captures_data = r->captures_data;
+
+        if (r->ncaptures) {
+            ngx_http_core_main_conf_t  *cmcf;
+
+            cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+            save_captures = ngx_palloc(r->pool,
+                                       cmcf->ncaptures * sizeof(int));
+            if (save_captures == NULL) {
+                e->ip = ngx_http_script_exit;
+                e->status = NGX_HTTP_INTERNAL_SERVER_ERROR;
+                return;
+            }
+
+            ngx_memcpy(save_captures, r->captures,
+                       cmcf->ncaptures * sizeof(int));
+
+        } else {
+            save_captures = NULL;
+        }
+#endif
+
         len = 0;
 
         while (*(uintptr_t *) le.ip) {
             lcode = *(ngx_http_script_len_code_pt *) le.ip;
             len += lcode(&le);
         }
+
+#if (NGX_PCRE)
+        r->ncaptures = save_ncaptures;
+        r->captures_data = save_captures_data;
+
+        if (save_captures) {
+            ngx_http_core_main_conf_t  *cmcf;
+
+            cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+
+            ngx_memcpy(r->captures, save_captures,
+                       cmcf->ncaptures * sizeof(int));
+        }
+#endif
 
         e->buf.len = len;
     }


### PR DESCRIPTION
## Summary

Save and restore `r->ncaptures`, `r->captures_data`, and the `r->captures` ovector array in `ngx_http_complex_value()`, `ngx_http_script_run()`, and `ngx_http_script_regex_start_code()` between the length-calculation pass and the value-filling pass, preventing regex side effects from corrupting request capture state (`$1`, `$2`, etc.).

Fixes both #244 and #357.

## Problem (captures empty — #244)

When a response body or variable expression (e.g., `return 200 "1: $1 2: $2 mv: $myvar\n"`) contains both regex capture references and a reference to a map variable with a regex pattern, the **capture variables are empty**:

```
$ curl http://localhost/api/test
1:
2:
myvar: mapped
```

## Problem (rewrite captures overwritten — #357)

When a rewrite replacement uses a map variable whose value references the map regex captur e (e.g., `rewrite ^(/test)$ $1/$lang/` where `$lang` is defined as `~\\b(de|fr)\\b $1`), the **rewrite $1 expands to the map capture instead of the rewrite capture**:

Intended: `Accept-Language: de` → rewrite to `/test/de/`
Actual:   `Accept-Language: de` → rewrite to `de/de/` (404)

## Root Cause

All three functions evaluate compiled scripts in two passes:
1. **Length pass** — iterates length codes to compute total output buffer size
2. **Value pass** — iterates value codes to fill the buffer with actual data

When a variable reference during the **length pass** triggers `ngx_http_map_variable()` → `ngx_http_map_find()` → `ngx_http_regex_exec()`, the regex execution overwrites `r->ncaptures`, `r->captures_data`, **and the `r->captures[]` ovector array** as a side effect. The subsequent **value pass** then reads the wrong capture state.

## Implementation

In all three functions, the full capture state is saved before the length pass and restored before the value pass, guarded by `#if (NGX_PCRE)`.

The fix covers three code paths:
- `ngx_http_complex_value()` (sub_filter, SSI, map value evaluation)
- `ngx_http_script_run()` (various variable evaluation contexts)
- `ngx_http_script_regex_start_code()` (rewrite replacement)

Each saves `r->ncaptures`, `r->captures_data`, and a deep copy of the `r->captures[]` array (allocated from the request pool), then restores all three after the length pass completes.

## Tests

Companion PR: nginx/nginx-tests#81 (updated) and nginx/nginx-tests#NEW

Test plan:
1. Map regex + location capture: `$1`, `$2`, `$myvar` all correct
2. Different URI lengths preserve captures
3. Short URIs preserve captures
4. Normal location (no captures) unaffected
5. Map regex capture in rewrite replacement (ticket #357)

## Related Issues

Closes #244.
Also fixed: #357 (map regex capture $1 in rewrite replacement).
