### PR TITLE
Image filter: bounded size parser reads by received data

### DIFF
--- a/src/http/modules/ngx_http_image_filter_module.c
+++ b/src/http/modules/ngx_http_image_filter_module.c
@@ -510,6 +510,7 @@ ngx_http_image_read(ngx_http_request_t *r, ngx_chain_t *in)
 
         if (b->last_buf) {
             ctx->last = p;
+            ctx->length = p - ctx->image;
             return NGX_OK;
         }
     }


### PR DESCRIPTION
### Summary

`ngx_http_image_filter_module` used `ctx->length` — the allocation size,
set to `image_filter_buffer` when the upstream response omits
`Content-Length` — as the amount of valid data, both in the size parser
(`ngx_http_image_size()`) and in the decoders (`ngx_http_image_source()`).
A truncated response without `Content-Length` could therefore be parsed
or decoded past the received bytes into uninitialized buffer memory.

### Change

`ctx->length` is now adjusted to the actually-read length once the
response body has been read, in `ngx_http_image_read()`, so every
downstream use (size parser and decoders) sees the received size.

### Tests

nginx/nginx-tests#83 (`image_filter_truncated.t`).
