### PR TITLE
Image filter: rejected PNG images with too large dimensions

### DIFF
--- a/src/http/modules/ngx_http_image_filter_module.c
+++ b/src/http/modules/ngx_http_image_filter_module.c
@@ -57,6 +57,7 @@ typedef struct {
     ngx_http_complex_value_t    *shcv;
 
     size_t                       buffer_size;
+    ngx_int_t                    max_pixels;
 } ngx_http_image_filter_conf_t;
 
 
@@ -168,6 +169,13 @@ static ngx_command_t  ngx_http_image_filter_commands[] = {
       ngx_conf_set_size_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_image_filter_conf_t, buffer_size),
+      NULL },
+
+    { ngx_string("image_filter_max_pixels"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_image_filter_conf_t, max_pixels),
       NULL },
 
       ngx_null_command
@@ -746,8 +754,10 @@ ngx_http_image_size(ngx_http_request_t *r, ngx_http_image_filter_ctx_t *ctx)
             return NGX_DECLINED;
         }
 
-        width = p[18] * 256 + p[19];
-        height = p[22] * 256 + p[23];
+        width = (ngx_uint_t) p[16] * 16777216 + p[17] * 65536
+                + p[18] * 256 + p[19];
+        height = (ngx_uint_t) p[20] * 16777216 + p[21] * 65536
+                 + p[22] * 256 + p[23];
 
         break;
 
@@ -829,6 +839,18 @@ ngx_http_image_resize(ngx_http_request_t *r, ngx_http_image_filter_ctx_t *ctx)
     ngx_pool_cleanup_t            *cln;
     ngx_http_image_filter_conf_t  *conf;
 
+    conf = ngx_http_get_module_loc_conf(r, ngx_http_image_filter_module);
+
+    if (conf->max_pixels
+        && ctx->height
+        && ctx->width > (ngx_uint_t) conf->max_pixels / ctx->height)
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "image filter: source dimensions out of range: "
+                      "%ui x %ui", ctx->width, ctx->height);
+        return NULL;
+    }
+
     src = ngx_http_image_source(r, ctx);
 
     if (src == NULL) {
@@ -837,8 +859,6 @@ ngx_http_image_resize(ngx_http_request_t *r, ngx_http_image_filter_ctx_t *ctx)
 
     sx = gdImageSX(src);
     sy = gdImageSY(src);
-
-    conf = ngx_http_get_module_loc_conf(r, ngx_http_image_filter_module);
 
     if (!ctx->force
         && ctx->angle == 0
@@ -1138,7 +1158,19 @@ ngx_http_image_source(ngx_http_request_t *r, ngx_http_image_filter_ctx_t *ctx)
 static gdImagePtr
 ngx_http_image_new(ngx_http_request_t *r, int w, int h, int colors)
 {
-    gdImagePtr  img;
+    gdImagePtr                     img;
+    ngx_http_image_filter_conf_t  *conf;
+
+    conf = ngx_http_get_module_loc_conf(r, ngx_http_image_filter_module);
+
+    if (w <= 0 || h <= 0
+        || (conf->max_pixels
+            && (ngx_uint_t) w > (ngx_uint_t) conf->max_pixels / (ngx_uint_t) h))
+    {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "image filter: dimensions out of range: %d x %d", w, h);
+        return NULL;
+    }
 
     if (colors == 0) {
         img = gdImageCreateTrueColor(w, h);
@@ -1302,6 +1334,7 @@ ngx_http_image_filter_create_conf(ngx_conf_t *cf)
     conf->transparency = NGX_CONF_UNSET;
     conf->interlace = NGX_CONF_UNSET;
     conf->buffer_size = NGX_CONF_UNSET_SIZE;
+    conf->max_pixels = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -1363,6 +1396,8 @@ ngx_http_image_filter_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_size_value(conf->buffer_size, prev->buffer_size,
                               1 * 1024 * 1024);
+
+    ngx_conf_merge_value(conf->max_pixels, prev->max_pixels, 20 * 1000 * 1000);
 
     return NGX_CONF_OK;
 }


### PR DESCRIPTION
`ngx_http_image_size()` used only the low 16 bits of the 32-bit width and height in the PNG IHDR chunk, so an image larger than 65535 pixels in either dimension was seen as a smaller one. Depending on the configuration it was then either passed through as is, or decoded by libgd, which allocates the image from the real dimensions -- `image_filter rotate`, for example, always decodes.

The full width and height are now parsed, and PNG images with a dimension that does not fit into 16 bits are rejected with 415, as such dimensions are not expected.

This replaces the earlier `image_filter_max_pixels` directive proposal, per review: no directive, just a correct parse and a reject.

## Measured

A valid 65536x512 PNG (95.6 KB), worker peak memory:

| filter | before | after |
|---|---|---|
| `resize 100 1000` | 200, passed through unchanged, +0.5 MB | 415, +0.5 MB |
| `rotate 90` | 200, decoded, **+260.9 MB** | 415, +0.4 MB |
| `size` | `"width": 0` | `{}` |
| a normal 800x400 PNG | resized | unchanged |

The rejection is a real 415 rather than `NGX_DECLINED`, which would fall through to `ngx_http_image_resize()` and decode the image.

Other formats are unaffected: JPEG and GIF dimensions are natively 16-bit, and WebP VP8X is already parsed correctly (24 bits); WebP sizes above 65535 are legitimate, so they are not rejected.

## Tests

`image_filter.t`, `image_filter_finalize.t`, `image_filter_webp.t` pass (67 tests). Regression test in nginx/nginx-tests#84.
