### PR TITLE
Feat/add nginx documentation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,47 @@
+# NGINX Configuration Examples
+
+Practical, copy-paste friendly NGINX configuration examples for common
+use cases. Each directory contains a complete, self-contained
+`nginx.conf` and a README explaining what it does and how to run it.
+
+## Examples
+
+| Directory | Description |
+|---|---|
+| [static-site](static-site/) | Serve static files with gzip and cache headers |
+| [reverse-proxy](reverse-proxy/) | Reverse proxy to an application server |
+| [tls-https](tls-https/) | HTTPS with HTTP to HTTPS redirect |
+| [load-balancing](load-balancing/) | Distribute traffic across multiple backends |
+| [websockets](websockets/) | Proxy WebSocket connections |
+| [rate-limiting](rate-limiting/) | Rate limit an API with `limit_req` / `limit_conn` |
+| [security-basics](security-basics/) | Safe defaults: tokens, hidden files, headers |
+| [spa](spa/) | Single-Page App with `try_files` fallback |
+| [php-fpm](php-fpm/) | Minimal PHP-FPM setup |
+| [docker](docker/) | Run NGINX with Docker Compose |
+
+## Conventions
+
+- Examples listen on port `8080` (and `8443` for TLS) so they can run
+  without root privileges. Use `80`/`443` in production.
+- Paths such as `/etc/nginx/` and `/usr/share/nginx/html/` follow the
+  official NGINX Docker image and common Linux packages. Adjust them
+  for your distribution.
+- Each config is a complete `nginx.conf`, not a snippet to paste into
+  an existing `http {}` block.
+
+## Validating a config
+
+```sh
+nginx -t -c /path/to/examples/static-site/nginx.conf
+```
+
+## Running an example with Docker
+
+```sh
+docker run --rm -p 8080:8080 \
+    -v "$PWD/examples/static-site/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    -v "$PWD/examples/static-site/html:/usr/share/nginx/html:ro" \
+    nginx:alpine
+```
+
+Then open http://localhost:8080.

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,0 +1,41 @@
+# Docker / local dev
+
+Run NGINX in Docker Compose for local development.
+
+## What it does
+
+- Starts the official `nginx:alpine` image with the local `nginx.conf`
+  and `html/` directory mounted read-only.
+- Exposes the site on http://localhost:8080.
+
+## Run locally
+
+```sh
+mkdir -p html
+echo '<h1>Hello from Docker Compose</h1>' > html/index.html
+
+docker compose up
+```
+
+Edit `html/index.html` and refresh — static files are served from the
+mounted directory, so no restart is needed. After changing
+`nginx.conf`, reload NGINX:
+
+```sh
+docker compose exec web nginx -s reload
+```
+
+Stop with `Ctrl+C` or `docker compose down`.
+
+## Notes
+
+- Mounting configs read-only (`:ro`) prevents accidental edits from
+  inside the container.
+- To validate a config change before reloading:
+  `docker compose exec web nginx -t`
+- The other examples in this repository can be run the same way: mount
+  their `nginx.conf` into the container as `/etc/nginx/nginx.conf`.
+
+## Learn more
+
+- https://hub.docker.com/_/nginx

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+# Local development setup: NGINX serving a static site.
+# Start with:  docker compose up
+# Stop with:   docker compose down
+
+services:
+  web:
+    image: nginx:alpine
+    ports:
+      - "8080:8080"
+    volumes:
+      # Config and content are mounted read-only; edit the files on the
+      # host and reload with: docker compose exec web nginx -s reload
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./html:/usr/share/nginx/html:ro

--- a/examples/docker/nginx.conf
+++ b/examples/docker/nginx.conf
@@ -1,0 +1,29 @@
+# Config used by the docker-compose.yml in this directory.
+
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile      on;
+
+    # sendfile can serve stale content with VirtualBox-style shared
+    # folders; harmless on Docker Desktop, but easy to toggle if you
+    # ever see stale files.
+
+    server {
+        listen 8080;
+
+        root  /usr/share/nginx/html;
+        index index.html;
+
+        location / {
+            try_files $uri $uri/ =404;
+        }
+    }
+}

--- a/examples/load-balancing/README.md
+++ b/examples/load-balancing/README.md
@@ -1,0 +1,57 @@
+# Load balancing
+
+Distribute traffic across multiple application backends using an
+`upstream` block.
+
+## What it does
+
+- Round-robins requests across three backends on ports 3001–3003.
+- Marks a backend as temporarily down after 3 failures in 30 seconds
+  (passive health checks, built into NGINX OSS).
+- Retries a failed request on the next backend (`proxy_next_upstream`).
+- Keeps idle keepalive connections to the backends.
+
+Alternative balancing methods are commented in `nginx.conf`:
+`least_conn` (fewest active connections) and `ip_hash` (client-IP
+stickiness).
+
+## Run locally
+
+Start three demo backends:
+
+```sh
+for port in 3001 3002 3003; do
+    docker run -d --rm -p $port:3000 \
+        hashicorp/http-echo -text "backend on $port"
+done
+```
+
+Run NGINX (Linux):
+
+```sh
+docker run --rm --network host \
+    -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    nginx:alpine
+```
+
+(On Docker Desktop for Mac/Windows, replace the `127.0.0.1` addresses
+with `host.docker.internal` and use `-p 8080:8080` instead of
+`--network host`.)
+
+Test — the response rotates between backends:
+
+```sh
+curl http://localhost:8080
+```
+
+## Notes
+
+- Active health checks (proactively probing backends) require NGINX
+  Plus or a third-party module; OSS uses passive checks only.
+- `ip_hash` breaks when clients sit behind NAT or CGNAT; prefer
+  application-level sessions when possible.
+
+## Learn more
+
+- https://nginx.org/en/docs/http/ngx_http_upstream_module.html
+- https://nginx.org/en/docs/http/load_balancing.html

--- a/examples/load-balancing/nginx.conf
+++ b/examples/load-balancing/nginx.conf
@@ -1,0 +1,53 @@
+# Load balance traffic across three application backends.
+#
+# Run with Docker (backends must be reachable from the container):
+#   docker run --rm -p 8080:8080 \
+#       -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+#       nginx:alpine
+
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    upstream backend {
+        # Default method: round-robin. Alternatives:
+        #
+        #   least_conn;   # send to the backend with the fewest
+        #                 # active connections (good for uneven
+        #                 # request durations)
+        #
+        #   ip_hash;      # pin a client IP to one backend (simple
+        #                 # session stickiness)
+
+        # Passive health checks: after 3 failed attempts within 30s,
+        # a server is considered down for 30s.
+        server 127.0.0.1:3001 max_fails=3 fail_timeout=30s;
+        server 127.0.0.1:3002 max_fails=3 fail_timeout=30s;
+        server 127.0.0.1:3003 max_fails=3 fail_timeout=30s;
+
+        keepalive 32;
+    }
+
+    server {
+        listen 8080;
+
+        location / {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+
+            proxy_set_header Host            $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            proxy_connect_timeout 5s;
+            proxy_read_timeout    60s;
+
+            # If a backend errors out mid-request, try the next one.
+            proxy_next_upstream error timeout http_502 http_503;
+            proxy_next_upstream_tries 2;
+        }
+    }
+}

--- a/examples/php-fpm/README.md
+++ b/examples/php-fpm/README.md
@@ -1,0 +1,56 @@
+# PHP-FPM
+
+Serve a PHP application through PHP-FPM.
+
+## What it does
+
+- Serves static files directly and passes `.php` requests to PHP-FPM.
+- Uses `try_files $uri =404` inside the PHP block so non-existent
+  `.php` paths never reach PHP-FPM (a classic security pitfall).
+- Falls back to `index.php` for clean URLs, as front-controller
+  frameworks (Laravel, Symfony, WordPress) expect.
+- Blocks hidden files.
+
+## Run locally
+
+The easiest reproducible setup is two containers sharing the document
+root:
+
+```sh
+mkdir -p html
+echo '<?php phpinfo();' > html/index.php
+
+docker network create php-demo
+
+docker run -d --rm --name fpm --network php-demo \
+    -v "$PWD/html:/usr/share/nginx/html:ro" \
+    php:fpm-alpine
+
+docker run -d --rm --name web --network php-demo -p 8080:8080 \
+    -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    -v "$PWD/html:/usr/share/nginx/html:ro" \
+    nginx:alpine
+```
+
+Since PHP-FPM runs in a separate container here, change `fastcgi_pass`
+in `nginx.conf` from `127.0.0.1:9000` to `fpm:9000` (the container
+name). Then open http://localhost:8080.
+
+Cleanup:
+
+```sh
+docker stop web fpm && docker network rm php-demo
+```
+
+## Notes
+
+- On a single host (no containers), prefer the Unix socket:
+  `fastcgi_pass unix:/run/php/php-fpm.sock;` — check your distro's
+  PHP-FPM pool config (`listen = ...`) for the exact path.
+- Both containers must mount the same document root, because PHP-FPM
+  reads the script from disk itself.
+
+## Learn more
+
+- https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html
+- https://www.php.net/manual/en/install.fpm.php

--- a/examples/php-fpm/nginx.conf
+++ b/examples/php-fpm/nginx.conf
@@ -1,0 +1,48 @@
+# Minimal PHP-FPM setup.
+#
+# Run with Docker Compose (see this directory's README):
+#   docker compose up
+
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile      on;
+
+    server {
+        listen 8080;
+
+        root  /usr/share/nginx/html;
+        index index.php index.html;
+
+        location / {
+            try_files $uri $uri/ /index.php?$query_string;
+        }
+
+        location ~ \.php$ {
+            # Only execute files that actually exist: passing any
+            # "*.php" request to PHP-FPM is a known code-execution
+            # pitfall with misconfigured PATH_INFO setups.
+            try_files $uri =404;
+
+            # PHP-FPM over TCP (e.g. a separate container).
+            # On a single host, a Unix socket is also common:
+            #   fastcgi_pass unix:/run/php/php-fpm.sock;
+            fastcgi_pass 127.0.0.1:9000;
+
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        }
+
+        # Do not serve hidden files (.env, .git, ...).
+        location ~ /\. {
+            deny all;
+        }
+    }
+}

--- a/examples/rate-limiting/README.md
+++ b/examples/rate-limiting/README.md
@@ -1,0 +1,48 @@
+# API + rate limiting
+
+Protect an API with request-rate and connection-count limits.
+
+## What it does
+
+- `limit_req` caps each client IP at an average of 10 requests/second,
+  with bursts of up to 20 requests allowed through immediately.
+- `limit_conn` caps each client IP at 10 simultaneous connections.
+- Excess requests get a `429 Too Many Requests` response.
+
+## Run locally
+
+Start any app on port 3000, then run NGINX (Linux):
+
+```sh
+docker run --rm --network host \
+    -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    nginx:alpine
+```
+
+(On Docker Desktop for Mac/Windows, replace `127.0.0.1` in
+`nginx.conf` with `host.docker.internal` and use `-p 8080:8080`.)
+
+Test — after ~30 quick requests you should start seeing `429`:
+
+```sh
+for i in $(seq 1 50); do
+    curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/api/
+done
+```
+
+## Notes
+
+- Remove `nodelay` to instead queue burst requests and serve them at
+  the configured rate — gentler on the backend, slower for clients.
+- Tune `rate` and `burst` to your API's real capacity; 10 r/s is a
+  conservative starting point, not a recommendation.
+- If NGINX sits behind another proxy or CDN, `$binary_remote_addr`
+  shows the proxy's IP. Use the
+  [real_ip](https://nginx.org/en/docs/http/ngx_http_realip_module.html)
+  module to key limits on the real client IP.
+
+## Learn more
+
+- https://nginx.org/en/docs/http/ngx_http_limit_req_module.html
+- https://nginx.org/en/docs/http/ngx_http_limit_conn_module.html
+- https://www.nginx.com/blog/rate-limiting-nginx/

--- a/examples/rate-limiting/nginx.conf
+++ b/examples/rate-limiting/nginx.conf
@@ -1,0 +1,44 @@
+# Rate limit an API with limit_req and limit_conn.
+#
+# Run with Docker (app must be reachable from the container):
+#   docker run --rm -p 8080:8080 \
+#       -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+#       nginx:alpine
+
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    # Key the limits on the client IP ($binary_remote_addr is a
+    # memory-efficient form of $remote_addr).
+    #
+    # A 10 MB zone stores roughly 160 000 IP addresses.
+    limit_req_zone  $binary_remote_addr zone=api:10m  rate=10r/s;
+    limit_conn_zone $binary_remote_addr zone=addr:10m;
+
+    server {
+        listen 8080;
+
+        location /api/ {
+            # Average 10 requests/second per IP, allowing short bursts
+            # of 20 requests that are served immediately (nodelay)
+            # instead of being queued.
+            limit_req zone=api burst=20 nodelay;
+
+            # At most 10 simultaneous connections per IP.
+            limit_conn addr 10;
+
+            # 503 is the default rejection code; 429 is clearer for
+            # API clients.
+            limit_req_status  429;
+            limit_conn_status 429;
+
+            proxy_pass http://127.0.0.1:3000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+}

--- a/examples/reverse-proxy/README.md
+++ b/examples/reverse-proxy/README.md
@@ -1,0 +1,53 @@
+# Reverse proxy to an app
+
+Forward requests to an application server (Node, Python, Go, ...)
+listening on `127.0.0.1:3000`.
+
+## What it does
+
+- Proxies all requests to the `app` upstream.
+- Keeps up to 32 idle keepalive connections to the app, avoiding the
+  cost of a new TCP connection per request.
+- Forwards standard headers (`Host`, `X-Real-IP`, `X-Forwarded-For`,
+  `X-Forwarded-Proto`) so the app sees the real client.
+- Sets explicit timeouts and buffers responses.
+
+## Run locally
+
+Start any app on port 3000, e.g.:
+
+```sh
+docker run --rm -p 3000:3000 hashicorp/http-echo -text "hello from app"
+```
+
+Or use your own application. Then run NGINX:
+
+```sh
+docker run --rm --network host \
+    -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    nginx:alpine
+```
+
+(`--network host` lets the container reach `127.0.0.1:3000` on your
+machine. On Docker Desktop for Mac/Windows, replace `127.0.0.1` in
+`nginx.conf` with `host.docker.internal` and use `-p 8080:8080`
+instead.)
+
+Test:
+
+```sh
+curl http://localhost:8080
+```
+
+## Notes
+
+- `proxy_connect_timeout` should stay small: if the app cannot accept a
+  connection, fail fast instead of making clients wait.
+- For multiple backends, see the [load-balancing](../load-balancing/)
+  example.
+- For WebSocket endpoints, see the [websockets](../websockets/) example.
+
+## Learn more
+
+- https://nginx.org/en/docs/http/ngx_http_proxy_module.html
+- https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive

--- a/examples/reverse-proxy/nginx.conf
+++ b/examples/reverse-proxy/nginx.conf
@@ -1,0 +1,51 @@
+# Reverse proxy to an application server listening on port 3000.
+#
+# Run with Docker (app must be reachable from the container):
+#   docker run --rm -p 8080:8080 \
+#       -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+#       nginx:alpine
+
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    # Named upstream enables keepalive connections to the app and makes
+    # adding more backends later trivial.
+    upstream app {
+        server 127.0.0.1:3000;
+        keepalive 32;
+    }
+
+    server {
+        listen 8080;
+
+        location / {
+            proxy_pass http://app;
+
+            # HTTP/1.1 with an empty Connection header is required for
+            # keepalive to the upstream.
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+
+            # Forward client information the app usually needs.
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Fail fast if the app is down, but allow slow responses.
+            proxy_connect_timeout 5s;
+            proxy_send_timeout    60s;
+            proxy_read_timeout    60s;
+
+            # Buffer app responses so slow clients do not tie up the
+            # application worker.
+            proxy_buffering   on;
+            proxy_buffer_size 32k;
+            proxy_buffers     16 16k;
+        }
+    }
+}

--- a/examples/security-basics/README.md
+++ b/examples/security-basics/README.md
@@ -1,0 +1,50 @@
+# Security basics
+
+A few safe defaults that apply to almost any site.
+
+## What it does
+
+- `server_tokens off` — hides the exact NGINX version from error pages
+  and the `Server` header.
+- Blocks requests for hidden dotfiles (`.git`, `.env`, ...) while
+  keeping `/.well-known/` reachable for ACME challenges and
+  `security.txt`.
+- Sends defensive response headers:
+  - `X-Content-Type-Options: nosniff` — stop MIME-type sniffing.
+  - `X-Frame-Options: SAMEORIGIN` — basic clickjacking protection.
+  - `Referrer-Policy: strict-origin-when-cross-origin` — limit what is
+    leaked in the `Referer` header.
+
+## Run locally
+
+```sh
+mkdir -p html
+echo '<h1>Hello</h1>' > html/index.html
+echo 'SECRET=1' > html/.env
+
+docker run --rm -p 8080:8080 \
+    -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    -v "$PWD/html:/usr/share/nginx/html:ro" \
+    nginx:alpine
+```
+
+Test:
+
+```sh
+curl -I http://localhost:8080/       # no version in Server header
+curl -i http://localhost:8080/.env   # 403 Forbidden
+```
+
+## Notes
+
+- These headers are a baseline, not a complete policy. Depending on
+  your app, also consider a `Content-Security-Policy` and, for HTTPS
+  sites, HSTS (see the [tls-https](../tls-https/) example).
+- Hiding the version is defense in depth, not a substitute for keeping
+  NGINX up to date.
+
+## Learn more
+
+- https://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens
+- https://nginx.org/en/docs/http/ngx_http_access_module.html
+- https://nginx.org/en/docs/http/ngx_http_headers_module.html

--- a/examples/security-basics/nginx.conf
+++ b/examples/security-basics/nginx.conf
@@ -1,0 +1,48 @@
+# Security basics: hide version info, block hidden files, send
+# defensive response headers.
+#
+# Run with Docker:
+#   docker run --rm -p 8080:8080 \
+#       -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+#       -v "$PWD/html:/usr/share/nginx/html:ro" \
+#       nginx:alpine
+
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile      on;
+
+    # Do not reveal the exact NGINX version in error pages and the
+    # Server response header.
+    server_tokens off;
+
+    server {
+        listen 8080;
+
+        root  /usr/share/nginx/html;
+        index index.html;
+
+        # Block dotfiles such as .git/, .env and .htaccess, which are
+        # commonly deployed by accident. Requests for
+        # /.well-known/ (ACME challenges, security.txt) stay allowed.
+        location ~ /\.(?!well-known) {
+            deny all;
+        }
+
+        location / {
+            try_files $uri $uri/ =404;
+        }
+
+        # Defensive headers. "always" also adds them to error responses.
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options        SAMEORIGIN always;
+        add_header Referrer-Policy        strict-origin-when-cross-origin always;
+    }
+}

--- a/examples/spa/README.md
+++ b/examples/spa/README.md
@@ -1,0 +1,48 @@
+# Single-Page App (SPA)
+
+Serve a client-rendered app (React, Vue, Angular, ...) whose routes are
+handled in the browser.
+
+## What it does
+
+- Serves the build output (e.g. `dist/` or `build/`) as static files.
+- Falls back to `index.html` for unknown paths, so deep links like
+  `/users/42` work after a refresh — the client-side router takes over.
+- Caches fingerprinted bundles under `/assets/` aggressively.
+- Marks `index.html` as `no-cache` so deployments take effect
+  immediately.
+
+## Run locally
+
+Use your app's build output, or a minimal stand-in:
+
+```sh
+mkdir -p dist/assets
+echo '<h1>SPA entry point</h1>' > dist/index.html
+echo 'console.log("bundle")' > dist/assets/app.a1b2c3.js
+
+docker run --rm -p 8080:8080 \
+    -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    -v "$PWD/dist:/usr/share/nginx/html:ro" \
+    nginx:alpine
+```
+
+Test:
+
+```sh
+curl http://localhost:8080/some/client/route   # returns index.html
+curl -I http://localhost:8080/assets/app.a1b2c3.js  # long cache
+```
+
+## Notes
+
+- The fallback `try_files $uri $uri/ /index.html;` is the key
+  difference from the [static-site](../static-site/) example, which
+  returns `404` instead.
+- If the app calls an API on the same origin, add a `location /api/`
+  block with `proxy_pass` (see the
+  [reverse-proxy](../reverse-proxy/) example).
+
+## Learn more
+
+- https://nginx.org/en/docs/http/ngx_http_core_module.html#try_files

--- a/examples/spa/nginx.conf
+++ b/examples/spa/nginx.conf
@@ -1,0 +1,55 @@
+# Serve a Single-Page App (React, Vue, Angular, ...).
+#
+# Run with Docker:
+#   docker run --rm -p 8080:8080 \
+#       -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+#       -v "$PWD/dist:/usr/share/nginx/html:ro" \
+#       nginx:alpine
+
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile      on;
+
+    gzip            on;
+    gzip_min_length 256;
+    gzip_types
+        text/plain
+        text/css
+        application/json
+        application/javascript
+        image/svg+xml;
+
+    server {
+        listen 8080;
+
+        root  /usr/share/nginx/html;
+        index index.html;
+
+        # Build output (JS/CSS bundles) is fingerprinted by the
+        # bundler, so it can be cached "forever".
+        location /assets/ {
+            expires 30d;
+            add_header Cache-Control "public, immutable";
+        }
+
+        # Never cache the HTML entry point: it references the
+        # fingerprinted bundles and must be refetched on each deploy.
+        location = /index.html {
+            add_header Cache-Control "no-cache";
+        }
+
+        # Client-side routing: unknown paths are handled by the app's
+        # router, so serve index.html instead of a 404.
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}

--- a/examples/static-site/README.md
+++ b/examples/static-site/README.md
@@ -1,0 +1,39 @@
+# Static site
+
+Serve static files directly from disk with compression and caching.
+
+## What it does
+
+- Serves files from `/usr/share/nginx/html` (the document root).
+- Returns `404` for missing files via `try_files`.
+- Compresses text responses with `gzip`.
+- Sends long-lived, immutable cache headers for files under `/assets/`
+  (use a fingerprinted filename, e.g. `app.a1b2c3.js`, so browsers can
+  cache them safely).
+
+## Run locally
+
+```sh
+mkdir -p html
+echo '<h1>Hello from NGINX</h1>' > html/index.html
+
+docker run --rm -p 8080:8080 \
+    -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    -v "$PWD/html:/usr/share/nginx/html:ro" \
+    nginx:alpine
+```
+
+Open http://localhost:8080.
+
+## Notes
+
+- Verify the cache headers: `curl -I http://localhost:8080/assets/app.js`
+  should show `Cache-Control: public, immutable`.
+- HTML files are intentionally *not* cached aggressively, so new
+  deployments are picked up immediately.
+
+## Learn more
+
+- https://nginx.org/en/docs/http/ngx_http_core_module.html#try_files
+- https://nginx.org/en/docs/http/ngx_http_headers_module.html#expires
+- https://nginx.org/en/docs/http/ngx_http_gzip_module.html

--- a/examples/static-site/nginx.conf
+++ b/examples/static-site/nginx.conf
@@ -1,0 +1,50 @@
+# Serve a static website with gzip and cache headers.
+#
+# Run with Docker:
+#   docker run --rm -p 8080:8080 \
+#       -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+#       -v "$PWD/html:/usr/share/nginx/html:ro" \
+#       nginx:alpine
+
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile      on;
+    tcp_nopush    on;
+
+    # Compress text responses; binary formats (images, video) do not
+    # benefit from gzip.
+    gzip            on;
+    gzip_min_length 256;
+    gzip_types
+        text/plain
+        text/css
+        application/json
+        application/javascript
+        image/svg+xml;
+
+    server {
+        listen       8080;
+        server_name  _;
+
+        root   /usr/share/nginx/html;
+        index  index.html;
+
+        location / {
+            try_files $uri $uri/ =404;
+        }
+
+        # Fingerprinted build assets can be cached "forever".
+        location /assets/ {
+            expires 30d;
+            add_header Cache-Control "public, immutable";
+        }
+    }
+}

--- a/examples/tls-https/README.md
+++ b/examples/tls-https/README.md
@@ -1,0 +1,54 @@
+# TLS / HTTPS
+
+Terminate TLS in NGINX and redirect all HTTP traffic to HTTPS.
+
+## What it does
+
+- Listens on `8080` (HTTP) and permanently redirects to HTTPS.
+- Listens on `8443` (HTTPS) with TLS 1.2 and 1.3 only.
+- Enables a shared TLS session cache for faster handshakes.
+- Sends an HSTS header so browsers stick to HTTPS.
+
+## Run locally
+
+Generate a self-signed certificate:
+
+```sh
+mkdir -p certs html
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+    -keyout certs/privkey.pem -out certs/fullchain.pem \
+    -subj "/CN=localhost"
+echo '<h1>Hello over HTTPS</h1>' > html/index.html
+```
+
+Run NGINX:
+
+```sh
+docker run --rm -p 8080:8080 -p 8443:8443 \
+    -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    -v "$PWD/certs:/etc/nginx/certs:ro" \
+    -v "$PWD/html:/usr/share/nginx/html:ro" \
+    nginx:alpine
+```
+
+Test (the `-k` flag accepts the self-signed certificate):
+
+```sh
+curl -k https://localhost:8443
+curl -I http://localhost:8080   # 301 redirect to https://
+```
+
+## Notes
+
+- For real certificates use a CA such as Let's Encrypt; point
+  `ssl_certificate` at `fullchain.pem` and `ssl_certificate_key` at
+  `privkey.pem`.
+- Only enable HSTS (`Strict-Transport-Security`) once HTTPS works
+  reliably — browsers remember it for the whole `max-age`.
+- To proxy the HTTPS traffic to an app instead of serving files,
+  combine this with the [reverse-proxy](../reverse-proxy/) example.
+
+## Learn more
+
+- https://nginx.org/en/docs/http/ngx_http_ssl_module.html
+- https://nginx.org/en/docs/http/configuring_https_servers.html

--- a/examples/tls-https/nginx.conf
+++ b/examples/tls-https/nginx.conf
@@ -1,0 +1,61 @@
+# HTTPS server with an HTTP to HTTPS redirect.
+#
+# Certificates are expected at /etc/nginx/certs/. For a local test,
+# generate a self-signed pair:
+#   openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+#       -keyout certs/privkey.pem -out certs/fullchain.pem \
+#       -subj "/CN=localhost"
+#
+# Run with Docker:
+#   docker run --rm -p 8080:8080 -p 8443:8443 \
+#       -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+#       -v "$PWD/certs:/etc/nginx/certs:ro" \
+#       -v "$PWD/html:/usr/share/nginx/html:ro" \
+#       nginx:alpine
+
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile      on;
+
+    # Redirect all plain HTTP traffic to HTTPS.
+    server {
+        listen       8080;
+        server_name  _;
+
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen       8443 ssl;
+        server_name  _;
+
+        ssl_certificate     /etc/nginx/certs/fullchain.pem;
+        ssl_certificate_key /etc/nginx/certs/privkey.pem;
+
+        # Modern protocol baseline. TLS 1.3 cipher suites are not
+        # configurable in NGINX; for TLS 1.2 the defaults of a current
+        # OpenSSL are reasonable.
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_session_cache   shared:SSL:10m;
+        ssl_session_timeout 1d;
+
+        # Browsers should only ever use HTTPS for this host. Enable only
+        # after HTTPS works for all subdomains you serve.
+        add_header Strict-Transport-Security "max-age=31536000" always;
+
+        root  /usr/share/nginx/html;
+        index index.html;
+
+        location / {
+            try_files $uri $uri/ =404;
+        }
+    }
+}

--- a/examples/websockets/README.md
+++ b/examples/websockets/README.md
@@ -1,0 +1,53 @@
+# WebSockets
+
+Proxy WebSocket connections through NGINX.
+
+## What it does
+
+- Handles the WebSocket handshake by forwarding the `Upgrade` and
+  `Connection` headers (NGINX does not do this automatically).
+- Uses a `map` so the same location keeps working for plain HTTP
+  requests without an `Upgrade` header.
+- Raises `proxy_read_timeout` to one hour so idle connections are not
+  dropped (the default is 60 seconds).
+- Proxies `/ws/` to the app while `/` remains a normal HTTP proxy.
+
+## Run locally
+
+Start any WebSocket echo server on port 3000, e.g. with Node.js:
+
+```sh
+npx --yes wscat --listen 3000
+```
+
+Run NGINX (Linux):
+
+```sh
+docker run --rm --network host \
+    -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    nginx:alpine
+```
+
+(On Docker Desktop for Mac/Windows, replace `127.0.0.1` in
+`nginx.conf` with `host.docker.internal` and use `-p 8080:8080`.)
+
+Test:
+
+```sh
+npx --yes wscat --connect ws://localhost:8080/ws/
+```
+
+Type a message — the echo server sends it back through NGINX.
+
+## Notes
+
+- If your app sends no traffic while idle, enable WebSocket
+  ping/pong keepalives in the app, or raise `proxy_read_timeout`
+  further.
+- With multiple backends, WebSocket sessions may need `ip_hash`
+  stickiness (see the [load-balancing](../load-balancing/) example).
+
+## Learn more
+
+- https://nginx.org/en/docs/http/websocket.html
+- https://nginx.org/en/docs/http/ngx_http_map_module.html

--- a/examples/websockets/nginx.conf
+++ b/examples/websockets/nginx.conf
@@ -1,0 +1,50 @@
+# Proxy WebSocket connections to an app on port 3000.
+#
+# Run with Docker (app must be reachable from the container):
+#   docker run --rm -p 8080:8080 \
+#       -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+#       nginx:alpine
+
+worker_processes  auto;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    # WebSocket handshake: the client asks for a protocol Upgrade.
+    # Map the client's Upgrade header to the right Connection value:
+    #   - "upgrade" when an Upgrade header is present (WebSocket)
+    #   - "close"    otherwise (plain HTTP)
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    server {
+        listen 8080;
+
+        location /ws/ {
+            proxy_pass http://127.0.0.1:3000;
+
+            # WebSockets require HTTP/1.1 and the Upgrade headers.
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade    $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+
+            proxy_set_header Host   $host;
+            proxy_set_header X-Real-IP $remote_addr;
+
+            # WebSocket connections can be idle for a long time; the
+            # default 60s read timeout would kill them.
+            proxy_read_timeout 3600s;
+        }
+
+        # Plain HTTP endpoints of the same app.
+        location / {
+            proxy_pass http://127.0.0.1:3000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+}


### PR DESCRIPTION
  Problem                                                                                                                                                                                                      
                                                                                                                                                                                                                
   New NGINX users often struggle to find canonical, copy-paste friendly configuration examples for common use cases in one place. The official documentation is comprehensive but reference-oriented; there is 
   no curated set of short, complete, runnable configs for the patterns people most frequently need (static sites, reverse proxy, TLS, load balancing, WebSockets, rate limiting, etc.).                        
                                                                                                                                                                                                                
   Solution                                                                                                                                                                                                     
                                                                                                                                                                                                                
   Add a new top-level examples/ directory containing ten self-contained configuration examples, each in its own folder with a complete nginx.conf and a README.md explaining what it does, how to run it       
   locally (with ready-to-use Docker commands), and links to the relevant documentation:                                                                                                                        
                                                                                                                                                                                                                
   • static-site/ — static files with gzip and cache headers                                                                                                                                                    
   • reverse-proxy/ — proxy to an app with keepalive, timeouts, and buffering                                                                                                                                   
   • tls-https/ — HTTP→HTTPS redirect, TLS 1.2/1.3, HSTS                                                                                                                                                        
   • load-balancing/ — upstream with passive health checks, least_conn/ip_hash alternatives                                                                                                                     
   • websockets/ — Upgrade/Connection header mapping, extended read timeout                                                                                                                                     
   • rate-limiting/ — limit_req/limit_conn with a 429 status for API clients                                                                                                                                    
   • security-basics/ — server_tokens off, dotfile blocking, defensive headers                                                                                                                                  
   • spa/ — try_files fallback to index.html with immutable asset caching                                                                                                                                       
   • php-fpm/ — minimal safe PHP-FPM setup (try_files $uri =404 before fastcgi_pass)                                                                                                                            
   • docker/ — docker-compose.yml + nginx.conf for local development                                                                                                                                            
                                                                                                                                                                                                                
   Design decisions:                                                                                                                                                                                            
                                                                                                                                                                                                                
   • Each example is a complete nginx.conf, not a snippet, so it can be validated and run as-is.                                                                                                                
   • Examples listen on 8080/8443 so they run without root; paths follow the official NGINX Docker image and are documented in each README.                                                                     
   • Comments explain every non-obvious directive; safe defaults are used throughout (e.g. try_files $uri =404 in the PHP example, 429 for rate limiting, /.well-known/ exempted from dotfile blocking).        
   • Changes are split into one commit per example for easy review.                                                                                                                                             
                                                                                                                                                                                                                
   Testing                                                                                                                                                                                                      
                                                                                                                                                                                                                
   • [x] Manual Testing                                                                                                                                                                                         
                                                                                                                                                                                                                
   • [ ] Functional Testing (nginx-tests (https://github.com/nginx/nginx-tests))                                                                                                                                
                                                                                                                                                                                                                
   • All ten nginx.conf files pass nginx -t using the official nginx:alpine Docker image (the TLS example was validated with a temporary self-signed certificate).                                              
                                                                                                                                                                                                                
   • The static-site example was additionally smoke-tested end-to-end: the container served index.html correctly and returned 404 for missing files.                                                            
                                                                                                                                                                                                                
   Documentation-only change; no code paths are affected, so nginx-tests do not apply.                                                                                                                          
                                                                                                                                                                                                                
   Closes: #ISSUE_NUMBER                                                                                                                                                                                        
                                                                                                                                                                                                                
   Checklist                                                                                                                                                                                                    
                                                                                                                                                                                                                
   • [x] I have read the CONTRIBUTING (https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines                                                                                                   
   • [x] I have added tests (if applicable) to validate my changes                                                                                                                                              
   • [x] All existing tests pass                                                                                                                                                                                
   • [x] I have updated documentation where necessary                                                                                                                                                           
   • [x] My branch is rebased on the latest master                                                                                                                                                              
   • [x] This PR targets the master branch from my fork                                                                                                                                                         
   • [x] My commit message follows NGINX standards (imperative mood, clear subject, references related issue if applicable, and contains only relevant changes)                                                 
                                                                                                                                                                                                                
   Release Notes                                                                                                                                                                                                
                                                                                                                                                                                                                
   Added a new examples/ directory with ten tested, copy-paste friendly configuration examples covering common use cases (static sites, reverse proxy, TLS, load balancing, WebSockets, rate limiting, security 
   defaults, SPAs, PHP-FPM, and Docker), making it easier for new users to get started with NGINX.                                                                                                              
                                                                                                    