### PR TITLE
Matched tokens in comma-separated header fields

### DIFF
--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -4442,6 +4442,9 @@ ngx_http_grpc_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
 }
 
 
+static ngx_str_t  ngx_http_grpc_trailers = ngx_string("trailers");
+
+
 static ngx_int_t
 ngx_http_grpc_internal_trailers_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data)
@@ -4455,8 +4458,7 @@ ngx_http_grpc_internal_trailers_variable(ngx_http_request_t *r,
         return NGX_OK;
     }
 
-    if (ngx_strlcasestrn(te->value.data, te->value.data + te->value.len,
-                         (u_char *) "trailers", 8 - 1)
+    if (ngx_http_parse_multi_header_lines(r, te, &ngx_http_grpc_trailers, NULL)
         == NULL)
     {
         v->not_found = 1;

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -2053,11 +2053,22 @@ ngx_http_parse_multi_header_lines_internal(ngx_http_request_t *r,
 
         while (start < end) {
 
+            while (start < end && (*start == ' ' || *start == '\t')) {
+                start++;
+            }
+
+            if (start == end) {
+                break;
+            }
+
             if (ngx_strncasecmp(start, name->data, name->len) != 0) {
                 goto skip;
             }
 
-            for (start += name->len; start < end && *start == ' '; start++) {
+            for (start += name->len;
+                 start < end && (*start == ' ' || *start == '\t');
+                 start++)
+            {
                 /* void */
             }
 
@@ -2074,7 +2085,9 @@ ngx_http_parse_multi_header_lines_internal(ngx_http_request_t *r,
                 goto skip;
             }
 
-            while (start < end && *start == ' ') { start++; }
+            while (start < end && (*start == ' ' || *start == '\t')) {
+                start++;
+            }
 
             for (last = start; last < end && *last != sep; last++) {
                 /* void */
@@ -2093,8 +2106,6 @@ ngx_http_parse_multi_header_lines_internal(ngx_http_request_t *r,
                     break;
                 }
             }
-
-            while (start < end && *start == ' ') { start++; }
         }
     }
 

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -1914,6 +1914,10 @@ ngx_http_process_host(ngx_http_request_t *r, ngx_table_elt_t *h,
 }
 
 
+static ngx_str_t  ngx_http_connection_close = ngx_string("close");
+static ngx_str_t  ngx_http_connection_keep_alive = ngx_string("keep-alive");
+
+
 static ngx_int_t
 ngx_http_process_connection(ngx_http_request_t *r, ngx_table_elt_t *h,
     ngx_uint_t offset)
@@ -1922,10 +1926,17 @@ ngx_http_process_connection(ngx_http_request_t *r, ngx_table_elt_t *h,
         return NGX_ERROR;
     }
 
-    if (ngx_strcasestrn(h->value.data, "close", 5 - 1)) {
+    if (ngx_http_parse_multi_header_lines(r, h, &ngx_http_connection_close,
+                                          NULL)
+        != NULL)
+    {
         r->headers_in.connection_type = NGX_HTTP_CONNECTION_CLOSE;
 
-    } else if (ngx_strcasestrn(h->value.data, "keep-alive", 10 - 1)) {
+    } else if (ngx_http_parse_multi_header_lines(r, h,
+                                                &ngx_http_connection_keep_alive,
+                                                NULL)
+               != NULL)
+    {
         r->headers_in.connection_type = NGX_HTTP_CONNECTION_KEEP_ALIVE;
     }
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -5480,6 +5480,9 @@ ngx_http_upstream_process_charset(ngx_http_request_t *r, ngx_table_elt_t *h,
 }
 
 
+static ngx_str_t  ngx_http_upstream_close = ngx_string("close");
+
+
 static ngx_int_t
 ngx_http_upstream_process_connection(ngx_http_request_t *r, ngx_table_elt_t *h,
     ngx_uint_t offset)
@@ -5495,8 +5498,8 @@ ngx_http_upstream_process_connection(ngx_http_request_t *r, ngx_table_elt_t *h,
     *ph = h;
     h->next = NULL;
 
-    if (ngx_strlcasestrn(h->value.data, h->value.data + h->value.len,
-                         (u_char *) "close", 5 - 1)
+    if (ngx_http_parse_multi_header_lines(r, h, &ngx_http_upstream_close,
+                                          NULL)
         != NULL)
     {
         u->headers_in.connection_close = 1;

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -5084,6 +5084,37 @@ ngx_http_upstream_process_set_cookie(ngx_http_request_t *r, ngx_table_elt_t *h,
 }
 
 
+#if (NGX_HTTP_CACHE)
+
+static ngx_str_t  ngx_http_upstream_cc_no_cache = ngx_string("no-cache");
+static ngx_str_t  ngx_http_upstream_cc_no_store = ngx_string("no-store");
+static ngx_str_t  ngx_http_upstream_cc_private = ngx_string("private");
+static ngx_str_t  ngx_http_upstream_cc_s_maxage = ngx_string("s-maxage");
+static ngx_str_t  ngx_http_upstream_cc_max_age = ngx_string("max-age");
+static ngx_str_t  ngx_http_upstream_cc_stale_wr =
+                                       ngx_string("stale-while-revalidate");
+static ngx_str_t  ngx_http_upstream_cc_stale_ie = ngx_string("stale-if-error");
+
+
+/*
+ * a cache-directive may carry an optional argument, for example
+ * no-cache="Set-Cookie"; such a directive is not implemented and is
+ * treated as its unqualified form, as it was before
+ */
+
+static ngx_uint_t
+ngx_http_upstream_cache_control(ngx_http_request_t *r, ngx_table_elt_t *h,
+    ngx_str_t *name)
+{
+    ngx_str_t  value;
+
+    return ngx_http_parse_multi_header_lines(r, h, name, NULL) != NULL
+           || ngx_http_parse_multi_header_lines(r, h, name, &value) != NULL;
+}
+
+#endif
+
+
 static ngx_int_t
 ngx_http_upstream_process_cache_control(ngx_http_request_t *r,
     ngx_table_elt_t *h, ngx_uint_t offset)
@@ -5101,7 +5132,7 @@ ngx_http_upstream_process_cache_control(ngx_http_request_t *r,
 
 #if (NGX_HTTP_CACHE)
     {
-    u_char     *p, *start, *last;
+    ngx_str_t   value;
     ngx_int_t   n;
 
     if (u->conf->ignore_headers & NGX_HTTP_UPSTREAM_IGN_CACHE_CONTROL) {
@@ -5112,31 +5143,29 @@ ngx_http_upstream_process_cache_control(ngx_http_request_t *r,
         return NGX_OK;
     }
 
-    start = h->value.data;
-    last = start + h->value.len;
-
     if (r->cache->valid_sec != 0 && u->headers_in.x_accel_expires != NULL) {
         goto extensions;
     }
 
-    if (ngx_strlcasestrn(start, last, (u_char *) "no-cache", 8 - 1) != NULL
-        || ngx_strlcasestrn(start, last, (u_char *) "no-store", 8 - 1) != NULL
-        || ngx_strlcasestrn(start, last, (u_char *) "private", 7 - 1) != NULL)
+    if (ngx_http_upstream_cache_control(r, h, &ngx_http_upstream_cc_no_cache)
+        || ngx_http_upstream_cache_control(r, h, &ngx_http_upstream_cc_no_store)
+        || ngx_http_upstream_cache_control(r, h, &ngx_http_upstream_cc_private))
     {
         u->headers_in.no_cache = 1;
         return NGX_OK;
     }
 
-    p = ngx_strlcasestrn(start, last, (u_char *) "s-maxage=", 9 - 1);
-    offset = 9;
-
-    if (p == NULL) {
-        p = ngx_strlcasestrn(start, last, (u_char *) "max-age=", 8 - 1);
-        offset = 8;
-    }
-
-    if (p) {
-        n = ngx_http_upstream_process_delta_seconds(p + offset, last);
+    if (ngx_http_parse_multi_header_lines(r, h,
+                                          &ngx_http_upstream_cc_s_maxage,
+                                          &value)
+        != NULL
+        || ngx_http_parse_multi_header_lines(r, h,
+                                            &ngx_http_upstream_cc_max_age,
+                                            &value)
+           != NULL)
+    {
+        n = ngx_http_upstream_process_delta_seconds(value.data,
+                                                   value.data + value.len);
 
         if (n == NGX_ERROR) {
             u->cacheable = 0;
@@ -5155,11 +5184,13 @@ ngx_http_upstream_process_cache_control(ngx_http_request_t *r,
 
 extensions:
 
-    p = ngx_strlcasestrn(start, last, (u_char *) "stale-while-revalidate=",
-                         23 - 1);
-
-    if (p) {
-        n = ngx_http_upstream_process_delta_seconds(p + 23, last);
+    if (ngx_http_parse_multi_header_lines(r, h,
+                                          &ngx_http_upstream_cc_stale_wr,
+                                          &value)
+        != NULL)
+    {
+        n = ngx_http_upstream_process_delta_seconds(value.data,
+                                                   value.data + value.len);
 
         if (n == NGX_ERROR) {
             u->cacheable = 0;
@@ -5170,10 +5201,13 @@ extensions:
         r->cache->error_sec = n;
     }
 
-    p = ngx_strlcasestrn(start, last, (u_char *) "stale-if-error=", 15 - 1);
-
-    if (p) {
-        n = ngx_http_upstream_process_delta_seconds(p + 15, last);
+    if (ngx_http_parse_multi_header_lines(r, h,
+                                          &ngx_http_upstream_cc_stale_ie,
+                                          &value)
+        != NULL)
+    {
+        n = ngx_http_upstream_process_delta_seconds(value.data,
+                                                   value.data + value.len);
 
         if (n == NGX_ERROR) {
             u->cacheable = 0;


### PR DESCRIPTION
## Problem

Several header field values that are comma-separated lists were searched for a
token with a plain substring search, so a token that merely contains a standard
one was treated as the standard token:

- `Cache-Control` (upstream response) -- `x-max-age=600` or `foo-s-maxage=600`
  acted as `max-age`/`s-maxage`, changing response cacheability.
- `Connection` (upstream response) -- an option such as `x-close` marked the
  upstream connection as non-reusable.
- `Connection` (client request) -- an option such as `x-close` or
  `x-keep-alive` selected the connection type.
- `TE` (client request) -- a coding such as `x-trailers` made
  `$grpc_internal_trailers` signal trailer support.

Per RFC 9110 and RFC 9111 these field values are `#rule` lists, so a token must
begin at the start of the value or right after a comma separator.

## Solution

The lookups now go through `ngx_http_parse_multi_header_lines()`, which matches
at comma-separated token boundaries and handles both `name` and `name=value`.
It already existed for this purpose -- it is the `','` wrapper around
`ngx_http_parse_multi_header_lines_internal()`, the sibling of
`ngx_http_parse_cookie_lines()` (`';'`) -- and `ngx_http_gzip_ok()` already uses
it on `Cache-Control`, so the same header was being parsed two ways in the tree.
A non-boundary match no longer matches, while a real token later in the list is
still found, for example `x-max-age=1, max-age=600` uses `max-age=600`.

That helper skipped only spaces around list elements, while RFC 9110 defines
optional whitespace as SP or HTAB, and the header line parser does not strip a
tab that follows the colon. Switching the lookups over without addressing that
would have stopped recognising values such as a tab-separated `close`, which the
previous substring search matched by ignoring whitespace altogether. The first
commit therefore teaches the shared parser to accept HTAB. It is also used by
`ngx_http_parse_cookie_lines()` and by `ngx_http_gzip_ok()`, which as a side
effect now recognise a tab-separated element as well.

The commits, in order:

- Allowed HTAB as whitespace around header list elements.
- `Upstream:` Cache-Control directives.
- `Upstream:` Connection `close`.
- `Core:` Connection `close` and `keep-alive`.
- `gRPC:` TE `trailers`; this one now also examines all `TE` header lines rather
  than only the first.

The HTAB commit comes first so that no single commit in the series carries the
regression.

A Cache-Control directive may carry an optional argument, and
`no-cache="Set-Cookie"` was previously caught by the substring search. Since the
valueless form of the lookup requires end-or-separator after the name, such a
qualified directive would no longer match and those responses would start being
cached; a small wrapper therefore checks both forms and keeps treating them as
the unqualified directive, as before.

Two similar sites are deliberately unchanged.
`ngx_http_gzip_accept_encoding()` already performs the boundary check itself, and
the shared helper cannot replace it: it has no notion of a parameterized token,
so `gzip;q=0.5` would not match, and the q-value is what that code needs. The
`url=` lookup used for `Refresh` rewriting is a different shape, with `;`
parameters and the match offset handed to `rewrite_redirect`.

## Priority / type

Low-priority correctness fix. Not a security fix: the effects are a mild
mis-cache, an unnecessary upstream connection close, a connection type selected
from a malformed option, and a spurious trailer signal to the backend. Note that
unlike the `Cache-Control` case, the client `Connection` and `TE` values are
client-supplied, so the sweep is not limited to trusted upstream input.

## Testing

Built with `-Werror`. Verified against a patched and an unpatched binary:

- Cache-Control -- `x-max-age=600` and `foo-s-maxage=600` are no longer cached
  (they were before); `max-age=600`, `s-maxage=600`, `public, max-age=600` are
  still cached; `no-cache, max-age=600` is still blocked;
  `x-max-age=1, max-age=600` is cached via the real `max-age`.
- Connection, client request -- `Connection: x-close` on HTTP/1.1 produced
  `Connection: close` before the change and keep-alive after;
  `Connection: x-keep-alive` on HTTP/1.0 produced `Connection: keep-alive`
  before and close after; the unprefixed values are unchanged.
- Connection, upstream response -- a backend option `x-close` no longer prevents
  the upstream connection from being reused.
- Whitespace -- a tab-separated element is still recognised, both directly after
  the colon and after a comma, matching the behaviour before the change.

Regression: 1187 tests across `proxy_cache*`, `proxy_keepalive`,
`http_keepalive*`, `upstream*`, `grpc*`, `proxy`, `proxy_chunked` and the cookie
and gzip suites, the latter two being the other users of the shared parser.
`grpc_trailers.t` passes for HTTP/1.1, HTTP/2 and HTTP/3 clients. The only
failure seen was `proxy_cache_use_stale.t` test 30, which flakes on unmodified
master as well.

The gRPC change has no boundary-case test: its only observable is the `te`
header sent to the backend, and the gRPC tests have no existing way to assert on
what the backend received.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

Test PR: nginx/nginx-tests#85
