### PR TITLE
Auth basic: compare passwords in constant time

### DIFF
--- a/src/http/modules/ngx_http_auth_basic_module.c
+++ b/src/http/modules/ngx_http_auth_basic_module.c
@@ -286,8 +286,9 @@ static ngx_int_t
 ngx_http_auth_basic_crypt_handler(ngx_http_request_t *r, ngx_str_t *passwd,
     ngx_str_t *realm)
 {
+    size_t      i, elen, plen;
+    u_char      ch, *encrypted;
     ngx_int_t   rc;
-    u_char     *encrypted;
 
     rc = ngx_crypt(r->pool, r->headers_in.passwd.data, passwd->data,
                    &encrypted);
@@ -300,7 +301,18 @@ ngx_http_auth_basic_crypt_handler(ngx_http_request_t *r, ngx_str_t *passwd,
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    if (ngx_strcmp(encrypted, passwd->data) == 0) {
+    /* constant time comparison */
+
+    elen = ngx_strlen(encrypted);
+    plen = ngx_strlen(passwd->data);
+
+    ch = (elen != plen);
+
+    for (i = 0; i < elen && i < plen; i++) {
+        ch |= encrypted[i] ^ passwd->data[i];
+    }
+
+    if (ch == 0) {
         return NGX_OK;
     }
 


### PR DESCRIPTION
### What

`ngx_http_auth_basic_crypt_handler()` compared the computed and stored password strings with `ngx_strcmp()`, which returns at the first differing byte and so leaks, through timing, how many leading bytes matched. With the `{PLAIN}` password scheme that is the number of correct leading password characters.

The secure link module was recently changed to compare hashes in constant time (bedf18f95d76); this makes the auth_basic comparison consistent.

### Priority / type

Low-priority hardening (enhancement), not a security fix. Timing measurement across a network is impractical and `{PLAIN}` is uncommon; this is a consistency follow-up to the secure link change.

### Testing

Built; verified `{PLAIN}` and crypt(3) users still authenticate with the correct password and are rejected (401) with a wrong, too-short, or too-long password.