### PR TITLE
Core: argument validation in ngx_conf_set_path_slot()

### DIFF
--- a/src/core/ngx_file.c
+++ b/src/core/ngx_file.c
@@ -394,6 +394,10 @@ ngx_conf_set_path_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     path->line = cf->conf_file->line;
 
     for (i = 0, n = 2; n < cf->args->nelts; i++, n++) {
+        if (i >= NGX_MAX_PATH_LEVEL) {
+            return "invalid value";
+        }
+
         level = ngx_atoi(value[n].data, value[n].len);
         if (level == NGX_ERROR || level == 0) {
             return "invalid value";

--- a/src/core/ngx_file.c
+++ b/src/core/ngx_file.c
@@ -382,6 +382,10 @@ ngx_conf_set_path_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     path->name = value[1];
 
+    if (path->name.len == 0) {
+        return "invalid value";
+    }
+
     if (path->name.data[path->name.len - 1] == '/') {
         path->name.len--;
     }


### PR DESCRIPTION
### What

`ngx_conf_set_path_slot()` wrote `path->level[i]` before checking `i` against `NGX_MAX_PATH_LEVEL`. The write is currently safe only because every directive using the slot is `NGX_CONF_TAKE1234` (at most three levels). This makes the bound explicit so the fixed-size `level[]` array cannot be overrun if a future directive permits more arguments.

### Priority / type

Low-priority defense-in-depth (enhancement). Not a reachable overflow today: all current callers are argument-count limited, and `proxy_cache_path` uses a separate `levels=` parser that is already bounded.

### Testing

Built; `nginx -t` accepts valid level counts and cleanly rejects excess ones with no crash.

---

Added a second commit for another missing argument check in the same function.

An empty path name is accepted by the parser, so `proxy_temp_path "";` reaches

```c
path->name = value[1];

if (path->name.data[path->name.len - 1] == '/') {
```

with `path->name.len == 0`, and the index underflows. Built with
`-DNGX_DEBUG_PALLOC=1` and AddressSanitizer this is reported as a one-byte
read before the allocation:

```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 1
    #0 ngx_conf_set_path_slot src/core/ngx_file.c:385
    #1 ngx_conf_handler src/core/ngx_conf_file.c:463
```

Without `NGX_DEBUG_PALLOC` the byte comes from the surrounding pool block, so
nothing is observed, but the read is still out of bounds and the result of the
comparison is meaningless; if the adjacent byte happened to be '/', the length
would be decremented to `(size_t) -1`.

All five directives using this handler are affected (`proxy_temp_path`,
`fastcgi_temp_path`, `scgi_temp_path`, `uwsgi_temp_path`,
`client_body_temp_path`); the single check covers all of them, and each now
reports "invalid value". Checked that ordinary values, including levels and a
trailing slash, are still accepted.

This is configuration-time only and so not a security issue, in the same way as
the levels bound above.