### PR TITLE
Limit conn, limit req, stream limit conn: reject an overlong key

### DIFF
--- a/src/http/modules/ngx_http_limit_conn_module.c
+++ b/src/http/modules/ngx_http_limit_conn_module.c
@@ -214,7 +214,18 @@ ngx_http_limit_conn_handler(ngx_http_request_t *r)
                           "the value of the \"%V\" key "
                           "is more than 255 bytes: \"%V\"",
                           &ctx->key.value, &key);
-            continue;
+
+            ngx_http_limit_conn_cleanup_all(r->pool);
+
+            if (lccf->dry_run) {
+                r->main->limit_conn_status =
+                                      NGX_HTTP_LIMIT_CONN_REJECTED_DRY_RUN;
+                return NGX_DECLINED;
+            }
+
+            r->main->limit_conn_status = NGX_HTTP_LIMIT_CONN_REJECTED;
+
+            return lccf->status_code;
         }
 
         r->main->limit_conn_status = NGX_HTTP_LIMIT_CONN_PASSED;

--- a/src/http/modules/ngx_http_limit_req_module.c
+++ b/src/http/modules/ngx_http_limit_req_module.c
@@ -238,7 +238,17 @@ ngx_http_limit_req_handler(ngx_http_request_t *r)
                           "the value of the \"%V\" key "
                           "is more than 65535 bytes: \"%V\"",
                           &ctx->key.value, &key);
-            continue;
+
+            ngx_http_limit_req_unlock(limits, n);
+
+            if (lrcf->dry_run) {
+                r->main->limit_req_status = NGX_HTTP_LIMIT_REQ_REJECTED_DRY_RUN;
+                return NGX_DECLINED;
+            }
+
+            r->main->limit_req_status = NGX_HTTP_LIMIT_REQ_REJECTED;
+
+            return lrcf->status_code;
         }
 
         hash = ngx_crc32_short(key.data, key.len);

--- a/src/stream/ngx_stream_limit_conn_module.c
+++ b/src/stream/ngx_stream_limit_conn_module.c
@@ -194,7 +194,17 @@ ngx_stream_limit_conn_handler(ngx_stream_session_t *s)
                           "the value of the \"%V\" key "
                           "is more than 255 bytes: \"%V\"",
                           &ctx->key.value, &key);
-            continue;
+
+            ngx_stream_limit_conn_cleanup_all(s->connection->pool);
+
+            if (lccf->dry_run) {
+                s->limit_conn_status = NGX_STREAM_LIMIT_CONN_REJECTED_DRY_RUN;
+                return NGX_DECLINED;
+            }
+
+            s->limit_conn_status = NGX_STREAM_LIMIT_CONN_REJECTED;
+
+            return NGX_STREAM_SERVICE_UNAVAILABLE;
         }
 
         s->limit_conn_status = NGX_STREAM_LIMIT_CONN_PASSED;


### PR DESCRIPTION
### What

When the evaluated key exceeded the storable length (255 bytes for `limit_conn`, 65535 for `limit_req`), the modules logged an error and `continue`d, silently skipping the limit -- so a request/connection with an overlong key was **not** limited (fail-open). With a single zone in the location it passed unlimited.

The overlong-key branch now fails **closed**: the request/connection is rejected like any other limited one (honouring `dry_run`, and releasing already-locked/registered state first). Keys within the length limit -- including the usual `$binary_remote_addr` -- are unaffected (that branch is never taken for bounded keys).

Covers three modules, in separate commits:

- `ngx_http_limit_conn_module` and `ngx_http_limit_req_module` -- reject with the configured `limit_*_status` code.
- `ngx_stream_limit_conn_module` -- reject the connection (`NGX_STREAM_SERVICE_UNAVAILABLE`). (There is no stream `limit_req` -- limit_req is http-only.)

### Priority / type

Low-priority hardening (fail-open -> fail-closed).

### Testing

Built with `-Werror`.

- http: with a key from a request header, short key -> 200, overlong key (>255 for limit_conn, >65535 for limit_req) -> 503.
- stream: with a zone keyed on an overlong value, under `limit_conn 1`, all concurrent connections were accepted before the change (fail-open) and are rejected after it; a bounded key is unaffected.

Test PR: nginx/nginx-tests#87 (http `limit_conn.t` / `limit_req.t` and stream `stream_limit_conn.t`).
