### PR TITLE
Memcached: rejected too long length in response

### DIFF
--- a/src/http/modules/ngx_http_memcached_module.c
+++ b/src/http/modules/ngx_http_memcached_module.c
@@ -421,6 +421,16 @@ found:
             return NGX_HTTP_UPSTREAM_INVALID_HEADER;
         }
 
+        if (u->headers_in.content_length_n
+            > NGX_MAX_OFF_T_VALUE - (off_t) NGX_HTTP_MEMCACHED_END)
+        {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "memcached sent too long length in response \"%V\" "
+                          "for key \"%V\"",
+                          &line, &ctx->key);
+            return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+        }
+
         u->headers_in.status_n = 200;
         u->state->status = 200;
         u->buffer.pos = p + sizeof(CRLF) - 1;


### PR DESCRIPTION
### What

`ngx_http_memcached_filter_init()` sets `u->length = content_length_n + NGX_HTTP_MEMCACHED_END`. A `VALUE` length close to the `off_t` maximum wraps this addition to a negative value, which the body filter then uses to compute an out-of-range pointer (`ngx_strncmp` on a wild `last`).

The length parsed from the memcached response is now bounded so the addition cannot overflow; an oversized length is treated as an invalid response.

### Priority / type

Low-priority robustness fix. The length comes from the memcached server, which is trusted under nginx's model, so this is **not** a security vulnerability -- it hardens against a malformed/compromised backend.

### Testing

Built; a fake backend returning `VALUE key 0 <off_t-max>` now yields 502 (invalid header) with the worker staying up, instead of the wild-pointer read. Normal responses are unaffected.