### PR TITLE
Upstream: skipped caching responses with a too large header block

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -3444,7 +3444,21 @@ ngx_http_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
         if (valid) {
             r->cache->date = now;
-            r->cache->body_start = (u_short) (u->buffer.pos - u->buffer.start);
+
+            if ((size_t) (u->buffer.pos - u->buffer.start) > 65535) {
+
+                /*
+                 * the offset does not fit into the u_short body_start field
+                 * of the cache file header; do not cache the response rather
+                 * than truncate the offset
+                 */
+
+                u->cacheable = 0;
+
+            } else {
+                r->cache->body_start =
+                                 (u_short) (u->buffer.pos - u->buffer.start);
+            }
 
             if (u->headers_in.status_n == NGX_HTTP_OK
                 || u->headers_in.status_n == NGX_HTTP_PARTIAL_CONTENT)


### PR DESCRIPTION
### What

The cache file header stores the response body offset in a `u_short` `body_start`. When the upstream response header block exceeds 65535 bytes, `r->cache->body_start = (u_short)(...)` truncates the offset; if the truncated value equals `header_start`, the HTTP/0.9 cache-hit fast path (`header_start == body_start`) sends the cached file from the wrong offset, exposing stored pre-body bytes (upstream headers / transport framing).

Such a response is now left uncached (`u->cacheable = 0`) instead of storing a truncated offset. Responses whose header block fits in the field are handled exactly as before.

### Priority / type

Low-priority robustness fix. It requires a non-default large proxy buffer (`proxy_buffer_size` > 64 KB) and an upstream emitting a > 64 KB header block -- both trusted -- so it is **not** a security vulnerability.

### Testing

Built; an upstream response with a ~70 KB header block under `proxy_buffer_size 128k` is no longer cached (stays MISS) and the worker is stable; normal responses cache as before.

### Note on behavior / testing

On the unpatched code the truncated `body_start` produces a **corrupt, unusable** cache entry that fails validation on read, so the response is re-fetched (MISS) rather than served -- except in the narrow case where the offset truncates to exactly `header_start`, which triggers the HTTP/0.9 fast-path disclosure. This fix cleanly skips caching in all such cases. A discriminating Test::Nginx regression is not practical (it would require constructing that exact `body_start == header_start` alignment), so no test PR accompanies this change.