### PR TITLE
QUIC: enforced stream flow control for the RESET_STREAM final size

### DIFF
--- a/src/event/quic/ngx_event_quic_streams.c
+++ b/src/event/quic/ngx_event_quic_streams.c
@@ -1481,11 +1481,11 @@ ngx_quic_handle_reset_stream_frame(ngx_connection_t *c,
         return NGX_OK;
     }
 
-    qs->recv_state = NGX_QUIC_STREAM_RECV_RESET_RECVD;
-
     if (ngx_quic_control_flow(qs, f->final_size) != NGX_OK) {
         return NGX_ERROR;
     }
+
+    qs->recv_state = NGX_QUIC_STREAM_RECV_RESET_RECVD;
 
     if (qs->recv_final_size != (uint64_t) -1
         && qs->recv_final_size != f->final_size)


### PR DESCRIPTION
### What

`ngx_quic_handle_reset_stream_frame()` set the stream receive state to `RESET_RECVD` **before** calling `ngx_quic_control_flow()`. The per-stream flow-control check in `ngx_quic_control_flow()` is gated on the stream being in the `RECV` state, so on the RESET_STREAM path it was skipped -- only the connection-level limit was enforced, allowing a `RESET_STREAM` `final_size` above the per-stream limit.

The check now runs before the receive state is changed, so an oversized `final_size` is rejected as a flow-control violation.

### Priority / type

Low-priority conformance hardening. Impact is self-limited -- the connection-level window (`initial_max_data`) is still the hard cap and it affects only the client's own connection -- so this is **not** a security vulnerability (RFC 9000 §4.5 conformance).

### Testing

Built against quictls 3.1.7 with `--with-http_v3_module`; the full `h3_*.t` + `quic_*.t` suite passes identically to the unpatched baseline (two files fail on both, pre-existing quictls/0-RTT env quirks unrelated to this change).