### PR TITLE
HTTP/3: rejected too large content length in a response

### DIFF
--- a/src/http/v3/ngx_http_v3_filter_module.c
+++ b/src/http/v3/ngx_http_v3_filter_module.c
@@ -144,6 +144,19 @@ ngx_http_v3_header_filter(ngx_http_request_t *r)
 
     c = r->connection;
 
+    if (r->headers_out.content_length_n > 0x3fffffffffffffff) {
+
+        /*
+         * the length would not fit into a QUIC variable-length integer
+         * and would be silently truncated in the DATA frame length
+         */
+
+        ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                      "too large content length %O in HTTP/3 response",
+                      r->headers_out.content_length_n);
+        return NGX_ERROR;
+    }
+
     out = NULL;
     ll = &out;
 


### PR DESCRIPTION
### What

A response `Content-Length` at or above 2^62 does not fit into a QUIC variable-length integer. It was passed to `ngx_http_v3_encode_varlen_int()` for the DATA frame length and silently truncated, so the framed length no longer matched the body -- the client could then misinterpret body bytes as subsequent HTTP/3 frames.

The response is now rejected in the HTTP/3 header filter before any frame is written.

### Priority / type

Low-priority robustness fix. `content_length_n` this large can only come from the upstream response, which is trusted under nginx's model (no client-driven path sets it), so this is **not** a security vulnerability.

### Testing

Built against quictls 3.1.7; `h3_request_body.t`, `h3_headers.t`, `h3_proxy.t` (114 tests) pass -- normal responses (length far below the bound, or -1) are unaffected. A positive regression test (oversized upstream Content-Length over HTTP/3) is warranted as a follow-up.