### PR TITLE
OAUTHBEARER support for IMAP/POP/SMTP mail proxy

### DIFF
--- a/src/core/ngx_string.c
+++ b/src/core/ngx_string.c
@@ -1990,6 +1990,65 @@ ngx_escape_json(u_char *dst, u_char *src, size_t size)
 }
 
 
+uintptr_t
+ngx_escape_xtext(u_char *dst, u_char *src, size_t size)
+{
+    u_char         ch;
+    ngx_uint_t     n;
+    static u_char  hex[] = "0123456789ABCDEF";
+
+    /*
+     * RFC 1891 / 3461 xtext encoding:
+     *
+     * xtext = *( xchar / hexchar )
+     *
+     * xchar = any ASCII CHAR between "!" (33) and "~" (126) inclusive,
+     *         except for "+" and "=".
+     *
+     * hexchar = ASCII "+" immediately followed by two upper case
+     *           hexadecimal digits
+     *
+     * Mostly equivalent to URI escaping, but uses "+" instead of "%".
+     */
+
+    if (dst == NULL) {
+
+        /* find the number of the characters to be escaped */
+
+        n = 0;
+
+        while (size) {
+            ch = *src++;
+
+            if (ch <= 0x20 || ch >= 0x7f || ch == '+' || ch == '=') {
+                n++;
+            }
+
+            size--;
+        }
+
+        return (uintptr_t) n;
+    }
+
+    while (size) {
+        ch = *src++;
+
+        if (ch <= 0x20 || ch >= 0x7f || ch == '+' || ch == '=') {
+            *dst++ = '+';
+            *dst++ = hex[ch >> 4];
+            *dst++ = hex[ch & 0xf];
+
+        } else {
+            *dst++ = ch;
+        }
+
+        size--;
+    }
+
+    return (uintptr_t) dst;
+}
+
+
 void
 ngx_str_rbtree_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel)

--- a/src/core/ngx_string.h
+++ b/src/core/ngx_string.h
@@ -213,6 +213,7 @@ uintptr_t ngx_escape_uri(u_char *dst, u_char *src, size_t size,
 void ngx_unescape_uri(u_char **dst, u_char **src, size_t size, ngx_uint_t type);
 uintptr_t ngx_escape_html(u_char *dst, u_char *src, size_t size);
 uintptr_t ngx_escape_json(u_char *dst, u_char *src, size_t size);
+uintptr_t ngx_escape_xtext(u_char *dst, u_char *src, size_t size);
 
 
 typedef struct {

--- a/src/mail/ngx_mail.h
+++ b/src/mail/ngx_mail.h
@@ -142,7 +142,9 @@ typedef enum {
     ngx_pop3_auth_login_password,
     ngx_pop3_auth_plain,
     ngx_pop3_auth_cram_md5,
-    ngx_pop3_auth_external
+    ngx_pop3_auth_external,
+    ngx_pop3_auth_xoauth2,
+    ngx_pop3_auth_oauthbearer
 } ngx_pop3_state_e;
 
 
@@ -153,6 +155,8 @@ typedef enum {
     ngx_imap_auth_plain,
     ngx_imap_auth_cram_md5,
     ngx_imap_auth_external,
+    ngx_imap_auth_xoauth2,
+    ngx_imap_auth_oauthbearer,
     ngx_imap_login,
     ngx_imap_user,
     ngx_imap_passwd
@@ -166,6 +170,8 @@ typedef enum {
     ngx_smtp_auth_plain,
     ngx_smtp_auth_cram_md5,
     ngx_smtp_auth_external,
+    ngx_smtp_auth_xoauth2,
+    ngx_smtp_auth_oauthbearer,
     ngx_smtp_helo,
     ngx_smtp_helo_xclient,
     ngx_smtp_helo_auth,
@@ -213,8 +219,9 @@ typedef struct {
     unsigned                no_sync_literal:1;
     unsigned                starttls:1;
     unsigned                esmtp:1;
-    unsigned                auth_method:3;
+    unsigned                auth_method:4;
     unsigned                auth_wait:1;
+    unsigned                auth_quit:1;
 
     ngx_str_t               login;
     ngx_str_t               passwd;
@@ -229,6 +236,8 @@ typedef struct {
     ngx_str_t               smtp_helo;
     ngx_str_t               smtp_from;
     ngx_str_t               smtp_to;
+
+    ngx_str_t               auth_err;
 
     ngx_str_t               cmd;
 
@@ -304,15 +313,19 @@ typedef struct {
 #define NGX_MAIL_AUTH_APOP              3
 #define NGX_MAIL_AUTH_CRAM_MD5          4
 #define NGX_MAIL_AUTH_EXTERNAL          5
-#define NGX_MAIL_AUTH_NONE              6
+#define NGX_MAIL_AUTH_XOAUTH2           6
+#define NGX_MAIL_AUTH_OAUTHBEARER       7
+#define NGX_MAIL_AUTH_NONE              8
 
 
-#define NGX_MAIL_AUTH_PLAIN_ENABLED     0x0002
-#define NGX_MAIL_AUTH_LOGIN_ENABLED     0x0004
-#define NGX_MAIL_AUTH_APOP_ENABLED      0x0008
-#define NGX_MAIL_AUTH_CRAM_MD5_ENABLED  0x0010
-#define NGX_MAIL_AUTH_EXTERNAL_ENABLED  0x0020
-#define NGX_MAIL_AUTH_NONE_ENABLED      0x0040
+#define NGX_MAIL_AUTH_PLAIN_ENABLED        0x0002
+#define NGX_MAIL_AUTH_LOGIN_ENABLED        0x0004
+#define NGX_MAIL_AUTH_APOP_ENABLED         0x0008
+#define NGX_MAIL_AUTH_CRAM_MD5_ENABLED     0x0010
+#define NGX_MAIL_AUTH_EXTERNAL_ENABLED     0x0020
+#define NGX_MAIL_AUTH_XOAUTH2_ENABLED      0x0040
+#define NGX_MAIL_AUTH_OAUTHBEARER_ENABLED  0x0080
+#define NGX_MAIL_AUTH_NONE_ENABLED         0x0100
 
 
 #define NGX_MAIL_PARSE_INVALID_COMMAND  20
@@ -399,6 +412,10 @@ ngx_int_t ngx_mail_auth_cram_md5_salt(ngx_mail_session_t *s,
     ngx_connection_t *c, char *prefix, size_t len);
 ngx_int_t ngx_mail_auth_cram_md5(ngx_mail_session_t *s, ngx_connection_t *c);
 ngx_int_t ngx_mail_auth_external(ngx_mail_session_t *s, ngx_connection_t *c,
+    ngx_uint_t n);
+ngx_int_t ngx_mail_auth_xoauth2(ngx_mail_session_t *s, ngx_connection_t *c,
+    ngx_uint_t n);
+ngx_int_t ngx_mail_auth_oauthbearer(ngx_mail_session_t *s, ngx_connection_t *c,
     ngx_uint_t n);
 ngx_int_t ngx_mail_auth_parse(ngx_mail_session_t *s, ngx_connection_t *c);
 

--- a/src/mail/ngx_mail.h
+++ b/src/mail/ngx_mail.h
@@ -117,6 +117,7 @@ typedef struct {
     ngx_msec_t              resolver_timeout;
 
     ngx_uint_t              max_errors;
+    ngx_uint_t              max_commands;
 
     ngx_str_t               server_name;
 
@@ -235,6 +236,7 @@ typedef struct {
     ngx_array_t             args;
 
     ngx_uint_t              errors;
+    ngx_uint_t              commands;
     ngx_uint_t              login_attempt;
 
     /* used to parse POP3/IMAP/SMTP command */

--- a/src/mail/ngx_mail_auth_http_module.c
+++ b/src/mail/ngx_mail_auth_http_module.c
@@ -883,6 +883,7 @@ ngx_mail_auth_sleep_handler(ngx_event_t *rev)
 
         s->mail_state = 0;
         s->auth_method = NGX_MAIL_AUTH_PLAIN;
+        s->tag.len = 0;
 
         c->log->action = "in auth state";
 

--- a/src/mail/ngx_mail_auth_http_module.c
+++ b/src/mail/ngx_mail_auth_http_module.c
@@ -31,7 +31,7 @@ typedef struct {
 
 typedef struct ngx_mail_auth_http_ctx_s  ngx_mail_auth_http_ctx_t;
 
-typedef void (*ngx_mail_auth_http_handler_pt)(ngx_mail_session_t *s,
+typedef ngx_int_t (*ngx_mail_auth_http_handler_pt)(ngx_mail_session_t *s,
     ngx_mail_auth_http_ctx_t *ctx);
 
 struct ngx_mail_auth_http_ctx_s {
@@ -63,9 +63,9 @@ struct ngx_mail_auth_http_ctx_s {
 
 static void ngx_mail_auth_http_write_handler(ngx_event_t *wev);
 static void ngx_mail_auth_http_read_handler(ngx_event_t *rev);
-static void ngx_mail_auth_http_ignore_status_line(ngx_mail_session_t *s,
+static ngx_int_t ngx_mail_auth_http_ignore_status_line(ngx_mail_session_t *s,
     ngx_mail_auth_http_ctx_t *ctx);
-static void ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
+static ngx_int_t ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
     ngx_mail_auth_http_ctx_t *ctx);
 static void ngx_mail_auth_sleep_handler(ngx_event_t *rev);
 static void ngx_mail_auth_send_error(ngx_mail_session_t *s);
@@ -297,13 +297,20 @@ ngx_mail_auth_http_write_handler(ngx_event_t *wev)
         ahcf = ngx_mail_get_module_srv_conf(s, ngx_mail_auth_http_module);
         ngx_add_timer(wev, ahcf->timeout);
     }
+
+    if (ngx_handle_write_event(wev, 0) != NGX_OK) {
+        ngx_close_connection(c);
+        ngx_destroy_pool(ctx->pool);
+        ngx_mail_session_internal_server_error(s);
+    }
 }
 
 
 static void
 ngx_mail_auth_http_read_handler(ngx_event_t *rev)
 {
-    ssize_t                     n, size;
+    ssize_t                    n, size;
+    ngx_int_t                  rc;
     ngx_connection_t          *c;
     ngx_mail_session_t        *s;
     ngx_mail_auth_http_ctx_t  *ctx;
@@ -335,19 +342,41 @@ ngx_mail_auth_http_read_handler(ngx_event_t *rev)
         }
     }
 
-    size = ctx->response->end - ctx->response->last;
+    for ( ;; ) {
 
-    n = ngx_recv(c, ctx->response->pos, size);
+        size = ctx->response->end - ctx->response->last;
 
-    if (n > 0) {
-        ctx->response->last += n;
+        n = ngx_recv(c, ctx->response->pos, size);
 
-        ctx->handler(s, ctx);
-        return;
+        if (n > 0) {
+            ctx->response->last += n;
+
+            rc = ctx->handler(s, ctx);
+
+            if (rc == NGX_ERROR || rc == NGX_DONE) {
+                return;
+            }
+
+            continue;
+        }
+
+        if (n == NGX_AGAIN) {
+            if (ngx_handle_read_event(rev, 0) != NGX_OK) {
+                ngx_close_connection(c);
+                ngx_destroy_pool(ctx->pool);
+                ngx_mail_session_internal_server_error(s);
+            }
+
+            return;
+        }
+
+        break;
     }
 
-    if (n == NGX_AGAIN) {
-        return;
+    if (n == 0) {
+        ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "auth http server %V prematurely closed connection",
+                      ctx->peer.name);
     }
 
     ngx_close_connection(c);
@@ -356,7 +385,7 @@ ngx_mail_auth_http_read_handler(ngx_event_t *rev)
 }
 
 
-static void
+static ngx_int_t
 ngx_mail_auth_http_ignore_status_line(ngx_mail_session_t *s,
     ngx_mail_auth_http_ctx_t *ctx)
 {
@@ -438,17 +467,19 @@ ngx_mail_auth_http_ignore_status_line(ngx_mail_session_t *s,
             ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
                           "auth http server %V sent invalid response",
                           ctx->peer.name);
+
             ngx_close_connection(ctx->peer.connection);
             ngx_destroy_pool(ctx->pool);
             ngx_mail_session_internal_server_error(s);
-            return;
+
+            return NGX_ERROR;
         }
     }
 
     ctx->response->pos = p;
     ctx->state = state;
 
-    return;
+    return NGX_AGAIN;
 
 next:
 
@@ -459,11 +490,11 @@ done:
     ctx->response->pos = p + 1;
     ctx->state = 0;
     ctx->handler = ngx_mail_auth_http_process_headers;
-    ctx->handler(s, ctx);
+    return ctx->handler(s, ctx);
 }
 
 
-static void
+static ngx_int_t
 ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
     ngx_mail_auth_http_ctx_t *ctx)
 {
@@ -547,7 +578,7 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
                     ngx_close_connection(ctx->peer.connection);
                     ngx_destroy_pool(ctx->pool);
                     ngx_mail_session_internal_server_error(s);
-                    return;
+                    return NGX_ERROR;
                 }
 
                 ctx->err.data = p;
@@ -612,7 +643,7 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
                     ngx_close_connection(ctx->peer.connection);
                     ngx_destroy_pool(ctx->pool);
                     ngx_mail_session_internal_server_error(s);
-                    return;
+                    return NGX_ERROR;
                 }
 
                 ngx_memcpy(s->login.data, ctx->header_start, s->login.len);
@@ -634,7 +665,7 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
                     ngx_close_connection(ctx->peer.connection);
                     ngx_destroy_pool(ctx->pool);
                     ngx_mail_session_internal_server_error(s);
-                    return;
+                    return NGX_ERROR;
                 }
 
                 ngx_memcpy(s->passwd.data, ctx->header_start, s->passwd.len);
@@ -672,7 +703,7 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
                     ngx_close_connection(ctx->peer.connection);
                     ngx_destroy_pool(ctx->pool);
                     ngx_mail_session_internal_server_error(s);
-                    return;
+                    return NGX_ERROR;
                 }
 
                 ngx_memcpy(ctx->errcode.data, ctx->header_start,
@@ -707,7 +738,7 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
                     ngx_close_connection(ctx->peer.connection);
                     ngx_destroy_pool(ctx->pool);
                     ngx_mail_session_internal_server_error(s);
-                    return;
+                    return NGX_ERROR;
                 }
 
                 ctx->errsasl.len = size;
@@ -755,7 +786,7 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
                     if (p == NULL) {
                         ngx_destroy_pool(ctx->pool);
                         ngx_mail_session_internal_server_error(s);
-                        return;
+                        return NGX_ERROR;
                     }
 
                     ctx->err.data = p;
@@ -775,14 +806,14 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
                 if (timer == 0) {
                     s->auth_quit = 1;
                     ngx_mail_auth_send_error(s);
-                    return;
+                    return NGX_DONE;
                 }
 
                 ngx_add_timer(s->connection->read, (ngx_msec_t) (timer * 1000));
 
                 s->connection->read->handler = ngx_mail_auth_sleep_handler;
 
-                return;
+                return NGX_DONE;
             }
 
             if (s->auth_wait) {
@@ -792,14 +823,14 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
 
                 if (timer == 0) {
                     ngx_mail_auth_http_init(s);
-                    return;
+                    return NGX_DONE;
                 }
 
                 ngx_add_timer(s->connection->read, (ngx_msec_t) (timer * 1000));
 
                 s->connection->read->handler = ngx_mail_auth_sleep_handler;
 
-                return;
+                return NGX_DONE;
             }
 
             if (ctx->addr.len == 0 || ctx->port.len == 0) {
@@ -808,7 +839,7 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
                               ctx->peer.name);
                 ngx_destroy_pool(ctx->pool);
                 ngx_mail_session_internal_server_error(s);
-                return;
+                return NGX_ERROR;
             }
 
             if (s->passwd.data == NULL
@@ -819,14 +850,14 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
                               ctx->peer.name);
                 ngx_destroy_pool(ctx->pool);
                 ngx_mail_session_internal_server_error(s);
-                return;
+                return NGX_ERROR;
             }
 
             peer = ngx_pcalloc(s->connection->pool, sizeof(ngx_addr_t));
             if (peer == NULL) {
                 ngx_destroy_pool(ctx->pool);
                 ngx_mail_session_internal_server_error(s);
-                return;
+                return NGX_ERROR;
             }
 
             rc = ngx_parse_addr(s->connection->pool, peer,
@@ -846,7 +877,7 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
             default:
                 ngx_destroy_pool(ctx->pool);
                 ngx_mail_session_internal_server_error(s);
-                return;
+                return NGX_ERROR;
             }
 
             port = ngx_atoi(ctx->port.data, ctx->port.len);
@@ -857,7 +888,7 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
                               ctx->peer.name, &ctx->port);
                 ngx_destroy_pool(ctx->pool);
                 ngx_mail_session_internal_server_error(s);
-                return;
+                return NGX_ERROR;
             }
 
             ngx_inet_set_port(peer->sockaddr, (in_port_t) port);
@@ -870,7 +901,7 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
             if (peer->name.data == NULL) {
                 ngx_destroy_pool(ctx->pool);
                 ngx_mail_session_internal_server_error(s);
-                return;
+                return NGX_ERROR;
             }
 
             len = ctx->addr.len;
@@ -884,11 +915,11 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
             ngx_destroy_pool(ctx->pool);
             ngx_mail_proxy_init(s, peer);
 
-            return;
+            return NGX_DONE;
         }
 
         if (rc == NGX_AGAIN ) {
-            return;
+            return NGX_AGAIN;
         }
 
         /* rc == NGX_ERROR */
@@ -896,12 +927,15 @@ ngx_mail_auth_http_process_headers(ngx_mail_session_t *s,
         ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
                       "auth http server %V sent invalid header in response",
                       ctx->peer.name);
+
         ngx_close_connection(ctx->peer.connection);
         ngx_destroy_pool(ctx->pool);
         ngx_mail_session_internal_server_error(s);
 
-        return;
+        return NGX_ERROR;
     }
+
+    /* not reached */
 }
 
 

--- a/src/mail/ngx_mail_auth_http_module.c
+++ b/src/mail/ngx_mail_auth_http_module.c
@@ -1245,7 +1245,7 @@ ngx_mail_auth_http_create_request(ngx_mail_session_t *s, ngx_pool_t *pool,
 {
     size_t                     len;
     ngx_buf_t                 *b;
-    ngx_str_t                  login, passwd;
+    ngx_str_t                  login, passwd, host;
     ngx_connection_t          *c;
 #if (NGX_MAIL_SSL)
     ngx_str_t                  protocol, cipher, verify, subject, issuer,
@@ -1259,6 +1259,10 @@ ngx_mail_auth_http_create_request(ngx_mail_session_t *s, ngx_pool_t *pool,
     }
 
     if (ngx_mail_auth_http_escape(pool, &s->passwd, &passwd) != NGX_OK) {
+        return NULL;
+    }
+
+    if (ngx_mail_auth_http_escape(pool, &s->host, &host) != NGX_OK) {
         return NULL;
     }
 
@@ -1354,7 +1358,7 @@ ngx_mail_auth_http_create_request(ngx_mail_session_t *s, ngx_pool_t *pool,
                 + sizeof(CRLF) - 1
           + sizeof("Client-IP: ") - 1 + s->connection->addr_text.len
                 + sizeof(CRLF) - 1
-          + sizeof("Client-Host: ") - 1 + s->host.len + sizeof(CRLF) - 1
+          + sizeof("Client-Host: ") - 1 + host.len + sizeof(CRLF) - 1
           + ahcf->header.len
           + sizeof(CRLF) - 1;
 
@@ -1456,10 +1460,10 @@ ngx_mail_auth_http_create_request(ngx_mail_session_t *s, ngx_pool_t *pool,
                        s->connection->addr_text.len);
     *b->last++ = CR; *b->last++ = LF;
 
-    if (s->host.len) {
+    if (host.len) {
         b->last = ngx_cpymem(b->last, "Client-Host: ",
                              sizeof("Client-Host: ") - 1);
-        b->last = ngx_copy(b->last, s->host.data, s->host.len);
+        b->last = ngx_copy(b->last, host.data, host.len);
         *b->last++ = CR; *b->last++ = LF;
     }
 

--- a/src/mail/ngx_mail_auth_http_module.c
+++ b/src/mail/ngx_mail_auth_http_module.c
@@ -964,6 +964,8 @@ ngx_mail_auth_send_error(ngx_mail_session_t *s)
         s->state = 0;
         s->mail_state = 0;
         s->tag.len = 0;
+        s->login.len = 0;
+        s->passwd.len = 0;
 
     } else {
         s->auth_err.len -= s->tag.len;

--- a/src/mail/ngx_mail_core_module.c
+++ b/src/mail/ngx_mail_core_module.c
@@ -92,6 +92,13 @@ static ngx_command_t  ngx_mail_core_commands[] = {
       offsetof(ngx_mail_core_srv_conf_t, max_errors),
       NULL },
 
+    { ngx_string("max_commands"),
+      NGX_MAIL_MAIN_CONF|NGX_MAIL_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_MAIL_SRV_CONF_OFFSET,
+      offsetof(ngx_mail_core_srv_conf_t, max_commands),
+      NULL },
+
       ngx_null_command
 };
 
@@ -171,6 +178,7 @@ ngx_mail_core_create_srv_conf(ngx_conf_t *cf)
     cscf->resolver_timeout = NGX_CONF_UNSET_MSEC;
 
     cscf->max_errors = NGX_CONF_UNSET_UINT;
+    cscf->max_commands = NGX_CONF_UNSET_UINT;
 
     cscf->resolver = NGX_CONF_UNSET_PTR;
 
@@ -192,6 +200,7 @@ ngx_mail_core_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
                               30000);
 
     ngx_conf_merge_uint_value(conf->max_errors, prev->max_errors, 5);
+    ngx_conf_merge_uint_value(conf->max_commands, prev->max_commands, 1000);
 
     ngx_conf_merge_str_value(conf->server_name, prev->server_name, "");
 

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -750,6 +750,8 @@ ngx_mail_auth_external(ngx_mail_session_t *s, ngx_connection_t *c,
     s->login.len = external.len;
     s->login.data = external.data;
 
+    ngx_str_null(&s->passwd);
+
     ngx_log_debug1(NGX_LOG_DEBUG_MAIL, c->log, 0,
                    "mail auth external: \"%V\"", &s->login);
 

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -805,7 +805,7 @@ ngx_mail_send(ngx_event_t *wev)
         }
 
         if (s->blocked) {
-            c->read->handler(c->read);
+            ngx_post_event(c->read, &ngx_posted_events);
         }
 
         return;

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -1048,7 +1048,7 @@ ngx_mail_send(ngx_event_t *wev)
     }
 
     if (s->out.len == 0) {
-        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
+        if (ngx_handle_write_event(wev, 0) != NGX_OK) {
             ngx_mail_close_connection(c);
         }
 
@@ -1092,9 +1092,9 @@ again:
 
     cscf = ngx_mail_get_module_srv_conf(s, ngx_mail_core_module);
 
-    ngx_add_timer(c->write, cscf->timeout);
+    ngx_add_timer(wev, cscf->timeout);
 
-    if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
+    if (ngx_handle_write_event(wev, 0) != NGX_OK) {
         ngx_mail_close_connection(c);
         return;
     }

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -1302,11 +1302,9 @@ ngx_mail_log_error(ngx_log_t *log, u_char *buf, size_t len)
         buf = p;
     }
 
-    if (s->proxy == NULL) {
-        return p;
+    if (s->proxy) {
+        p = ngx_snprintf(buf, len, ", upstream: %V", s->proxy->upstream.name);
     }
-
-    p = ngx_snprintf(buf, len, ", upstream: %V", s->proxy->upstream.name);
 
     return p;
 }

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -22,6 +22,8 @@ static ngx_int_t ngx_mail_verify_cert(ngx_mail_session_t *s,
     ngx_connection_t *c);
 #endif
 
+static void ngx_mail_block_read(ngx_event_t *rev);
+
 
 void
 ngx_mail_init_connection(ngx_connection_t *c)
@@ -415,8 +417,6 @@ ngx_mail_verify_cert(ngx_mail_session_t *s, ngx_connection_t *c)
         s->out = cscf->protocol->cert_error;
         s->quit = 1;
 
-        c->write->handler = ngx_mail_send;
-
         ngx_mail_send(s->connection->write);
         return NGX_ERROR;
     }
@@ -435,8 +435,6 @@ ngx_mail_verify_cert(ngx_mail_session_t *s, ngx_connection_t *c)
 
             s->out = cscf->protocol->no_cert;
             s->quit = 1;
-
-            c->write->handler = ngx_mail_send;
 
             ngx_mail_send(s->connection->write);
             return NGX_ERROR;
@@ -1098,6 +1096,11 @@ again:
 
     ngx_add_timer(wev, cscf->timeout);
 
+    if (s->quit) {
+        c->read->handler = ngx_mail_block_read;
+        c->write->handler = ngx_mail_send;
+    }
+
     if (ngx_handle_write_event(wev, 0) != NGX_OK) {
         ngx_mail_close_connection(c);
         return;
@@ -1229,6 +1232,17 @@ ngx_mail_session_internal_server_error(ngx_mail_session_t *s)
     s->quit = 1;
 
     ngx_mail_send(s->connection->write);
+}
+
+
+static void
+ngx_mail_block_read(ngx_event_t *rev)
+{
+    ngx_log_debug0(NGX_LOG_DEBUG_MAIL, rev->log, 0, "mail block read");
+
+    if (ngx_handle_read_event(rev, 0) != NGX_OK) {
+        ngx_mail_close_connection(rev->data);
+    }
 }
 
 

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -778,6 +778,8 @@ ngx_mail_auth_xoauth2(ngx_mail_session_t *s, ngx_connection_t *c, ngx_uint_t n)
             s->quit = s->auth_quit;
             s->state = 0;
             s->mail_state = 0;
+            s->login.len = 0;
+            s->passwd.len = 0;
             ngx_str_null(&s->auth_err);
             return NGX_OK;
         }
@@ -887,6 +889,8 @@ ngx_mail_auth_oauthbearer(ngx_mail_session_t *s, ngx_connection_t *c,
             s->quit = s->auth_quit;
             s->state = 0;
             s->mail_state = 0;
+            s->login.len = 0;
+            s->passwd.len = 0;
             ngx_str_null(&s->auth_err);
             return NGX_OK;
         }

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -902,6 +902,18 @@ ngx_mail_read_command(ngx_mail_session_t *s, ngx_connection_t *c)
         return NGX_ERROR;
     }
 
+    s->commands++;
+
+    if (s->commands > cscf->max_commands) {
+
+        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                      "client sent too many commands");
+
+        s->quit = 1;
+
+        return NGX_MAIL_PARSE_INVALID_COMMAND;
+    }
+
     return NGX_OK;
 }
 

--- a/src/mail/ngx_mail_imap_handler.c
+++ b/src/mail/ngx_mail_imap_handler.c
@@ -251,9 +251,11 @@ ngx_mail_imap_auth_state(ngx_event_t *rev)
         return;
 
     case NGX_MAIL_PARSE_INVALID_COMMAND:
-        s->state = 0;
-        ngx_str_set(&s->out, imap_invalid_command);
         s->mail_state = ngx_imap_start;
+        s->state = 0;
+        s->login.len = 0;
+        s->passwd.len = 0;
+        ngx_str_set(&s->out, imap_invalid_command);
         break;
     }
 

--- a/src/mail/ngx_mail_imap_handler.c
+++ b/src/mail/ngx_mail_imap_handler.c
@@ -103,6 +103,7 @@ void
 ngx_mail_imap_auth_state(ngx_event_t *rev)
 {
     u_char              *p;
+    size_t               n;
     ngx_int_t            rc;
     ngx_uint_t           tag;
     ngx_connection_t    *c;
@@ -286,6 +287,12 @@ ngx_mail_imap_auth_state(ngx_event_t *rev)
             if (s->buffer->pos == s->buffer->last) {
                 s->buffer->pos = s->buffer->start;
                 s->buffer->last = s->buffer->start;
+
+            } else {
+                n = s->buffer->last - s->buffer->pos;
+                ngx_memmove(s->buffer->start, s->buffer->pos, n);
+                s->buffer->pos = s->buffer->start;
+                s->buffer->last = s->buffer->start + n;
             }
 
             s->tag.len = 0;

--- a/src/mail/ngx_mail_imap_handler.c
+++ b/src/mail/ngx_mail_imap_handler.c
@@ -221,6 +221,14 @@ ngx_mail_imap_auth_state(ngx_event_t *rev)
         case ngx_imap_auth_external:
             rc = ngx_mail_auth_external(s, c, 0);
             break;
+
+        case ngx_imap_auth_xoauth2:
+            rc = ngx_mail_auth_xoauth2(s, c, 0);
+            break;
+
+        case ngx_imap_auth_oauthbearer:
+            rc = ngx_mail_auth_oauthbearer(s, c, 0);
+            break;
         }
 
     } else if (rc == NGX_IMAP_NEXT) {
@@ -431,6 +439,38 @@ ngx_mail_imap_authenticate(ngx_mail_session_t *s, ngx_connection_t *c)
 
         ngx_str_set(&s->out, imap_username);
         s->mail_state = ngx_imap_auth_external;
+
+        return NGX_OK;
+
+    case NGX_MAIL_AUTH_XOAUTH2:
+
+        if (!(iscf->auth_methods & NGX_MAIL_AUTH_XOAUTH2_ENABLED)) {
+            return NGX_MAIL_PARSE_INVALID_COMMAND;
+        }
+
+        if (s->args.nelts == 2) {
+            s->mail_state = ngx_imap_auth_xoauth2;
+            return ngx_mail_auth_xoauth2(s, c, 1);
+        }
+
+        ngx_str_set(&s->out, imap_plain_next);
+        s->mail_state = ngx_imap_auth_xoauth2;
+
+        return NGX_OK;
+
+    case NGX_MAIL_AUTH_OAUTHBEARER:
+
+        if (!(iscf->auth_methods & NGX_MAIL_AUTH_OAUTHBEARER_ENABLED)) {
+            return NGX_MAIL_PARSE_INVALID_COMMAND;
+        }
+
+        if (s->args.nelts == 2) {
+            s->mail_state = ngx_imap_auth_oauthbearer;
+            return ngx_mail_auth_oauthbearer(s, c, 1);
+        }
+
+        ngx_str_set(&s->out, imap_plain_next);
+        s->mail_state = ngx_imap_auth_oauthbearer;
 
         return NGX_OK;
     }

--- a/src/mail/ngx_mail_imap_handler.c
+++ b/src/mail/ngx_mail_imap_handler.c
@@ -389,6 +389,10 @@ ngx_mail_imap_authenticate(ngx_mail_session_t *s, ngx_connection_t *c)
 
     case NGX_MAIL_AUTH_PLAIN:
 
+        if (s->args.nelts == 2) {
+            return ngx_mail_auth_plain(s, c, 1);
+        }
+
         ngx_str_set(&s->out, imap_plain_next);
         s->mail_state = ngx_imap_auth_plain;
 
@@ -419,6 +423,10 @@ ngx_mail_imap_authenticate(ngx_mail_session_t *s, ngx_connection_t *c)
 
         if (!(iscf->auth_methods & NGX_MAIL_AUTH_EXTERNAL_ENABLED)) {
             return NGX_MAIL_PARSE_INVALID_COMMAND;
+        }
+
+        if (s->args.nelts == 2) {
+            return ngx_mail_auth_external(s, c, 1);
         }
 
         ngx_str_set(&s->out, imap_username);

--- a/src/mail/ngx_mail_imap_handler.c
+++ b/src/mail/ngx_mail_imap_handler.c
@@ -227,7 +227,7 @@ ngx_mail_imap_auth_state(ngx_event_t *rev)
         ngx_str_set(&s->out, imap_next);
     }
 
-    if (s->buffer->pos < s->buffer->last) {
+    if (s->buffer->pos < s->buffer->last || c->read->ready) {
         s->blocked = 1;
     }
 

--- a/src/mail/ngx_mail_imap_module.c
+++ b/src/mail/ngx_mail_imap_module.c
@@ -30,6 +30,8 @@ static ngx_conf_bitmask_t  ngx_mail_imap_auth_methods[] = {
     { ngx_string("login"), NGX_MAIL_AUTH_LOGIN_ENABLED },
     { ngx_string("cram-md5"), NGX_MAIL_AUTH_CRAM_MD5_ENABLED },
     { ngx_string("external"), NGX_MAIL_AUTH_EXTERNAL_ENABLED },
+    { ngx_string("xoauth2"), NGX_MAIL_AUTH_XOAUTH2_ENABLED },
+    { ngx_string("oauthbearer"), NGX_MAIL_AUTH_OAUTHBEARER_ENABLED },
     { ngx_null_string, 0 }
 };
 
@@ -40,6 +42,8 @@ static ngx_str_t  ngx_mail_imap_auth_methods_names[] = {
     ngx_null_string,  /* APOP */
     ngx_string("AUTH=CRAM-MD5"),
     ngx_string("AUTH=EXTERNAL"),
+    ngx_string("AUTH=XOAUTH2"),
+    ngx_string("AUTH=OAUTHBEARER"),
     ngx_null_string   /* NONE */
 };
 
@@ -182,7 +186,7 @@ ngx_mail_imap_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     }
 
     for (m = NGX_MAIL_AUTH_PLAIN_ENABLED, i = 0;
-         m <= NGX_MAIL_AUTH_EXTERNAL_ENABLED;
+         m < NGX_MAIL_AUTH_NONE_ENABLED;
          m <<= 1, i++)
     {
         if (m & conf->auth_methods) {
@@ -208,7 +212,7 @@ ngx_mail_imap_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     auth = p;
 
     for (m = NGX_MAIL_AUTH_PLAIN_ENABLED, i = 0;
-         m <= NGX_MAIL_AUTH_EXTERNAL_ENABLED;
+         m < NGX_MAIL_AUTH_NONE_ENABLED;
          m <<= 1, i++)
     {
         if (m & conf->auth_methods) {

--- a/src/mail/ngx_mail_parse.c
+++ b/src/mail/ngx_mail_parse.c
@@ -30,6 +30,9 @@ ngx_mail_pop3_parse_command(ngx_mail_session_t *s)
 
     state = s->state;
 
+    ngx_log_debug1(NGX_LOG_DEBUG_MAIL, s->connection->log, 0,
+                   "pop3 parse: %d", state);
+
     for (p = s->buffer->pos; p < s->buffer->last; p++) {
         ch = *p;
 
@@ -247,6 +250,9 @@ ngx_mail_imap_parse_command(ngx_mail_session_t *s)
     } state;
 
     state = s->state;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_MAIL, s->connection->log, 0,
+                   "imap parse: %d", state);
 
     for (p = s->buffer->pos; p < s->buffer->last; p++) {
         ch = *p;
@@ -690,6 +696,9 @@ ngx_mail_smtp_parse_command(ngx_mail_session_t *s)
     } state;
 
     state = s->state;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_MAIL, s->connection->log, 0,
+                   "smtp parse: %d", state);
 
     for (p = s->buffer->pos; p < s->buffer->last; p++) {
         ch = *p;

--- a/src/mail/ngx_mail_parse.c
+++ b/src/mail/ngx_mail_parse.c
@@ -952,6 +952,20 @@ ngx_mail_auth_parse(ngx_mail_session_t *s, ngx_connection_t *c)
         return NGX_MAIL_PARSE_INVALID_COMMAND;
     }
 
+    if (arg[0].len == 7) {
+
+        if (ngx_strncasecmp(arg[0].data, (u_char *) "XOAUTH2", 7) == 0) {
+
+            if (s->args.nelts == 1 || s->args.nelts == 2) {
+                return NGX_MAIL_AUTH_XOAUTH2;
+            }
+
+            return NGX_MAIL_PARSE_INVALID_COMMAND;
+        }
+
+        return NGX_MAIL_PARSE_INVALID_COMMAND;
+    }
+
     if (arg[0].len == 8) {
 
         if (ngx_strncasecmp(arg[0].data, (u_char *) "CRAM-MD5", 8) == 0) {
@@ -967,6 +981,20 @@ ngx_mail_auth_parse(ngx_mail_session_t *s, ngx_connection_t *c)
 
             if (s->args.nelts == 1 || s->args.nelts == 2) {
                 return NGX_MAIL_AUTH_EXTERNAL;
+            }
+
+            return NGX_MAIL_PARSE_INVALID_COMMAND;
+        }
+
+        return NGX_MAIL_PARSE_INVALID_COMMAND;
+    }
+
+    if (arg[0].len == 11) {
+
+        if (ngx_strncasecmp(arg[0].data, (u_char *) "OAUTHBEARER", 11) == 0) {
+
+            if (s->args.nelts == 1 || s->args.nelts == 2) {
+                return NGX_MAIL_AUTH_OAUTHBEARER;
             }
 
             return NGX_MAIL_PARSE_INVALID_COMMAND;

--- a/src/mail/ngx_mail_parse.c
+++ b/src/mail/ngx_mail_parse.c
@@ -933,13 +933,11 @@ ngx_mail_auth_parse(ngx_mail_session_t *s, ngx_connection_t *c)
 
         if (ngx_strncasecmp(arg[0].data, (u_char *) "PLAIN", 5) == 0) {
 
-            if (s->args.nelts == 1) {
+            if (s->args.nelts == 1 || s->args.nelts == 2) {
                 return NGX_MAIL_AUTH_PLAIN;
             }
 
-            if (s->args.nelts == 2) {
-                return ngx_mail_auth_plain(s, c, 1);
-            }
+            return NGX_MAIL_PARSE_INVALID_COMMAND;
         }
 
         return NGX_MAIL_PARSE_INVALID_COMMAND;
@@ -958,13 +956,11 @@ ngx_mail_auth_parse(ngx_mail_session_t *s, ngx_connection_t *c)
 
         if (ngx_strncasecmp(arg[0].data, (u_char *) "EXTERNAL", 8) == 0) {
 
-            if (s->args.nelts == 1) {
+            if (s->args.nelts == 1 || s->args.nelts == 2) {
                 return NGX_MAIL_AUTH_EXTERNAL;
             }
 
-            if (s->args.nelts == 2) {
-                return ngx_mail_auth_external(s, c, 1);
-            }
+            return NGX_MAIL_PARSE_INVALID_COMMAND;
         }
 
         return NGX_MAIL_PARSE_INVALID_COMMAND;

--- a/src/mail/ngx_mail_pop3_handler.c
+++ b/src/mail/ngx_mail_pop3_handler.c
@@ -289,6 +289,8 @@ ngx_mail_pop3_auth_state(ngx_event_t *rev)
     case NGX_MAIL_PARSE_INVALID_COMMAND:
         s->mail_state = ngx_pop3_start;
         s->state = 0;
+        s->login.len = 0;
+        s->passwd.len = 0;
 
         ngx_str_set(&s->out, pop3_invalid_command);
 

--- a/src/mail/ngx_mail_pop3_handler.c
+++ b/src/mail/ngx_mail_pop3_handler.c
@@ -261,6 +261,14 @@ ngx_mail_pop3_auth_state(ngx_event_t *rev)
         case ngx_pop3_auth_external:
             rc = ngx_mail_auth_external(s, c, 0);
             break;
+
+        case ngx_pop3_auth_xoauth2:
+            rc = ngx_mail_auth_xoauth2(s, c, 0);
+            break;
+
+        case ngx_pop3_auth_oauthbearer:
+            rc = ngx_mail_auth_oauthbearer(s, c, 0);
+            break;
         }
     }
 
@@ -552,6 +560,38 @@ ngx_mail_pop3_auth(ngx_mail_session_t *s, ngx_connection_t *c)
 
         ngx_str_set(&s->out, pop3_username);
         s->mail_state = ngx_pop3_auth_external;
+
+        return NGX_OK;
+
+    case NGX_MAIL_AUTH_XOAUTH2:
+
+        if (!(pscf->auth_methods & NGX_MAIL_AUTH_XOAUTH2_ENABLED)) {
+            return NGX_MAIL_PARSE_INVALID_COMMAND;
+        }
+
+        if (s->args.nelts == 2) {
+            s->mail_state = ngx_pop3_auth_xoauth2;
+            return ngx_mail_auth_xoauth2(s, c, 1);
+        }
+
+        ngx_str_set(&s->out, pop3_next);
+        s->mail_state = ngx_pop3_auth_xoauth2;
+
+        return NGX_OK;
+
+    case NGX_MAIL_AUTH_OAUTHBEARER:
+
+        if (!(pscf->auth_methods & NGX_MAIL_AUTH_OAUTHBEARER_ENABLED)) {
+            return NGX_MAIL_PARSE_INVALID_COMMAND;
+        }
+
+        if (s->args.nelts == 2) {
+            s->mail_state = ngx_pop3_auth_oauthbearer;
+            return ngx_mail_auth_oauthbearer(s, c, 1);
+        }
+
+        ngx_str_set(&s->out, pop3_next);
+        s->mail_state = ngx_pop3_auth_oauthbearer;
 
         return NGX_OK;
     }

--- a/src/mail/ngx_mail_pop3_handler.c
+++ b/src/mail/ngx_mail_pop3_handler.c
@@ -120,6 +120,7 @@ ngx_mail_pop3_init_protocol(ngx_event_t *rev)
 void
 ngx_mail_pop3_auth_state(ngx_event_t *rev)
 {
+    size_t               n;
     ngx_int_t            rc;
     ngx_connection_t    *c;
     ngx_mail_session_t  *s;
@@ -292,6 +293,12 @@ ngx_mail_pop3_auth_state(ngx_event_t *rev)
         if (s->buffer->pos == s->buffer->last) {
             s->buffer->pos = s->buffer->start;
             s->buffer->last = s->buffer->start;
+
+        } else {
+            n = s->buffer->last - s->buffer->pos;
+            ngx_memmove(s->buffer->start, s->buffer->pos, n);
+            s->buffer->pos = s->buffer->start;
+            s->buffer->last = s->buffer->start + n;
         }
 
         if (s->state) {

--- a/src/mail/ngx_mail_pop3_handler.c
+++ b/src/mail/ngx_mail_pop3_handler.c
@@ -79,8 +79,9 @@ ngx_mail_pop3_init_session(ngx_mail_session_t *s, ngx_connection_t *c)
 void
 ngx_mail_pop3_init_protocol(ngx_event_t *rev)
 {
-    ngx_connection_t    *c;
-    ngx_mail_session_t  *s;
+    ngx_connection_t          *c;
+    ngx_mail_session_t        *s;
+    ngx_mail_pop3_srv_conf_t  *pscf;
 
     c = rev->data;
 
@@ -103,7 +104,9 @@ ngx_mail_pop3_init_protocol(ngx_event_t *rev)
             return;
         }
 
-        s->buffer = ngx_create_temp_buf(c->pool, 128);
+        pscf = ngx_mail_get_module_srv_conf(s, ngx_mail_pop3_module);
+
+        s->buffer = ngx_create_temp_buf(c->pool, pscf->client_buffer_size);
         if (s->buffer == NULL) {
             ngx_mail_session_internal_server_error(s);
             return;

--- a/src/mail/ngx_mail_pop3_handler.c
+++ b/src/mail/ngx_mail_pop3_handler.c
@@ -518,6 +518,10 @@ ngx_mail_pop3_auth(ngx_mail_session_t *s, ngx_connection_t *c)
 
     case NGX_MAIL_AUTH_PLAIN:
 
+        if (s->args.nelts == 2) {
+            return ngx_mail_auth_plain(s, c, 1);
+        }
+
         ngx_str_set(&s->out, pop3_next);
         s->mail_state = ngx_pop3_auth_plain;
 
@@ -540,6 +544,10 @@ ngx_mail_pop3_auth(ngx_mail_session_t *s, ngx_connection_t *c)
 
         if (!(pscf->auth_methods & NGX_MAIL_AUTH_EXTERNAL_ENABLED)) {
             return NGX_MAIL_PARSE_INVALID_COMMAND;
+        }
+
+        if (s->args.nelts == 2) {
+            return ngx_mail_auth_external(s, c, 1);
         }
 
         ngx_str_set(&s->out, pop3_username);

--- a/src/mail/ngx_mail_pop3_handler.c
+++ b/src/mail/ngx_mail_pop3_handler.c
@@ -263,7 +263,7 @@ ngx_mail_pop3_auth_state(ngx_event_t *rev)
         }
     }
 
-    if (s->buffer->pos < s->buffer->last) {
+    if (s->buffer->pos < s->buffer->last || c->read->ready) {
         s->blocked = 1;
     }
 

--- a/src/mail/ngx_mail_pop3_module.c
+++ b/src/mail/ngx_mail_pop3_module.c
@@ -30,6 +30,8 @@ static ngx_conf_bitmask_t  ngx_mail_pop3_auth_methods[] = {
     { ngx_string("apop"), NGX_MAIL_AUTH_APOP_ENABLED },
     { ngx_string("cram-md5"), NGX_MAIL_AUTH_CRAM_MD5_ENABLED },
     { ngx_string("external"), NGX_MAIL_AUTH_EXTERNAL_ENABLED },
+    { ngx_string("xoauth2"), NGX_MAIL_AUTH_XOAUTH2_ENABLED },
+    { ngx_string("oauthbearer"), NGX_MAIL_AUTH_OAUTHBEARER_ENABLED },
     { ngx_null_string, 0 }
 };
 
@@ -40,6 +42,8 @@ static ngx_str_t  ngx_mail_pop3_auth_methods_names[] = {
     ngx_null_string,  /* APOP */
     ngx_string("CRAM-MD5"),
     ngx_string("EXTERNAL"),
+    ngx_string("XOAUTH2"),
+    ngx_string("OAUTHBEARER"),
     ngx_null_string   /* NONE */
 };
 
@@ -183,7 +187,7 @@ ngx_mail_pop3_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     size += sizeof("SASL") - 1 + sizeof(CRLF) - 1;
 
     for (m = NGX_MAIL_AUTH_PLAIN_ENABLED, i = 0;
-         m <= NGX_MAIL_AUTH_EXTERNAL_ENABLED;
+         m < NGX_MAIL_AUTH_NONE_ENABLED;
          m <<= 1, i++)
     {
         if (ngx_mail_pop3_auth_methods_names[i].len == 0) {
@@ -214,7 +218,7 @@ ngx_mail_pop3_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     p = ngx_cpymem(p, "SASL", sizeof("SASL") - 1);
 
     for (m = NGX_MAIL_AUTH_PLAIN_ENABLED, i = 0;
-         m <= NGX_MAIL_AUTH_EXTERNAL_ENABLED;
+         m < NGX_MAIL_AUTH_NONE_ENABLED;
          m <<= 1, i++)
     {
         if (ngx_mail_pop3_auth_methods_names[i].len == 0) {
@@ -254,7 +258,7 @@ ngx_mail_pop3_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
            + sizeof("." CRLF) - 1;
 
     for (m = NGX_MAIL_AUTH_PLAIN_ENABLED, i = 0;
-         m <= NGX_MAIL_AUTH_EXTERNAL_ENABLED;
+         m < NGX_MAIL_AUTH_NONE_ENABLED;
          m <<= 1, i++)
     {
         if (ngx_mail_pop3_auth_methods_names[i].len == 0) {
@@ -279,7 +283,7 @@ ngx_mail_pop3_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
                    sizeof("+OK methods supported:" CRLF) - 1);
 
     for (m = NGX_MAIL_AUTH_PLAIN_ENABLED, i = 0;
-         m <= NGX_MAIL_AUTH_EXTERNAL_ENABLED;
+         m < NGX_MAIL_AUTH_NONE_ENABLED;
          m <<= 1, i++)
     {
         if (ngx_mail_pop3_auth_methods_names[i].len == 0) {

--- a/src/mail/ngx_mail_pop3_module.c
+++ b/src/mail/ngx_mail_pop3_module.c
@@ -67,6 +67,13 @@ static ngx_mail_protocol_t  ngx_mail_pop3_protocol = {
 
 static ngx_command_t  ngx_mail_pop3_commands[] = {
 
+    { ngx_string("pop3_client_buffer"),
+      NGX_MAIL_MAIN_CONF|NGX_MAIL_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_MAIL_SRV_CONF_OFFSET,
+      offsetof(ngx_mail_pop3_srv_conf_t, client_buffer_size),
+      NULL },
+
     { ngx_string("pop3_capabilities"),
       NGX_MAIL_MAIN_CONF|NGX_MAIL_SRV_CONF|NGX_CONF_1MORE,
       ngx_mail_capabilities,
@@ -128,6 +135,8 @@ ngx_mail_pop3_create_srv_conf(ngx_conf_t *cf)
         return NULL;
     }
 
+    pscf->client_buffer_size = NGX_CONF_UNSET_SIZE;
+
     return pscf;
 }
 
@@ -142,6 +151,10 @@ ngx_mail_pop3_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     size_t       size, stls_only_size;
     ngx_str_t   *c, *d;
     ngx_uint_t   i, m;
+
+    ngx_conf_merge_size_value(conf->client_buffer_size,
+                              prev->client_buffer_size,
+                              (size_t) ngx_pagesize);
 
     ngx_conf_merge_bitmask_value(conf->auth_methods,
                                  prev->auth_methods,

--- a/src/mail/ngx_mail_pop3_module.h
+++ b/src/mail/ngx_mail_pop3_module.h
@@ -15,6 +15,8 @@
 
 
 typedef struct {
+    size_t       client_buffer_size;
+
     ngx_str_t    capability;
     ngx_str_t    starttls_capability;
     ngx_str_t    starttls_only_capability;

--- a/src/mail/ngx_mail_proxy_module.c
+++ b/src/mail/ngx_mail_proxy_module.c
@@ -552,7 +552,6 @@ ngx_mail_proxy_smtp_handler(ngx_event_t *rev)
     ngx_int_t                  rc;
     ngx_str_t                  line, auth, encoded;
     ngx_buf_t                 *b;
-    uintptr_t                  n;
     ngx_connection_t          *c;
     ngx_mail_session_t        *s;
     ngx_mail_proxy_conf_t     *pcf;
@@ -647,11 +646,11 @@ ngx_mail_proxy_smtp_handler(ngx_event_t *rev)
 
         line.len = sizeof("XCLIENT ADDR= LOGIN= NAME="
                           CRLF) - 1
-                   + s->connection->addr_text.len + s->login.len + s->host.len;
-
-        n = ngx_escape_uri(NULL, s->login.data, s->login.len,
-                           NGX_ESCAPE_MAIL_XTEXT);
-        line.len += n * 2;
+                   + s->connection->addr_text.len
+                   + s->login.len
+                   + 2 * ngx_escape_xtext(NULL, s->login.data, s->login.len)
+                   + s->host.len
+                   + 2 * ngx_escape_xtext(NULL, s->host.data, s->host.len);
 
 #if (NGX_HAVE_INET6)
         if (s->connection->sockaddr->sa_family == AF_INET6) {
@@ -680,18 +679,11 @@ ngx_mail_proxy_smtp_handler(ngx_event_t *rev)
 
         if (s->login.len && !pcf->smtp_auth) {
             p = ngx_cpymem(p, " LOGIN=", sizeof(" LOGIN=") - 1);
-
-            if (n == 0) {
-                p = ngx_copy(p, s->login.data, s->login.len);
-
-            } else {
-                p = (u_char *) ngx_escape_uri(p, s->login.data, s->login.len,
-                                              NGX_ESCAPE_MAIL_XTEXT);
-            }
+            p = (u_char *) ngx_escape_xtext(p, s->login.data, s->login.len);
         }
 
         p = ngx_cpymem(p, " NAME=", sizeof(" NAME=") - 1);
-        p = ngx_copy(p, s->host.data, s->host.len);
+        p = (u_char *) ngx_escape_xtext(p, s->host.data, s->host.len);
 
         *p++ = CR; *p++ = LF;
 

--- a/src/mail/ngx_mail_proxy_module.c
+++ b/src/mail/ngx_mail_proxy_module.c
@@ -1184,37 +1184,21 @@ ngx_mail_proxy_handler(ngx_event_t *ev)
         return;
     }
 
-    if (c == s->connection) {
-        if (ev->write) {
-            recv_action = "proxying and reading from upstream";
-            send_action = "proxying and sending to client";
-            src = s->proxy->upstream.connection;
-            dst = c;
-            b = s->proxy->buffer;
-
-        } else {
-            recv_action = "proxying and reading from client";
-            send_action = "proxying and sending to upstream";
-            src = c;
-            dst = s->proxy->upstream.connection;
-            b = s->buffer;
-        }
+    if ((c == s->connection && ev->write)
+        || (c != s->connection && !ev->write))
+    {
+        recv_action = "proxying and reading from upstream";
+        send_action = "proxying and sending to client";
+        src = s->proxy->upstream.connection;
+        dst = s->connection;
+        b = s->proxy->buffer;
 
     } else {
-        if (ev->write) {
-            recv_action = "proxying and reading from client";
-            send_action = "proxying and sending to upstream";
-            src = s->connection;
-            dst = c;
-            b = s->buffer;
-
-        } else {
-            recv_action = "proxying and reading from upstream";
-            send_action = "proxying and sending to client";
-            src = c;
-            dst = s->connection;
-            b = s->proxy->buffer;
-        }
+        recv_action = "proxying and reading from client";
+        send_action = "proxying and sending to upstream";
+        src = s->connection;
+        dst = s->proxy->upstream.connection;
+        b = s->buffer;
     }
 
     do_write = ev->write ? 1 : 0;

--- a/src/mail/ngx_mail_proxy_module.c
+++ b/src/mail/ngx_mail_proxy_module.c
@@ -227,6 +227,7 @@ static void
 ngx_mail_proxy_pop3_handler(ngx_event_t *rev)
 {
     u_char                 *p;
+    ssize_t                 n;
     ngx_int_t               rc;
     ngx_str_t               line;
     ngx_connection_t       *c;
@@ -344,11 +345,20 @@ ngx_mail_proxy_pop3_handler(ngx_event_t *rev)
         break;
     }
 
-    if (c->send(c, line.data, line.len) < (ssize_t) line.len) {
+    n = c->send(c, line.data, line.len);
+
+    if (n == NGX_ERROR) {
+        ngx_mail_proxy_internal_server_error(s);
+        return;
+    }
+
+    if (n != (ssize_t) line.len) {
         /*
          * we treat the incomplete sending as NGX_ERROR
          * because it is very strange here
          */
+        ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                      "sent only %z of %uz", n, line.len);
         ngx_mail_proxy_internal_server_error(s);
         return;
     }
@@ -367,6 +377,7 @@ static void
 ngx_mail_proxy_imap_handler(ngx_event_t *rev)
 {
     u_char                 *p;
+    ssize_t                 n;
     ngx_int_t               rc;
     ngx_str_t               line;
     ngx_connection_t       *c;
@@ -505,11 +516,20 @@ ngx_mail_proxy_imap_handler(ngx_event_t *rev)
         break;
     }
 
-    if (c->send(c, line.data, line.len) < (ssize_t) line.len) {
+    n = c->send(c, line.data, line.len);
+
+    if (n == NGX_ERROR) {
+        ngx_mail_proxy_internal_server_error(s);
+        return;
+    }
+
+    if (n != (ssize_t) line.len) {
         /*
          * we treat the incomplete sending as NGX_ERROR
          * because it is very strange here
          */
+        ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                      "sent only %z of %uz", n, line.len);
         ngx_mail_proxy_internal_server_error(s);
         return;
     }
@@ -528,6 +548,7 @@ static void
 ngx_mail_proxy_smtp_handler(ngx_event_t *rev)
 {
     u_char                    *p;
+    ssize_t                    n;
     ngx_int_t                  rc;
     ngx_str_t                  line, auth, encoded;
     ngx_buf_t                 *b;
@@ -854,11 +875,20 @@ ngx_mail_proxy_smtp_handler(ngx_event_t *rev)
         break;
     }
 
-    if (c->send(c, line.data, line.len) < (ssize_t) line.len) {
+    n = c->send(c, line.data, line.len);
+
+    if (n == NGX_ERROR) {
+        ngx_mail_proxy_internal_server_error(s);
+        return;
+    }
+
+    if (n != (ssize_t) line.len) {
         /*
          * we treat the incomplete sending as NGX_ERROR
          * because it is very strange here
          */
+        ngx_log_error(NGX_LOG_ERR, c->log, 0,
+                      "sent only %z of %uz", n, line.len);
         ngx_mail_proxy_internal_server_error(s);
         return;
     }

--- a/src/mail/ngx_mail_proxy_module.c
+++ b/src/mail/ngx_mail_proxy_module.c
@@ -248,7 +248,7 @@ ngx_mail_proxy_pop3_handler(ngx_event_t *rev)
         return;
     }
 
-    if (s->proxy->proxy_protocol) {
+    if (s->proxy->proxy_protocol || !c->write->ready) {
         ngx_log_debug0(NGX_LOG_DEBUG_MAIL, c->log, 0, "mail proxy pop3 busy");
 
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
@@ -398,7 +398,7 @@ ngx_mail_proxy_imap_handler(ngx_event_t *rev)
         return;
     }
 
-    if (s->proxy->proxy_protocol) {
+    if (s->proxy->proxy_protocol || !c->write->ready) {
         ngx_log_debug0(NGX_LOG_DEBUG_MAIL, c->log, 0, "mail proxy imap busy");
 
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
@@ -572,7 +572,7 @@ ngx_mail_proxy_smtp_handler(ngx_event_t *rev)
         return;
     }
 
-    if (s->proxy->proxy_protocol) {
+    if (s->proxy->proxy_protocol || !c->write->ready) {
         ngx_log_debug0(NGX_LOG_DEBUG_MAIL, c->log, 0, "mail proxy smtp busy");
 
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {

--- a/src/mail/ngx_mail_smtp_handler.c
+++ b/src/mail/ngx_mail_smtp_handler.c
@@ -622,6 +622,8 @@ ngx_mail_smtp_auth_state(ngx_event_t *rev)
     case NGX_MAIL_PARSE_INVALID_COMMAND:
         s->mail_state = ngx_smtp_start;
         s->state = 0;
+        s->login.len = 0;
+        s->passwd.len = 0;
         ngx_str_set(&s->out, smtp_invalid_command);
 
         /* fall through */

--- a/src/mail/ngx_mail_smtp_handler.c
+++ b/src/mail/ngx_mail_smtp_handler.c
@@ -594,6 +594,14 @@ ngx_mail_smtp_auth_state(ngx_event_t *rev)
         case ngx_smtp_auth_external:
             rc = ngx_mail_auth_external(s, c, 0);
             break;
+
+        case ngx_smtp_auth_xoauth2:
+            rc = ngx_mail_auth_xoauth2(s, c, 0);
+            break;
+
+        case ngx_smtp_auth_oauthbearer:
+            rc = ngx_mail_auth_oauthbearer(s, c, 0);
+            break;
         }
     }
 
@@ -789,6 +797,38 @@ ngx_mail_smtp_auth(ngx_mail_session_t *s, ngx_connection_t *c)
 
         ngx_str_set(&s->out, smtp_username);
         s->mail_state = ngx_smtp_auth_external;
+
+        return NGX_OK;
+
+    case NGX_MAIL_AUTH_XOAUTH2:
+
+        if (!(sscf->auth_methods & NGX_MAIL_AUTH_XOAUTH2_ENABLED)) {
+            return NGX_MAIL_PARSE_INVALID_COMMAND;
+        }
+
+        if (s->args.nelts == 2) {
+            s->mail_state = ngx_smtp_auth_xoauth2;
+            return ngx_mail_auth_xoauth2(s, c, 1);
+        }
+
+        ngx_str_set(&s->out, smtp_next);
+        s->mail_state = ngx_smtp_auth_xoauth2;
+
+        return NGX_OK;
+
+    case NGX_MAIL_AUTH_OAUTHBEARER:
+
+        if (!(sscf->auth_methods & NGX_MAIL_AUTH_OAUTHBEARER_ENABLED)) {
+            return NGX_MAIL_PARSE_INVALID_COMMAND;
+        }
+
+        if (s->args.nelts == 2) {
+            s->mail_state = ngx_smtp_auth_oauthbearer;
+            return ngx_mail_auth_oauthbearer(s, c, 1);
+        }
+
+        ngx_str_set(&s->out, smtp_next);
+        s->mail_state = ngx_smtp_auth_oauthbearer;
 
         return NGX_OK;
     }

--- a/src/mail/ngx_mail_smtp_handler.c
+++ b/src/mail/ngx_mail_smtp_handler.c
@@ -747,6 +747,10 @@ ngx_mail_smtp_auth(ngx_mail_session_t *s, ngx_connection_t *c)
 
     case NGX_MAIL_AUTH_PLAIN:
 
+        if (s->args.nelts == 2) {
+            return ngx_mail_auth_plain(s, c, 1);
+        }
+
         ngx_str_set(&s->out, smtp_next);
         s->mail_state = ngx_smtp_auth_plain;
 
@@ -777,6 +781,10 @@ ngx_mail_smtp_auth(ngx_mail_session_t *s, ngx_connection_t *c)
 
         if (!(sscf->auth_methods & NGX_MAIL_AUTH_EXTERNAL_ENABLED)) {
             return NGX_MAIL_PARSE_INVALID_COMMAND;
+        }
+
+        if (s->args.nelts == 2) {
+            return ngx_mail_auth_external(s, c, 1);
         }
 
         ngx_str_set(&s->out, smtp_username);

--- a/src/mail/ngx_mail_smtp_handler.c
+++ b/src/mail/ngx_mail_smtp_handler.c
@@ -596,7 +596,7 @@ ngx_mail_smtp_auth_state(ngx_event_t *rev)
         }
     }
 
-    if (s->buffer->pos < s->buffer->last) {
+    if (s->buffer->pos < s->buffer->last || c->read->ready) {
         s->blocked = 1;
     }
 

--- a/src/mail/ngx_mail_smtp_handler.c
+++ b/src/mail/ngx_mail_smtp_handler.c
@@ -476,6 +476,7 @@ ngx_mail_smtp_create_buffer(ngx_mail_session_t *s, ngx_connection_t *c)
 void
 ngx_mail_smtp_auth_state(ngx_event_t *rev)
 {
+    size_t               n;
     ngx_int_t            rc;
     ngx_connection_t    *c;
     ngx_mail_session_t  *s;
@@ -623,6 +624,12 @@ ngx_mail_smtp_auth_state(ngx_event_t *rev)
         if (s->buffer->pos == s->buffer->last) {
             s->buffer->pos = s->buffer->start;
             s->buffer->last = s->buffer->start;
+
+        } else {
+            n = s->buffer->last - s->buffer->pos;
+            ngx_memmove(s->buffer->start, s->buffer->pos, n);
+            s->buffer->pos = s->buffer->start;
+            s->buffer->last = s->buffer->start + n;
         }
 
         if (s->state) {

--- a/src/mail/ngx_mail_smtp_module.c
+++ b/src/mail/ngx_mail_smtp_module.c
@@ -22,6 +22,8 @@ static ngx_conf_bitmask_t  ngx_mail_smtp_auth_methods[] = {
     { ngx_string("login"), NGX_MAIL_AUTH_LOGIN_ENABLED },
     { ngx_string("cram-md5"), NGX_MAIL_AUTH_CRAM_MD5_ENABLED },
     { ngx_string("external"), NGX_MAIL_AUTH_EXTERNAL_ENABLED },
+    { ngx_string("xoauth2"), NGX_MAIL_AUTH_XOAUTH2_ENABLED },
+    { ngx_string("oauthbearer"), NGX_MAIL_AUTH_OAUTHBEARER_ENABLED },
     { ngx_string("none"), NGX_MAIL_AUTH_NONE_ENABLED },
     { ngx_null_string, 0 }
 };
@@ -33,6 +35,8 @@ static ngx_str_t  ngx_mail_smtp_auth_methods_names[] = {
     ngx_null_string,  /* APOP */
     ngx_string("CRAM-MD5"),
     ngx_string("EXTERNAL"),
+    ngx_string("XOAUTH2"),
+    ngx_string("OAUTHBEARER"),
     ngx_null_string   /* NONE */
 };
 
@@ -210,7 +214,7 @@ ngx_mail_smtp_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     auth_enabled = 0;
 
     for (m = NGX_MAIL_AUTH_PLAIN_ENABLED, i = 0;
-         m <= NGX_MAIL_AUTH_EXTERNAL_ENABLED;
+         m < NGX_MAIL_AUTH_NONE_ENABLED;
          m <<= 1, i++)
     {
         if (m & conf->auth_methods) {
@@ -253,7 +257,7 @@ ngx_mail_smtp_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
         *p++ = 'A'; *p++ = 'U'; *p++ = 'T'; *p++ = 'H';
 
         for (m = NGX_MAIL_AUTH_PLAIN_ENABLED, i = 0;
-             m <= NGX_MAIL_AUTH_EXTERNAL_ENABLED;
+             m < NGX_MAIL_AUTH_NONE_ENABLED;
              m <<= 1, i++)
         {
             if (m & conf->auth_methods) {


### PR DESCRIPTION
## Problem

The nginx mail proxy has no support for OAuth bearer-token authentication. [RFC 7628](https://datatracker.ietf.org/doc/html/rfc7628) defines the `OAUTHBEARER` SASL mechanism for mail protocols like IMAP, POP and SMTP, and Google's widely deployed `XOAUTH2` predates it — nginx currently supports neither.

## Solution

This PR adds `OAUTHBEARER` (RFC 7628) and `XOAUTH2` authentication to the mail proxy for IMAP, POP and SMTP. The bearer token is passed through to the `auth_http` service, and the authentication server can return a SASL error response to the client via a new `Auth-Error-SASL` header.

Because a base64-encoded bearer token easily exceeds the POP3 command buffer's historical fixed size of 128 bytes, this also makes that buffer configurable via a new `pop3_client_buffer` directive, defaulting to one memory page to match the existing `imap_client_buffer` and `smtp_client_buffer`.

This branch also includes a small number of other fixes that I think are worthwhile including upstream. I've included them in this PR because they all relate to the mail proxy and making it more stable, so I feel are sufficiently small and related to go in at the same time:

- **Command pipelining and buffering:** Correctly handle pipelined commands that cross the read-buffer boundary and buffers holding multiple commands, and resume reads via posted events. Adds a `max_commands` directive to bound the number of commands accepted during authentication.
- **SASL EXTERNAL and auth state:** Accept `EXTERNAL` only when it is enabled, and reliably clear the login, password and IMAP tag between authentication attempts.
- **Upstream error reporting:** Report errors when connecting to the upstream and when a command cannot be fully sent, and fix occasional proxy errors on Windows.
- **Error-path robustness:** Fix a potential use-after-free when `ngx_mail_send()` runs with `s->quit` set, along with missing returns and missing event handling on `auth_http` error paths.
- **auth_http request correctness:** Escape the client host name, and drop a spurious `upstream: ...` entry from the logs with `smtp_auth none`.

For completeness, the history of this work is:
1. I developed the original patch
2. I ended up submitting it to freenginx to be incorporated upstream there
3. Maxim took the patch, cleaned it up a bit, fixed some problems, and upstreamed it into freenginx
4. I then cherry-picked the patch against upstream mainline nginx and used it in our Fastmail builds (the -fastmail branches at https://github.com/fastmailops/nginx)

The freenginx-authored commits are included here with their original authorship, an `Origin:` link to the freenginx source, and my `Signed-off-by`, mirroring the way freenginx changes are already imported into nginx mainline.

Support for OAUTHBEARER will become more important over the next year. At the recent IETF, interoperability testing was done against the new PACC (https://datatracker.ietf.org/doc/draft-ietf-mailmaint-pacc/) spec which, along with dynamic client registration (https://datatracker.ietf.org/doc/html/rfc7591), will allow email clients and providers to offer OAuth-style authentication for all clients against all servers without each client/server having to register with each other. This will be a major step forward in both email security and setup simplicity, but it requires servers to support OAUTHBEARER, hence this PR.

I have an updated documentation branch at https://github.com/robmueller/nginx.org/tree/oauthbearer-support that documents the new directives and the additions to the `auth_http` protocol. nginx docs live in a separate repo, so that would be a separate PR; the version markers there are placeholders pending the release this lands in.

## Testing

- **Automated tests:** I wrote a test suite covering all of these changes. OAUTHBEARER/XOAUTH2 across IMAP, POP and SMTP (including the SASL-failure flow and a long-token POP3 case), `max_commands`, pipelining, EXTERNAL, and host-name escaping. It's on this branch: (https://github.com/robmueller/nginx-tests/tree/oauthbearer-support). I'm happy to open it as a PR when you're ready. All existing mail tests pass, and the branch is rebased on current master.
- **Production:** We've run this at Fastmail in production for over a year, with Thunderbird clients authenticating via OAUTHBEARER against us successfully.

## Checklist

Before submitting this PR, please confirm:

- [X] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [X] I have added tests (if applicable) to validate my changes
- [X] All existing tests pass
- [X] I have updated documentation where necessary
- [X] My branch is rebased on the latest master
- [X] This PR targets the master branch from my fork
- [X] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

Add OAUTHBEARER (RFC 7628) and XOAUTH2 authentication for IMAP, POP and SMTP in the mail proxy module