### PR TITLE
gRPC: narrowed special handling of "trailer only" responses

### DIFF
--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -2047,7 +2047,13 @@ ngx_http_grpc_process_header(ngx_http_request_t *r)
                 }
 
                 if (ctx->end_stream) {
-                    u->headers_in.content_length_n = 0;
+                    if (u->headers_in.content_length == NULL) {
+                        u->headers_in.content_length_n = 0;
+                    } else if (u->headers_in.content_length_n > 0) {
+                        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                      "upstream prematurely closed stream");
+                        return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+                    }
 
                     if (ctx->in == NULL
                         && ctx->out == NULL

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -2047,7 +2047,10 @@ ngx_http_grpc_process_header(ngx_http_request_t *r)
                 }
 
                 if (ctx->end_stream) {
-                    u->headers_in.content_length_n = 0;
+
+                    if (u->headers_in.content_length_n == -1) {
+                        u->headers_in.content_length_n = 0;
+                    }
 
                     if (ctx->in == NULL
                         && ctx->out == NULL


### PR DESCRIPTION
## Problem

When a gRPC upstream ends a response on the initial HEADERS frame and also
sends a positive Content-Length, nginx replaces the parsed length with 0
before its response-length check runs. nginx consequently accepts the malformed
upstream response and sends an empty successful response downstream.

## Solution

Only zero out content_length_n when no explicit Content-Length header was sent. If the upstream declared Content-Length > 0 but ended the stream immediately and no DATA frames, reject it as invalid.
nginx now returns 502 Bad Gateway and logs upstream prematurely closed stream.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1568

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
