### PR TITLE
Format specifier fixes in error logging

### DIFF
--- a/src/core/ngx_conf_file.c
+++ b/src/core/ngx_conf_file.c
@@ -566,7 +566,7 @@ ngx_conf_read_token(ngx_conf_t *cf)
                 } else {
                     ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                        "too long parameter \"%*s...\" started",
-                                       10, start);
+                                       (size_t) 10, start);
                     return NGX_ERROR;
                 }
 

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -1730,7 +1730,7 @@ ngx_ssl_ech_files(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *filenames)
 
     if (OSSL_ECHSTORE_num_keys(es, &numkeys) != 1) {
         ngx_ssl_error(NGX_LOG_EMERG, ssl->log, 0,
-                      "OSSL_ECHSTORE_num_keys(%s) failed");
+                      "OSSL_ECHSTORE_num_keys() failed");
         goto cleanup;
     }
 

--- a/src/event/quic/ngx_event_quic_frames.c
+++ b/src/event/quic/ngx_event_quic_frames.c
@@ -694,7 +694,7 @@ ngx_quic_log_frame(ngx_log_t *log, ngx_quic_frame_t *f, ngx_uint_t tx)
     case NGX_QUIC_FT_ACK:
     case NGX_QUIC_FT_ACK_ECN:
 
-        p = ngx_slprintf(p, last, "ACK n:%ui delay:%uL ",
+        p = ngx_slprintf(p, last, "ACK n:%uL delay:%uL ",
                          f->u.ack.range_count, f->u.ack.delay);
 
         if (f->data) {
@@ -758,7 +758,7 @@ ngx_quic_log_frame(ngx_log_t *log, ngx_quic_frame_t *f, ngx_uint_t tx)
 
     case NGX_QUIC_FT_CONNECTION_CLOSE:
     case NGX_QUIC_FT_CONNECTION_CLOSE_APP:
-        p = ngx_slprintf(p, last, "CONNECTION_CLOSE%s err:%ui",
+        p = ngx_slprintf(p, last, "CONNECTION_CLOSE%s err:%uL",
                          f->type == NGX_QUIC_FT_CONNECTION_CLOSE ? "" : "_APP",
                          f->u.close.error_code);
 
@@ -767,7 +767,7 @@ ngx_quic_log_frame(ngx_log_t *log, ngx_quic_frame_t *f, ngx_uint_t tx)
         }
 
         if (f->type == NGX_QUIC_FT_CONNECTION_CLOSE) {
-            p = ngx_slprintf(p, last, " ft:%ui", f->u.close.frame_type);
+            p = ngx_slprintf(p, last, " ft:%uL", f->u.close.frame_type);
         }
 
         break;

--- a/src/http/modules/ngx_http_geo_module.c
+++ b/src/http/modules/ngx_http_geo_module.c
@@ -964,7 +964,7 @@ ngx_http_geo_add_range(ngx_conf_t *cf, ngx_http_geo_conf_ctx_t *ctx,
             e = (ngx_uint_t) range[i].end;
 
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                         "range \"%V\" overlaps \"%d.%d.%d.%d-%d.%d.%d.%d\"",
+                         "range \"%V\" overlaps \"%i.%i.%i.%i-%i.%i.%i.%i\"",
                          ctx->net,
                          h >> 8, h & 0xff, s >> 8, s & 0xff,
                          h >> 8, h & 0xff, e >> 8, e & 0xff);

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -5456,7 +5456,7 @@ ngx_http_core_pool_size(ngx_conf_t *cf, void *post, void *data)
 
     if (*sp % NGX_POOL_ALIGNMENT) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                           "the pool size must be a multiple of %uz",
+                           "the pool size must be a multiple of %d",
                            NGX_POOL_ALIGNMENT);
         return NGX_CONF_ERROR;
     }

--- a/src/http/v2/ngx_http_v2_module.c
+++ b/src/http/v2/ngx_http_v2_module.c
@@ -411,7 +411,7 @@ ngx_http_v2_pool_size(ngx_conf_t *cf, void *post, void *data)
 
     if (*sp % NGX_POOL_ALIGNMENT) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                           "the pool size must be a multiple of %uz",
+                           "the pool size must be a multiple of %d",
                            NGX_POOL_ALIGNMENT);
 
         return NGX_CONF_ERROR;
@@ -428,7 +428,7 @@ ngx_http_v2_preread_size(ngx_conf_t *cf, void *post, void *data)
 
     if (*sp > NGX_HTTP_V2_MAX_WINDOW) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                           "the maximum body preread buffer size is %uz",
+                           "the maximum body preread buffer size is %ud",
                            NGX_HTTP_V2_MAX_WINDOW);
 
         return NGX_CONF_ERROR;

--- a/src/stream/ngx_stream_geo_module.c
+++ b/src/stream/ngx_stream_geo_module.c
@@ -914,7 +914,7 @@ ngx_stream_geo_add_range(ngx_conf_t *cf, ngx_stream_geo_conf_ctx_t *ctx,
             e = (ngx_uint_t) range[i].end;
 
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                         "range \"%V\" overlaps \"%d.%d.%d.%d-%d.%d.%d.%d\"",
+                         "range \"%V\" overlaps \"%i.%i.%i.%i-%i.%i.%i.%i\"",
                          ctx->net,
                          h >> 8, h & 0xff, s >> 8, s & 0xff,
                          h >> 8, h & 0xff, e >> 8, e & 0xff);


### PR DESCRIPTION
## Problem

**Format string / argument mismatches in error logging**

This started as a single missing argument: `ngx_ssl_ech_files()` logged `"OSSL_ECHSTORE_num_keys(%s) failed"` with nothing for the `%s`, so on that branch `ngx_vslprintf()` did `va_arg(args, u_char *)` and walked an indeterminate pointer out of the vararg area, either crashing config load or copying unrelated memory into the log.

The maintainer's clang-ast runner then turned up several more format specifier problems in the same class (wrong width/type conversions in the QUIC frame log, the geo range overlap messages, the pool-size / preread-size config errors, and a too-long-parameter message), so the change now covers all of them.

## Solution

- ECH: drop the stray `%s`, matching the neighbouring `OSSL_ECHSTORE_new()` / `SSL_CTX_set1_echstore()` diagnostics.
- QUIC frame log: use `%uL` for the 64-bit fields.
- geo modules: use `%i` for the `ngx_int_t` octet values.
- config errors: match the specifier to the constant's type (`%d` / `%ud`, `(size_t) 10` for `%*s`).

## Testing

Full `make` on macOS/arm64 with the project's own `-Werror` flags stays green. The ECH path was confirmed by driving `ngx_vslprintf()` with the exact format string and no argument under ASan, which faults on the wild `%s` read before the patch and logs cleanly after.

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)
