### PR TITLE
QUIC: log HTTP/3 requests aborted by a peer close as 499

### DIFF
--- a/src/event/quic/ngx_event_quic_streams.c
+++ b/src/event/quic/ngx_event_quic_streams.c
@@ -221,6 +221,11 @@ ngx_quic_close_streams(ngx_connection_t *c, ngx_quic_connection_t *qc)
 
         sc->close = 1;
 
+        if (qc->draining) {
+            /* peer-initiated close: CONNECTION_CLOSE or stateless reset */
+            sc->error = 1;
+        }
+
         if (sc->read->posted) {
             ngx_delete_posted_event(sc->read);
         }

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -2595,6 +2595,24 @@ ngx_http_request_handler(ngx_event_t *ev)
                    "http run request: \"%V?%V\"", &r->uri, &r->args);
 
     if (c->close) {
+
+#if (NGX_HTTP_V3)
+
+        /*
+         * a stream torn down by a peer-initiated connection close is
+         * terminated with rc = 0 and logged without a status; account
+         * it as a client abort, as with HTTP/2
+         */
+
+        if (c->quic
+            && c->error
+            && r->err_status == 0
+            && r->headers_out.status == 0)
+        {
+            r->err_status = NGX_HTTP_CLIENT_CLOSED_REQUEST;
+        }
+#endif
+
         r->main->count++;
         ngx_http_terminate_request(r, 0);
         ngx_http_run_posted_requests(c);


### PR DESCRIPTION
When a client closes a QUIC connection while nginx is still waiting for an upstream response, ngx_quic_close_streams() tears down the in-flight stream connections and the request is terminated with rc = 0.  With no status set, such requests are logged with $status "000".

Streams torn down while the connection is draining, that is, after a CONNECTION_CLOSE frame was received or a stateless reset was detected, are now marked with c->error, and the request is finalized with NGX_HTTP_CLIENT_CLOSED_REQUEST, matching HTTP/2 accounting of a client that goes away before the response is delivered.

Server-initiated teardown and idle timeouts are not affected.

[0313ab1808ebae3c.sqlog.txt](https://github.com/user-attachments/files/30295345/0313ab1808ebae3c.sqlog.txt)
Production qlog trace: HTTP/3 connection where the client sends a transport CONNECTION_CLOSE (error_code 0, NO_ERROR) with ~10 requests still in flight. Those requests are terminated with no response and logged as status 000. qvis-loadable after renaming .txt → .qlog.

https://github.com/nginx/nginx/pull/1398 qlog implementation used


## Problem

Briefly describe the issue or feature being addressed.

## Solution

Explain your approach and any important design decisions.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #ISSUE\_NUMBER

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
