### PR TITLE
Events: validate descriptor before FD_SET()

### DIFF
--- a/src/event/modules/ngx_select_module.c
+++ b/src/event/modules/ngx_select_module.c
@@ -146,6 +146,17 @@ ngx_select_add_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags)
         return NGX_ERROR;
     }
 
+    /* disable warning: the default FD_SETSIZE is 1024U in FreeBSD 5.x-10.x */
+
+    if ((event == NGX_READ_EVENT || event == NGX_WRITE_EVENT)
+        && (unsigned) c->fd >= FD_SETSIZE)
+    {
+        ngx_log_error(NGX_LOG_ERR, ev->log, 0,
+                      "maximum number of descriptors "
+                      "supported by select() is %ud", FD_SETSIZE);
+        return NGX_ERROR;
+    }
+
     if (event == NGX_READ_EVENT) {
         FD_SET(c->fd, &master_read_fd_set);
 
@@ -410,8 +421,6 @@ ngx_select_init_conf(ngx_cycle_t *cycle, void *conf)
     if (ecf->use != ngx_select_module.ctx_index) {
         return NGX_CONF_OK;
     }
-
-    /* disable warning: the default FD_SETSIZE is 1024U in FreeBSD 5.x */
 
     if (cycle->connection_n > FD_SETSIZE) {
         ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,


### PR DESCRIPTION
## Problem

The issue is when NGINX uses select() event method to monitor client connections. The select() API can only work with file descriptors smaller than FD_SETSIZE (Typically 1024). During initialization NGINX validates that the configured worker_connections value does not exceed FD_SETSIZE, but it does not validate the actual file descriptor returned by OS before calling FD_SET(). As a result, if OS assigns a file descriptor greater than or equal to FD_SETSIZE, then FD_SET() performs an out-of-bounds write, which can crash the worker process. 

## Solution

Add a runtime validation in ngx_select_add_event() before calling FD_SET().

This validates If the file descriptor is outside the range supported by select(), nginx returns an error instead of performing an out-of-bounds memory write.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [ x] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #ISSUE\_NUMBER

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
