### PR TITLE
SSL: checked i2d_SSL_SESSION() return value before caching session

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -4391,9 +4391,9 @@ ngx_ssl_new_session(ngx_ssl_conn_t *ssl_conn, ngx_ssl_session_t *sess)
 
     len = i2d_SSL_SESSION(sess, NULL);
 
-    /* do not cache too big session */
+    /* do not cache invalid or too big session */
 
-    if (len > NGX_SSL_MAX_SESSION_SIZE) {
+    if (len <= 0 || len > NGX_SSL_MAX_SESSION_SIZE) {
         return 0;
     }
 

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -1194,9 +1194,9 @@ ngx_http_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                        "save session: %p:%d", ssl_session, len);
 
-        /* do not cache too big session */
+        /* do not cache invalid or too big session */
 
-        if (len > NGX_SSL_MAX_SESSION_SIZE) {
+        if (len <= 0 || len > NGX_SSL_MAX_SESSION_SIZE) {
             return;
         }
 

--- a/src/stream/ngx_stream_upstream_round_robin.c
+++ b/src/stream/ngx_stream_upstream_round_robin.c
@@ -1025,9 +1025,9 @@ ngx_stream_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
         ngx_log_debug2(NGX_LOG_DEBUG_STREAM, pc->log, 0,
                        "save session: %p:%d", ssl_session, len);
 
-        /* do not cache too big session */
+        /* do not cache invalid or too big session */
 
-        if (len > NGX_SSL_MAX_SESSION_SIZE) {
+        if (len <= 0 || len > NGX_SSL_MAX_SESSION_SIZE) {
             return;
         }
 


### PR DESCRIPTION
## Problem

`i2d_SSL_SESSION()` returns the DER-encoded length, or a negative value
on error. The three session-caching paths checked the length only
against `NGX_SSL_MAX_SESSION_SIZE` and then used it as the size argument
to `ngx_memcpy()` into `ngx_ssl_session_buffer`. A negative return would
pass the upper-bound check and be converted to a large `size_t` in
`ngx_memcpy()`, reading out of bounds.

In practice `i2d_SSL_SESSION()` returns a negative value only on an
OpenSSL internal error (e.g. allocation or ASN.1 encoding failure), not
on client-controlled input, so this is a defensive/robustness fix rather
than a client-reachable issue.

## Fix

Reject a non-positive length before the copy in all three session save
paths:

- `ngx_ssl_new_session()` -- builtin SSL session cache
- `ngx_http_upstream_save_round_robin_peer_session()`
- `ngx_stream_upstream_save_round_robin_peer_session()`

## Testing

Builds cleanly with `--with-http_ssl_module --with-stream
--with-stream_ssl_module --with-debug`; no new warnings.
