### PR TITLE
Reset c->pipeline on the keepalive path

### DIFF
--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -3656,6 +3656,7 @@ ngx_http_keepalive_handler(ngx_event_t *rev)
 
     c->sent = 0;
     c->destroyed = 0;
+    c->pipeline = 0;
 
     ngx_del_timer(rev);
 


### PR DESCRIPTION
## Problem

`c->pipeline` is set to `1` in `ngx_http_set_keepalive()` when a
pipelined request is present in the connection buffer, and it is read in
`ngx_http_finalize_connection()` as one of the conditions that forces a
lingering close.

The flag is never cleared when a new request starts on a kept-alive
connection (`ngx_http_keepalive_handler()` resets `c->sent` and
`c->destroyed`, but not `c->pipeline`). As a result the flag can persist
across the keepalive boundary and trigger an unnecessary lingering close
for a later request that was not actually pipelined.

## Fix

Reset `c->pipeline = 0` in `ngx_http_keepalive_handler()` alongside the
existing `c->sent`/`c->destroyed` resets, restoring the flag's intended
present-tense meaning.

Impact is limited to a needless lingering close (no memory-safety or
security effect); this is a correctness cleanup.

## Testing

Builds cleanly (`--with-http_ssl_module --with-stream
--with-stream_ssl_module --with-debug`); no new warnings.
