### PR TITLE
Script: improved compatibility of complex value codes

### DIFF
--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -1867,20 +1867,28 @@ ngx_http_script_complex_value_code(ngx_http_script_engine_t *e)
 
     e->pos = e->buf.data;
     e->end = e->buf.data + len;
+
+    e->sp->len = e->buf.len;
+    e->sp->data = e->buf.data;
+    e->sp++;
 }
 
 
 void
 ngx_http_script_complex_value_end_code(ngx_http_script_engine_t *e)
 {
+    ngx_http_variable_value_t  *val;
+
+    val = e->sp - 1;
+
     e->ip += sizeof(ngx_http_script_complex_value_end_code_t);
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, e->request->connection->log, 0,
                    "http script complex value end");
 
-    e->sp->len = e->pos - e->buf.data;
-    e->sp->data = e->buf.data;
-    e->sp++;
+    if (val->data == e->buf.data) {
+        val->len = e->pos - e->buf.data;
+    }
 }
 
 


### PR DESCRIPTION
In a8289aa69c74, we introduced a new code to finalize the evaluation of a complex value, deferring the stack update to this new code.  However, the change inadvertently broke compatibility with several third-party modules that were reusing `ngx_http_script_complex_value_code`.

This change relegates omitted `ngx_http_script_complex_value_end_code` from crash to a potential read of uninitialized bytes at the end of the allocated buffer.

***
This does not absolve the aforementioned third-party modules from the need to use `ngx_http_script_complex_value_end_code`; a possibility of reading uninitialized heap memory[^1] is only slightly better than crashing. That being said, the breaking change was backported to stable, and we usually offer better compatibility guarantees.

[^1]: in a very small set of affected configurations with no possibility of overwrite or out-of bounds access; refer to a8289aa69c74