### PR TITLE
HTTP: fixed HTAB not being stripped from header field values - Issue 1597

### DIFF
--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -1027,6 +1027,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_space_before_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 break;
             case CR:
                 r->header_start = p;
@@ -1051,6 +1052,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 r->header_end = p;
                 state = sw_space_after_value;
                 break;
@@ -1071,6 +1073,7 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
         case sw_space_after_value:
             switch (ch) {
             case ' ':
+            case '\t':
                 break;
             case CR:
                 state = sw_almost_done;


### PR DESCRIPTION
This fixes #1597.

## What changed

Updated `src/http/ngx_http_parse.c` in `ngx_http_parse_header_line()` to treat horizontal tabs (`'\t'`) as optional whitespace alongside spaces (`' '`) by adding `case '\t':` in:

- `sw_space_before_value`
- `sw_value`
- `sw_space_after_value`

This is a minimal parser-only change (3 lines added, 1 file modified) with no other logic changes.

## Why

RFC 9112 §5 defines optional whitespace (OWS) around HTTP header field values as either a space (`SP`) or a horizontal tab (`HTAB`).

Previously, only spaces were treated as optional whitespace, causing leading and trailing tabs to become part of the parsed header value. After this change, tabs are handled consistently with spaces and are trimmed during parsing.

Example:

Custom: \they\t
Custom: \tthere\t

Before:
$http_custom = "\they\t, \tthere\t"

After:
$http_custom = "hey, there"

The fix is implemented in the parser so all downstream consumers of parsed header values receive the corrected value without requiring additional handling.

## Testing

- Built nginx with `--with-debug`.
- Verified:
  - Single header with leading/trailing tabs.
  - Duplicate headers.
  - Values containing internal spaces/tabs (ensuring internal whitespace is preserved).
  - Plain header values.
- Ran the full `nginx-tests` suite: 2519 tests passed.
- Re-ran `proxy_*`, `fastcgi_*`, and `scgi_*` test groups.

Remaining skipped tests are due to optional modules or unavailable external test helpers and are unrelated to this change.