### PR TITLE
Upstream: hide hop-by-hop headers in early hints responses

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -340,6 +340,24 @@ static ngx_http_upstream_header_t  ngx_http_upstream_headers_in[] = {
 };
 
 
+/*
+ * Connection-specific and framing header fields are never forwarded within
+ * a 103 (Early Hints) response: they are hop-by-hop (RFC 9110, 7.6.1), a
+ * 1xx response never carries content, and with HTTP/2 and HTTP/3 such fields
+ * make the response malformed (RFC 9113, 8.2.2; RFC 9114, 4.2).
+ */
+
+static ngx_str_t  ngx_http_upstream_early_hints_hide_headers[] = {
+    ngx_string("Connection"),
+    ngx_string("Content-Length"),
+    ngx_string("Keep-Alive"),
+    ngx_string("Proxy-Connection"),
+    ngx_string("Transfer-Encoding"),
+    ngx_string("Upgrade"),
+    ngx_null_string
+};
+
+
 static ngx_command_t  ngx_http_upstream_commands[] = {
 
     { ngx_string("upstream"),
@@ -2648,13 +2666,16 @@ static ngx_int_t
 ngx_http_upstream_process_early_hints(ngx_http_request_t *r,
     ngx_http_upstream_t *u)
 {
-    u_char            *p;
-    ngx_uint_t         i;
-    ngx_list_part_t   *part;
-    ngx_table_elt_t   *h, *ho;
-    ngx_connection_t  *c;
+    u_char                         *p;
+    ngx_uint_t                      i;
+    ngx_list_part_t                *part;
+    ngx_table_elt_t                *h, *ho;
+    ngx_connection_t               *c;
+    ngx_http_upstream_main_conf_t  *umcf;
 
     c = r->connection;
+
+    umcf = ngx_http_get_module_main_conf(r, ngx_http_upstream_module);
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http upstream early hints");
 
@@ -2681,6 +2702,12 @@ ngx_http_upstream_process_early_hints(ngx_http_request_t *r,
 
                 if (ngx_hash_find(&u->conf->hide_headers_hash, h[i].hash,
                                   h[i].lowcase_key, h[i].key.len))
+                {
+                    continue;
+                }
+
+                if (ngx_hash_find(&umcf->early_hints_hide_headers_hash,
+                                  h[i].hash, h[i].lowcase_key, h[i].key.len))
                 {
                     continue;
                 }
@@ -7296,6 +7323,7 @@ ngx_http_upstream_init_main_conf(ngx_conf_t *cf, void *conf)
 {
     ngx_http_upstream_main_conf_t  *umcf = conf;
 
+    ngx_str_t                      *name;
     ngx_uint_t                      i;
     ngx_array_t                     headers_in;
     ngx_hash_key_t                 *hk;
@@ -7341,6 +7369,41 @@ ngx_http_upstream_init_main_conf(ngx_conf_t *cf, void *conf)
     hash.max_size = 512;
     hash.bucket_size = ngx_align(64, ngx_cacheline_size);
     hash.name = "upstream_headers_in_hash";
+    hash.pool = cf->pool;
+    hash.temp_pool = NULL;
+
+    if (ngx_hash_init(&hash, headers_in.elts, headers_in.nelts) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+
+    /* early_hints_hide_headers_hash */
+
+    if (ngx_array_init(&headers_in, cf->temp_pool, 8, sizeof(ngx_hash_key_t))
+        != NGX_OK)
+    {
+        return NGX_CONF_ERROR;
+    }
+
+    for (name = ngx_http_upstream_early_hints_hide_headers;
+         name->len;
+         name++)
+    {
+        hk = ngx_array_push(&headers_in);
+        if (hk == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        hk->key = *name;
+        hk->key_hash = ngx_hash_key_lc(name->data, name->len);
+        hk->value = (void *) 1;
+    }
+
+    hash.hash = &umcf->early_hints_hide_headers_hash;
+    hash.key = ngx_hash_key_lc;
+    hash.max_size = 512;
+    hash.bucket_size = ngx_align(64, ngx_cacheline_size);
+    hash.name = "early_hints_hide_headers_hash";
     hash.pool = cf->pool;
     hash.temp_pool = NULL;
 

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -76,6 +76,7 @@ typedef struct {
 
 typedef struct {
     ngx_hash_t                       headers_in_hash;
+    ngx_hash_t                       early_hints_hide_headers_hash;
     ngx_array_t                      upstreams;
                                              /* ngx_http_upstream_srv_conf_t */
 } ngx_http_upstream_main_conf_t;


### PR DESCRIPTION
## Problem

`ngx_http_upstream_process_early_hints()` copies header fields received in a
103 (Early Hints) response into `r->headers_out.headers`, filtered only by
`hide_headers_hash`. The copy handlers from `ngx_http_upstream_headers_in[]`,
which normally drop connection-specific and framing header fields, never run
on this path — the proxy module deliberately skips them for 1xx responses
(`ngx_http_proxy_module.c`, `if (... == NGX_HTTP_EARLY_HINTS) { continue; }`)
and nothing takes their place.

So `Connection`, `Keep-Alive`, `Upgrade`, `Transfer-Encoding` and
`Content-Length` are relayed to the client verbatim inside the 103. These are
hop-by-hop header fields (RFC 9110, 7.6.1), and a 1xx response never carries
content, so framing fields are meaningless in it.

**With HTTP/2 and HTTP/3 the request fails outright.** nginx emits an
informational response containing connection-specific fields, which RFC 9113
8.2.2 and RFC 9114 4.2 forbid. Compliant clients treat it as malformed and
reset the stream:

```
* Invalid HTTP header field was received: frame type: 1, stream: 1, name: [connection], value: [close]
< HTTP/2 103
* HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR (err 1)
```

I reproduced this independently for each of `Connection`, `Content-Length`,
`Transfer-Encoding`, `Keep-Alive` and `Upgrade`.

This does not require a hostile upstream. A backend that stamps `Connection`
on every response it writes is enough to break every HTTP/2 and HTTP/3 client
for that location.

**With HTTP/1.x**, `Content-Length` / `Transfer-Encoding` on an informational
response is a desync primitive for an intermediary that honours them, and
`Connection: close` tells the client to close a connection nginx intends to
keep alive:

```
HTTP/1.1 103 Early Hints
Link: </style.css>; rel=preload; as=style
Content-Length: 42
Transfer-Encoding: chunked
Connection: close
Keep-Alive: timeout=1
Upgrade: h2c

HTTP/1.1 200 OK
Server: nginx/1.31.4
...
```

### Reproducer

```nginx
http {
    server {
        listen 127.0.0.1:8899;
        http2 on;
        location / {
            early_hints 1;
            proxy_pass http://127.0.0.1:8898;
        }
    }
}
```

Backend that emits a 103 carrying a hop-by-hop field:

```python
import socket
s = socket.socket(); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
s.bind(('127.0.0.1', 8898)); s.listen(5)
while True:
    c, _ = s.accept()
    c.recv(65535)
    c.sendall(b"HTTP/1.1 103 Early Hints\r\n"
              b"Link: </style.css>; rel=preload; as=style\r\n"
              b"Connection: close\r\n"
              b"\r\n"
              b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nhi\n")
    c.close()
```

```
curl -sv --http2-prior-knowledge -o /dev/null http://127.0.0.1:8899/
```

Before this change the stream is reset with `PROTOCOL_ERROR`; after it, the
103 carries only `link` and the 200 is delivered normally.

## Solution

Added `ngx_http_upstream_early_hints_hide_headers[]` and built it into an
`early_hints_hide_headers_hash` in `ngx_http_upstream_init_main_conf()`,
alongside the existing `headers_in_hash`. The early hints copy loop now
consults it in addition to `hide_headers_hash`.

Using a dedicated list rather than reusing the `headers_in_hash` copy
handlers was deliberate: only `Content-Length`, `Connection`, `Keep-Alive` and
`Transfer-Encoding` have `ngx_http_upstream_ignore_header_line` as their copy
handler. `Upgrade` uses `ngx_http_upstream_copy_header_line`, because it is
needed for 101 protocol switching on the normal path, so a copy-handler-based
filter would still let it through. `Proxy-Connection` is not in the table at
all.

The set matches the connection-specific fields enumerated in RFC 9113 8.2.2,
plus `Content-Length`.

Happy to reshape this if you would rather see the filtering expressed
differently — e.g. folded into the per-module `hide_headers` machinery.

## Testing

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**New test:** `proxy_early_hints_headers.t`, submitted as
nginx/nginx-tests#89. It covers HTTP/1.1, HTTP/2 and
HTTP/3, and fails against current master:

```
#   Failed test 'h2 no hop-by-hop headers'
#          got: 'connection content-length transfer-encoding keep-alive upgrade'
#     expected: ''

#   Failed test 'h3 no hop-by-hop headers'
#          got: 'connection content-length transfer-encoding keep-alive upgrade'
#     expected: ''
# Looks like you failed 3 tests of 12.
```

**Existing tests:** the full suite passes against the patched build — 492
files, 6580 tests, `Result: PASS`. Built with
`--with-http_v2_module --with-http_v3_module` and CryptX present so no
early-hints test is skipped:

```
proxy_early_hints.t ..... ok
proxy_h2_early_hints.t .. ok
grpc_early_hints.t ...... ok
All tests successful.
```

**Manual:** verified over HTTP/1.1 and HTTP/2 that the listed header fields
are stripped from the 103 while `Link` is preserved, that multiple consecutive
103 responses still work, and that HTTP/2 no longer resets the stream.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

The `Connection`, `Keep-Alive`, `Upgrade`, `Transfer-Encoding` and
`Content-Length` header fields received in a 103 (Early Hints) response from
an upstream are no longer passed to the client. Previously they could make
the informational response malformed for HTTP/2 and HTTP/3 clients, causing
the request to fail.
