### PR TITLE
GH: restrict the mark_stale job to nginx/nginx

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   mark_stale:
+    if: ${{ github.repository == 'nginx/nginx' }}
     runs-on: ubuntu-24.04
     permissions:
       actions: write


### PR DESCRIPTION
## Problem

Other workflows have some kind of checks whether in current repository or in the repository which workflow is getting included, so they only get run on nginx organizations.

## Solution

Ensure forked repositories do not run this workflow unnecessarily.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [ ] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #ISSUE\_NUMBER

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
