### PR TITLE
HTTP: counted early hints bytes in r->header_size

### DIFF
--- a/src/http/ngx_http_header_filter_module.c
+++ b/src/http/ngx_http_header_filter_module.c
@@ -616,7 +616,7 @@ ngx_http_header_filter(ngx_http_request_t *r)
     /* the end of HTTP header */
     *b->last++ = CR; *b->last++ = LF;
 
-    r->header_size = b->last - b->pos;
+    r->header_size += b->last - b->pos;
 
     if (r->header_only) {
         b->last_buf = 1;
@@ -720,7 +720,7 @@ ngx_http_early_hints_filter(ngx_http_request_t *r)
     /* the end of HTTP early hints */
     *b->last++ = CR; *b->last++ = LF;
 
-    r->header_size = b->last - b->pos;
+    r->header_size += b->last - b->pos;
 
     b->flush = 1;
 


### PR DESCRIPTION
## Problem

`$body_bytes_sent` is inflated by the size of every 103 (Early Hints)
response sent to an HTTP/1.x client.

`ngx_http_early_hints_filter()` assigns `r->header_size`, and the final
`ngx_http_header_filter()` then overwrites it with the size of the last header
block. The bytes written for early hints stay in `c->sent` but disappear from
`r->header_size`, and `$body_bytes_sent` is computed as
`c->sent - r->header_size` (`ngx_http_variables.c`, `ngx_http_log_module.c`).

The HTTP/2 and HTTP/3 header filters already accumulate `header_size` with
`+=`, so they are correct. The result is that the same response reports
different body sizes depending on the protocol:

```
log_format t '$server_protocol sent=$bytes_sent body=$body_bytes_sent';
```

```
HTTP/1.1  sent=294  body=178      <- response body is 3 bytes
HTTP/2.0  sent=185  body=3        <- correct
```

### Reproducer

```nginx
http {
    log_format t '$server_protocol sent=$bytes_sent body=$body_bytes_sent';
    access_log logs/access.log t;

    server {
        listen 127.0.0.1:8899;
        http2 on;
        location / {
            early_hints 1;
            proxy_pass http://127.0.0.1:8898;
        }
    }
}
```

Backend emitting a 103 followed by a 3-byte body:

```python
import socket
s = socket.socket(); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
s.bind(('127.0.0.1', 8898)); s.listen(5)
while True:
    c, _ = s.accept()
    c.recv(65535)
    c.sendall(b"HTTP/1.1 103 Early Hints\r\n"
              b"Link: </style.css>; rel=preload; as=style\r\n"
              b"\r\n"
              b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nhi\n")
    c.close()
```

Request the location over HTTP/1.1 and over HTTP/2 and compare the logged
`body=` values.

## Solution

Both HTTP/1.x header filters now accumulate `r->header_size` instead of
assigning it, matching what the HTTP/2 and HTTP/3 filters already do.

`ngx_http_header_filter()` runs at most once per main request — it returns
early when `r->header_sent` is set, and again when `r != r->main` — so `+=`
is equivalent to the previous assignment when no early hints are sent.

## Testing

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**New test:** `proxy_early_hints_bytes.t`, submitted as
nginx/nginx-tests#90. Against current master it
fails with `/ HTTP/1.1 79` where 8 is expected — 8 body bytes plus the 71-byte
103 response — while the `early_hints 0` and HTTP/2 control cases pass
unchanged.

**Existing tests:** the full suite passes against the patched build — 492
files, 6580 tests, `Result: PASS`. In particular `access_log_variables.t`,
which pins `$bytes_sent` / `$body_bytes_sent` to exact values:

```
proxy_early_hints.t ..... ok
proxy_h2_early_hints.t .. ok
grpc_early_hints.t ...... ok
access_log_variables.t .. ok
proxy_upgrade.t ......... ok
All tests successful.
```

**Manual:** confirmed `$body_bytes_sent` is now 3 on both HTTP/1.1 and HTTP/2
for the reproducer above, and that byte counts are unchanged for plain static
GET, HEAD, 404 error pages, HTTP/1.0 and HTTP/2 requests with no early hints
in play.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

`$body_bytes_sent` no longer includes the bytes of 103 (Early Hints) responses
sent to HTTP/1.x clients. HTTP/2 and HTTP/3 were already correct.