### PR TITLE
SLICE: the slice directive supports variables

### DIFF
--- a/src/http/modules/ngx_http_slice_filter_module.c
+++ b/src/http/modules/ngx_http_slice_filter_module.c
@@ -11,13 +11,15 @@
 
 
 typedef struct {
-    size_t               size;
+    size_t                     size;
+    ngx_http_complex_value_t  *cv;
 } ngx_http_slice_loc_conf_t;
 
 
 typedef struct {
     off_t                start;
     off_t                end;
+    size_t               size;
     ngx_str_t            range;
     ngx_str_t            etag;
     unsigned             last:1;
@@ -46,13 +48,15 @@ static char *ngx_http_slice_merge_loc_conf(ngx_conf_t *cf, void *parent,
     void *child);
 static ngx_int_t ngx_http_slice_add_variables(ngx_conf_t *cf);
 static ngx_int_t ngx_http_slice_init(ngx_conf_t *cf);
+static char *ngx_http_slice_set(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static size_t ngx_http_slice_get_size(ngx_http_request_t *r, ngx_http_slice_loc_conf_t *slcf);
 
 
 static ngx_command_t  ngx_http_slice_filter_commands[] = {
 
     { ngx_string("slice"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_size_slot,
+      ngx_http_slice_set,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_slice_loc_conf_t, size),
       NULL },
@@ -105,7 +109,6 @@ ngx_http_slice_header_filter(ngx_http_request_t *r)
     ngx_int_t                        rc;
     ngx_table_elt_t                 *h;
     ngx_http_slice_ctx_t            *ctx;
-    ngx_http_slice_loc_conf_t       *slcf;
     ngx_http_slice_content_range_t   cr;
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_slice_filter_module);
@@ -159,9 +162,7 @@ ngx_http_slice_header_filter(ngx_http_request_t *r)
                    "http slice response range: %O-%O/%O",
                    cr.start, cr.end, cr.complete_length);
 
-    slcf = ngx_http_get_module_loc_conf(r, ngx_http_slice_filter_module);
-
-    end = ngx_min(cr.start + (off_t) slcf->size, cr.complete_length);
+    end = ngx_min(cr.start + (off_t) ctx->size, cr.complete_length);
 
     if (cr.start != ctx->start || cr.end != end) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
@@ -198,9 +199,9 @@ ngx_http_slice_header_filter(ngx_http_request_t *r)
     r->preserve_body = 1;
 
     if (r->headers_out.status == NGX_HTTP_PARTIAL_CONTENT) {
-        if (ctx->start + (off_t) slcf->size <= r->headers_out.content_offset) {
-            ctx->start = slcf->size
-                         * (r->headers_out.content_offset / slcf->size);
+        if (ctx->start + (off_t) ctx->size <= r->headers_out.content_offset) {
+            ctx->start = ctx->size
+                         * (r->headers_out.content_offset / ctx->size);
         }
 
         ctx->end = r->headers_out.content_offset
@@ -220,7 +221,6 @@ ngx_http_slice_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     ngx_int_t                   rc;
     ngx_chain_t                *cl;
     ngx_http_slice_ctx_t       *ctx;
-    ngx_http_slice_loc_conf_t  *slcf;
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_slice_filter_module);
 
@@ -272,10 +272,8 @@ ngx_http_slice_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
     ngx_http_set_ctx(ctx->sr, ctx, ngx_http_slice_filter_module);
 
-    slcf = ngx_http_get_module_loc_conf(r, ngx_http_slice_filter_module);
-
     ctx->range.len = ngx_sprintf(ctx->range.data, "bytes=%O-%O", ctx->start,
-                                 ctx->start + (off_t) slcf->size - 1)
+                                 ctx->start + (off_t) ctx->size - 1)
                      - ctx->range.data;
 
     ctx->active = 0;
@@ -398,6 +396,7 @@ ngx_http_slice_range_variable(ngx_http_request_t *r,
     u_char                     *p;
     ngx_http_slice_ctx_t       *ctx;
     ngx_http_slice_loc_conf_t  *slcf;
+    size_t                      slice_size;
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_slice_filter_module);
 
@@ -408,8 +407,9 @@ ngx_http_slice_range_variable(ngx_http_request_t *r,
         }
 
         slcf = ngx_http_get_module_loc_conf(r, ngx_http_slice_filter_module);
+        slice_size = ngx_http_slice_get_size(r, slcf);
 
-        if (slcf->size == 0) {
+        if (slice_size == 0) {
             v->not_found = 1;
             return NGX_OK;
         }
@@ -426,11 +426,12 @@ ngx_http_slice_range_variable(ngx_http_request_t *r,
 
         ngx_http_set_ctx(r, ctx, ngx_http_slice_filter_module);
 
-        ctx->start = slcf->size * (ngx_http_slice_get_start(r) / slcf->size);
+        ctx->start = slice_size * (ngx_http_slice_get_start(r) / slice_size);
+        ctx->size = slice_size;
 
         ctx->range.data = p;
         ctx->range.len = ngx_sprintf(p, "bytes=%O-%O", ctx->start,
-                                     ctx->start + (off_t) slcf->size - 1)
+                                     ctx->start + (off_t) slice_size - 1)
                          - p;
     }
 
@@ -443,6 +444,65 @@ ngx_http_slice_range_variable(ngx_http_request_t *r,
     return NGX_OK;
 }
 
+static char *
+ngx_http_slice_set(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_slice_loc_conf_t  *slcf = conf;
+    ngx_str_t                  *value;
+    ngx_http_compile_complex_value_t   ccv;
+
+    if (slcf->size != NGX_CONF_UNSET_SIZE || slcf->cv != NULL) {
+        return "is duplicate";
+    }
+
+    value = cf->args->elts;
+
+    if (value[1].data[0] == '$') {
+        slcf->cv = ngx_palloc(cf->pool, sizeof(ngx_http_complex_value_t));
+        if (slcf->cv == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
+
+        ccv.cf = cf;
+        ccv.value = &value[1];
+        ccv.complex_value = slcf->cv;
+
+        if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+            return NGX_CONF_ERROR;
+        }
+
+        return NGX_CONF_OK;
+    }
+
+    return ngx_conf_set_size_slot(cf, cmd, conf);
+}
+
+static size_t
+ngx_http_slice_get_size(ngx_http_request_t *r, ngx_http_slice_loc_conf_t *slcf)
+{
+    ngx_str_t  val;
+    size_t     size;
+
+    if (slcf->cv) {
+        if (ngx_http_complex_value(r, slcf->cv, &val) != NGX_OK) {
+            return 0;
+        }
+
+        size = ngx_parse_size(&val);
+
+        if (size == (size_t) NGX_ERROR) {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "invalid slice size \"%V\"", &val);
+            return 0;
+        }
+
+        return size;
+    }
+
+    return slcf->size;
+}
 
 static off_t
 ngx_http_slice_get_start(ngx_http_request_t *r)
@@ -504,6 +564,7 @@ ngx_http_slice_create_loc_conf(ngx_conf_t *cf)
     }
 
     slcf->size = NGX_CONF_UNSET_SIZE;
+    slcf->cv = NULL;
 
     return slcf;
 }
@@ -514,6 +575,10 @@ ngx_http_slice_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 {
     ngx_http_slice_loc_conf_t *prev = parent;
     ngx_http_slice_loc_conf_t *conf = child;
+
+    if (conf->size == NGX_CONF_UNSET_SIZE && conf->cv == NULL) {
+        conf->cv = prev->cv;
+    }
 
     ngx_conf_merge_size_value(conf->size, prev->size, 0);
 


### PR DESCRIPTION
## Problem

The slice directive does not support variables

However, in some scenarios, when reverse proxying multiple domain names, different business types require different shard sizes.
for example
1. Installation packages, long videos, and images require large fragments, such as 10mb
2. Small static resources such as css and js may only require 128kb (it doesn’t matter if the slice setting for this business is large)
3. Some business client requests are all 256kb, so the fragmentation of such requests also needs to be accurate to 256kb (for example, the bandwidth back to the original is expensive, and it is necessary to reduce the upstream amplification as much as possible)
These businesses may be under the same location

Therefore, we need to support slice support variables, which can be set based on the request dimension (such as with the Lua stage)

## Solution

The parsing function of the slice directive has been changed from ngx_conf_set_size_slot to the custom ngx_http_slice_set().
If the parameter starts with $, it is compiled into ngx_http_complex_value_t and saved to slcf->cv.
When each request is run, the variable value is obtained through ngx_http_complex_value(), and then converted into the slice size using ngx_parse_size().
The calculated size is saved to the request context ctx->size, and subsequent header/body filters use ctx->size to avoid inconsistencies caused by repeated configurations during a request.
When inheriting configuration, the inheritance logic of variable configuration is also added: when the child location is not configured, it inherits the parent's cv.

## Testing

Compiled and passed

<img width="292" height="42" alt="image" src="https://github.com/user-attachments/assets/eb89dea7-86a4-4b40-ad14-ea5fbccdc3e7" />

Manual Testing

Combined with the lua plug-in, in the lua rewrite stage, different values ​​are set for the variables corresponding to the slice according to different domain names.
The variable defaults to 512k. Some special domain names modify its value. The observed fragment size returned to the upstream response request is in line with expectations, and the cache downloaded to the local is configured with the expected fragment size.
Verification passed

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

No impact on historical configuration (still compatible with non-variable configuration)
