### PR TITLE
Slice filter: restored subrequest context lost in a named location

### DIFF
--- a/src/http/modules/ngx_http_slice_filter_module.c
+++ b/src/http/modules/ngx_http_slice_filter_module.c
@@ -401,6 +401,23 @@ ngx_http_slice_range_variable(ngx_http_request_t *r,
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_slice_filter_module);
 
+    if (ctx == NULL && r != r->main) {
+
+        /*
+         * a named location redirect zeroes the subrequest's module
+         * contexts; restore the slice context from the main request
+         */
+
+        ctx = ngx_http_get_module_ctx(r->main, ngx_http_slice_filter_module);
+
+        if (ctx != NULL && ctx->sr == r) {
+            ngx_http_set_ctx(r, ctx, ngx_http_slice_filter_module);
+
+        } else {
+            ctx = NULL;
+        }
+    }
+
     if (ctx == NULL) {
         if (r != r->main || r->headers_out.status) {
             v->not_found = 1;


### PR DESCRIPTION
### What

When a slice subrequest is redirected into a named location — e.g. by `error_page 302` with `proxy_intercept_errors on` — `ngx_http_named_location()` zeroes the subrequest's module contexts and the slice context is lost. `$slice_range` then evaluates to an empty value in the redirected subrequest:

- the re-proxied request goes upstream without a `Range` header;
- the origin's complete 200 response is appended to the parent response at the slice offset (silent body corruption for the client);
- with `proxy_cache_key` containing `$slice_range`, the complete response is cached under a sliceless key, poisoning the cache for subsequent requests.

The `missing slice response` check added for [trac #1219](https://trac.nginx.org/nginx/ticket/1219) detects the lost context only after the redirected subrequest's response has already been sent to the client and written to the cache, so it stops the infinite loop from that ticket but not this corruption.

### Fix

`ngx_http_slice_range_variable()` now restores the slice context from the main request when a subrequest has none and the main request's context identifies this subrequest (`ctx->sr == r`) as the in-flight slice subrequest. Restoring the context also brings back the slice header filter's 206/etag/Content-Range validation for the redirected fetch.

### References

- [trac #1219 — Subrequest using slice stuck in infinite loop](https://trac.nginx.org/nginx/ticket/1219): same root cause ("When a slice subrequest was redirected to a new location, its context was lost."); the fix there is detect-and-abort rather than recovery.
- [openresty/lua-nginx-module#796](https://github.com/openresty/lua-nginx-module/issues/796): independent report of the same context-wipe mechanism via a named-location redirect from `ngx.exit()`.

Observed in production: slice + `proxy_intercept_errors` + `error_page 302` re-proxying `$upstream_http_location`, against an origin that redirects range requests. Reproduced locally with a minimal config; test in nginx/nginx-tests#98 — passes with this fix applied, fails without it on the corrupt body, the sliceless cache key, and the "missing slice response" error line.


