### PR TITLE
QUIC: apply stream flow control to RESET_STREAM final_size

### DIFF
--- a/src/event/quic/ngx_event_quic_frames.c
+++ b/src/event/quic/ngx_event_quic_frames.c
@@ -809,7 +809,7 @@ ngx_quic_log_frame(ngx_log_t *log, ngx_quic_frame_t *f, ngx_uint_t tx)
 
     case NGX_QUIC_FT_RESET_STREAM:
         p = ngx_slprintf(p, last, "RESET_STREAM"
-                        " id:0x%xL error_code:0x%xL final_size:0x%xL",
+                        " id:0x%xL error_code:0x%xL final_size:%uL",
                         f->u.reset_stream.id, f->u.reset_stream.error_code,
                         f->u.reset_stream.final_size);
         break;

--- a/src/event/quic/ngx_event_quic_streams.c
+++ b/src/event/quic/ngx_event_quic_streams.c
@@ -1260,6 +1260,19 @@ ngx_quic_handle_stream_frame(ngx_connection_t *c, ngx_quic_header_t *pkt,
         return NGX_OK;
     }
 
+    if (qs->recv_final_size != (uint64_t) -1
+        && (qs->recv_final_size < last
+            || (qs->recv_final_size > last && f->fin)))
+    {
+        qc->error = NGX_QUIC_ERR_FINAL_SIZE_ERROR;
+        return NGX_ERROR;
+    }
+
+    if (qs->recv_last > last && f->fin) {
+        qc->error = NGX_QUIC_ERR_FINAL_SIZE_ERROR;
+        return NGX_ERROR;
+    }
+
     if (qs->recv_state != NGX_QUIC_STREAM_RECV_RECV
         && qs->recv_state != NGX_QUIC_STREAM_RECV_SIZE_KNOWN)
     {
@@ -1270,27 +1283,11 @@ ngx_quic_handle_stream_frame(ngx_connection_t *c, ngx_quic_header_t *pkt,
         return NGX_ERROR;
     }
 
-    if (qs->recv_final_size != (uint64_t) -1 && last > qs->recv_final_size) {
-        qc->error = NGX_QUIC_ERR_FINAL_SIZE_ERROR;
-        return NGX_ERROR;
-    }
-
     if (last < qs->recv_offset) {
         return NGX_OK;
     }
 
     if (f->fin) {
-        if (qs->recv_final_size != (uint64_t) -1 && qs->recv_final_size != last)
-        {
-            qc->error = NGX_QUIC_ERR_FINAL_SIZE_ERROR;
-            return NGX_ERROR;
-        }
-
-        if (qs->recv_last > last) {
-            qc->error = NGX_QUIC_ERR_FINAL_SIZE_ERROR;
-            return NGX_ERROR;
-        }
-
         qs->recv_final_size = last;
         qs->recv_state = NGX_QUIC_STREAM_RECV_SIZE_KNOWN;
     }
@@ -1475,16 +1472,6 @@ ngx_quic_handle_reset_stream_frame(ngx_connection_t *c,
         return NGX_OK;
     }
 
-    if (qs->recv_state == NGX_QUIC_STREAM_RECV_RESET_RECVD
-        || qs->recv_state == NGX_QUIC_STREAM_RECV_RESET_READ)
-    {
-        return NGX_OK;
-    }
-
-    if (ngx_quic_control_flow(qs, f->final_size) != NGX_OK) {
-        return NGX_ERROR;
-    }
-
     if (qs->recv_final_size != (uint64_t) -1
         && qs->recv_final_size != f->final_size)
     {
@@ -1494,6 +1481,16 @@ ngx_quic_handle_reset_stream_frame(ngx_connection_t *c,
 
     if (qs->recv_last > f->final_size) {
         qc->error = NGX_QUIC_ERR_FINAL_SIZE_ERROR;
+        return NGX_ERROR;
+    }
+
+    if (qs->recv_state == NGX_QUIC_STREAM_RECV_RESET_RECVD
+        || qs->recv_state == NGX_QUIC_STREAM_RECV_RESET_READ)
+    {
+        return NGX_OK;
+    }
+
+    if (ngx_quic_control_flow(qs, f->final_size) != NGX_OK) {
         return NGX_ERROR;
     }
 

--- a/src/event/quic/ngx_event_quic_streams.c
+++ b/src/event/quic/ngx_event_quic_streams.c
@@ -1481,8 +1481,6 @@ ngx_quic_handle_reset_stream_frame(ngx_connection_t *c,
         return NGX_OK;
     }
 
-    qs->recv_state = NGX_QUIC_STREAM_RECV_RESET_RECVD;
-
     if (ngx_quic_control_flow(qs, f->final_size) != NGX_OK) {
         return NGX_ERROR;
     }
@@ -1500,6 +1498,7 @@ ngx_quic_handle_reset_stream_frame(ngx_connection_t *c,
     }
 
     qs->recv_final_size = f->final_size;
+    qs->recv_state = NGX_QUIC_STREAM_RECV_RESET_RECVD;
 
     if (ngx_quic_update_flow(qs, qs->recv_final_size) != NGX_OK) {
         return NGX_ERROR;


### PR DESCRIPTION
Previously, stream flow control was not applied to the RESET_STREAM final_size, which allowed a client to exceed it.  The excess had to be within the connection flow control limits.

Reported by Tony Wang.