### PR TITLE
Autoindex: Add config variable to list hidden files

### DIFF
--- a/src/http/modules/ngx_http_autoindex_module.c
+++ b/src/http/modules/ngx_http_autoindex_module.c
@@ -42,6 +42,7 @@ typedef struct {
     ngx_uint_t     format;
     ngx_flag_t     localtime;
     ngx_flag_t     exact_size;
+    ngx_flag_t     list_hidden;
 } ngx_http_autoindex_loc_conf_t;
 
 
@@ -110,6 +111,13 @@ static ngx_command_t  ngx_http_autoindex_commands[] = {
       ngx_conf_set_flag_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_autoindex_loc_conf_t, exact_size),
+      NULL },
+
+    { ngx_string("autoindex_list_hidden"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_autoindex_loc_conf_t, list_hidden),
       NULL },
 
       ngx_null_command
@@ -314,7 +322,13 @@ ngx_http_autoindex_handler(ngx_http_request_t *r)
 
         len = ngx_de_namelen(&dir);
 
-        if (ngx_de_name(&dir)[0] == '.') {
+        if (alcf->list_hidden) {
+            if (ngx_strcmp(ngx_de_name(&dir), ".") == 0
+                || ngx_strcmp(ngx_de_name(&dir), "..") == 0)
+            {
+                continue;
+            }
+        } else if (ngx_de_name(&dir)[0] == '.') {
             continue;
         }
 
@@ -1034,6 +1048,7 @@ ngx_http_autoindex_create_loc_conf(ngx_conf_t *cf)
     conf->format = NGX_CONF_UNSET_UINT;
     conf->localtime = NGX_CONF_UNSET;
     conf->exact_size = NGX_CONF_UNSET;
+    conf->list_hidden = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -1050,6 +1065,7 @@ ngx_http_autoindex_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                               NGX_HTTP_AUTOINDEX_HTML);
     ngx_conf_merge_value(conf->localtime, prev->localtime, 0);
     ngx_conf_merge_value(conf->exact_size, prev->exact_size, 1);
+    ngx_conf_merge_value(conf->list_hidden, prev->list_hidden, 0);
 
     return NGX_CONF_OK;
 }


### PR DESCRIPTION
Previously, all files starting with a period would be excluded from automatically generated directory indices. While this is a useful default, listing hidden files has its uses, too.

This fixes a long-standing feature request dating back to 2014.

Fixes: https://github.com/nginx/nginx/issues/289
Fixes: https://trac.nginx.org/nginx/ticket/557

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
