### PR TITLE
Core: reject mixed address families in PROXY v1

### DIFF
--- a/src/core/ngx_proxy_protocol.c
+++ b/src/core/ngx_proxy_protocol.c
@@ -291,6 +291,11 @@ ngx_proxy_protocol_write(ngx_connection_t *c, u_char *buf, u_char *last)
         return NULL;
     }
 
+    if (c->sockaddr->sa_family != c->local_sockaddr->sa_family) {
+        return ngx_cpymem(buf, "PROXY UNKNOWN" CRLF,
+                          sizeof("PROXY UNKNOWN" CRLF) - 1);
+    }
+
     switch (c->sockaddr->sa_family) {
 
     case AF_INET:

--- a/src/core/ngx_proxy_protocol.c
+++ b/src/core/ngx_proxy_protocol.c
@@ -101,6 +101,7 @@ ngx_proxy_protocol_read(ngx_connection_t *c, u_char *buf, u_char *last)
 {
     size_t                 len;
     u_char                *p;
+    ngx_uint_t             family;
     ngx_proxy_protocol_t  *pp;
 
     static const u_char signature[] = "\r\n\r\n\0\r\nQUIT\n";
@@ -134,12 +135,17 @@ ngx_proxy_protocol_read(ngx_connection_t *c, u_char *buf, u_char *last)
         goto invalid;
     }
 
+    family = (p[3] == '4') ? NGX_PROXY_PROTOCOL_AF_INET
+                            : NGX_PROXY_PROTOCOL_AF_INET6;
+
     p += 5;
 
     pp = ngx_pcalloc(c->pool, sizeof(ngx_proxy_protocol_t));
     if (pp == NULL) {
         return NULL;
     }
+
+    pp->family = family;
 
     p = ngx_proxy_protocol_read_addr(c, p, last, &pp->src_addr);
     if (p == NULL) {
@@ -279,12 +285,43 @@ ngx_proxy_protocol_read_port(u_char *p, u_char *last, in_port_t *port,
 u_char *
 ngx_proxy_protocol_write(ngx_connection_t *c, u_char *buf, u_char *last)
 {
-    ngx_uint_t  port, lport;
+    ngx_uint_t             port, lport;
+    ngx_proxy_protocol_t  *pp;
 
     if (last - buf < NGX_PROXY_PROTOCOL_V1_MAX_HEADER) {
         ngx_log_error(NGX_LOG_ALERT, c->log, 0,
                       "too small buffer for PROXY protocol");
         return NULL;
+    }
+
+    pp = c->proxy_protocol;
+
+    if (pp) {
+        switch (pp->family) {
+
+        case NGX_PROXY_PROTOCOL_AF_INET:
+            buf = ngx_cpymem(buf, "PROXY TCP4 ",
+                              sizeof("PROXY TCP4 ") - 1);
+            break;
+
+        case NGX_PROXY_PROTOCOL_AF_INET6:
+            buf = ngx_cpymem(buf, "PROXY TCP6 ",
+                              sizeof("PROXY TCP6 ") - 1);
+            break;
+
+        default:
+            return ngx_cpymem(buf, "PROXY UNKNOWN" CRLF,
+                              sizeof("PROXY UNKNOWN" CRLF) - 1);
+        }
+
+        buf = ngx_cpymem(buf, pp->src_addr.data, pp->src_addr.len);
+
+        *buf++ = ' ';
+
+        buf = ngx_cpymem(buf, pp->dst_addr.data, pp->dst_addr.len);
+
+        return ngx_slprintf(buf, last, " %ui %ui" CRLF, pp->src_port,
+                            pp->dst_port);
     }
 
     if (ngx_connection_local_sockaddr(c, NULL, 0) != NGX_OK) {
@@ -409,6 +446,7 @@ ngx_proxy_protocol_v2_read(ngx_connection_t *c, u_char *buf, u_char *last)
 
         pp->src_port = ngx_proxy_protocol_parse_uint16(in->src_port);
         pp->dst_port = ngx_proxy_protocol_parse_uint16(in->dst_port);
+        pp->family = family;
 
         socklen = sizeof(struct sockaddr_in);
 
@@ -436,6 +474,7 @@ ngx_proxy_protocol_v2_read(ngx_connection_t *c, u_char *buf, u_char *last)
 
         pp->src_port = ngx_proxy_protocol_parse_uint16(in6->src_port);
         pp->dst_port = ngx_proxy_protocol_parse_uint16(in6->dst_port);
+        pp->family = family;
 
         socklen = sizeof(struct sockaddr_in6);
 

--- a/src/core/ngx_proxy_protocol.h
+++ b/src/core/ngx_proxy_protocol.h
@@ -22,6 +22,7 @@ struct ngx_proxy_protocol_s {
     ngx_str_t           dst_addr;
     in_port_t           src_port;
     in_port_t           dst_port;
+    ngx_uint_t          family;
     ngx_str_t           tlvs;
 };
 


### PR DESCRIPTION
## Problem

PROXY protocol v1 requires the source and destination addresses to use the same address family. After a realip module replaces the remote address, it can differ from the family of the accepted socket local address. `ngx_proxy_protocol_write()` then emits invalid lines such as:

```
PROXY TCP6 2001:db8::1 127.0.0.1 1234 8083
```

This reproduces nginx/nginx#1609 and causes strict downstream parsers to reject the connection.

## Solution

Emit the standard `PROXY UNKNOWN` form when the remote and local socket address families differ. Same-family IPv4 and IPv6 output is unchanged.

## Testing

A companion nginx-tests change covers both directions:

- IPv6 remote address over an IPv4 accepted socket;
- IPv4 remote address over an IPv6 accepted socket.

Against master the first case returns the invalid mixed `TCP6` line. With this patch both return `PROXY UNKNOWN`. The following related tests pass against a build with stream, stream realip, and mail enabled:

```
stream_proxy_protocol.t        6/6
stream_proxy_protocol_ipv6.t   4/4
stream_realip.t               10/10
mail_proxy_protocol.t         10/10
Result: PASS
```

Closes: https://github.com/nginx/nginx/issues/1609

## Release Notes

PROXY protocol v1 output now uses `UNKNOWN` when the source and destination address families differ, instead of emitting an invalid mixed-family `TCP4` or `TCP6` header.

Companion tests: https://github.com/nginx/nginx-tests/pull/91