### PR TITLE
QUIC: let handshake recovery bypass congestion

### DIFF
--- a/src/event/quic/ngx_event_quic_ack.c
+++ b/src/event/quic/ngx_event_quic_ack.c
@@ -906,7 +906,7 @@ ngx_quic_congestion_lost(ngx_connection_t *c, ngx_quic_frame_t *f)
     /* RFC 9438, 4.7. Fast Convergence */
     cg->w_max = (cg->window < cg->w_max)
                 ? cg->window * (10 + NGX_QUIC_CUBIC_BETA) / 20 : cg->window;
-    cg->ssthresh = cg->in_flight * NGX_QUIC_CUBIC_BETA / 10;
+    cg->ssthresh = cg->w_prior * NGX_QUIC_CUBIC_BETA / 10;
     cg->window = ngx_max(cg->ssthresh, cg->mtu * 2);
     cg->w_est = cg->window;
     cg->k = now + ngx_quic_congestion_cubic_time(c);

--- a/src/event/quic/ngx_event_quic_ack.c
+++ b/src/event/quic/ngx_event_quic_ack.c
@@ -841,6 +841,12 @@ ngx_quic_resend_frames(ngx_connection_t *c, ngx_quic_send_ctx_t *ctx)
             /* fall through */
 
         default:
+            if (f->type == NGX_QUIC_FT_CRYPTO
+                && ctx->level != NGX_QUIC_ENCRYPTION_APPLICATION)
+            {
+                f->ignore_congestion = 1;
+            }
+
             ngx_queue_insert_tail(&ctx->frames, &f->queue);
         }
 

--- a/src/event/quic/ngx_event_quic_output.c
+++ b/src/event/quic/ngx_event_quic_output.c
@@ -592,7 +592,9 @@ ngx_quic_output_packet(ngx_connection_t *c, ngx_quic_send_ctx_t *ctx,
     {
         f = ngx_queue_data(q, ngx_quic_frame_t, queue);
 
-        if (ack_only && f->type != NGX_QUIC_FT_ACK) {
+        if (ack_only && f->type != NGX_QUIC_FT_ACK
+            && !f->ignore_congestion)
+        {
             break;
         }
 


### PR DESCRIPTION
## Summary

Signal the existing QUIC "speeding up handshake completion" recovery path to resend Initial and Handshake CRYPTO with a temporary congestion bypass. Teach the main packet builder to honor the existing `ignore_congestion` frame flag.

This replaces the earlier CUBIC-window adjustment. It does not change normal congestion-window reduction: ordinary loss recovery passes no bypass and clears any prior CRYPTO bypass flag. Only the duplicate-Initial recovery path requests it.

## Rationale

When the certificate flight fills the initial congestion window, a lost Initial CRYPTO frame can be requeued but never emitted. The peer cannot acknowledge the outstanding Handshake flight until it receives that Initial data, so the congestion window cannot reopen.

The scoped bypass follows the direction suggested in #1616: explicitly identify the special handshake-completion resend instead of exempting every handshake loss.

Reported, traced, and reproduced by @Ozy-666 in #1616. Their broader two-hunk prototype completed 200/200 lossy handshakes; this revision narrows the bypass to the intended recovery trigger.

## Verification

- rebased onto current `master`
- strict Clang build with HTTP/3, HTTP SSL, OpenSSL 3, `-Wall -Wextra -Werror`: passed
- official QUIC/HTTP/3 `nginx-tests`: 24 files, 331 tests passed
- two environment-only skips: HTTP/2 was not built; `127.0.0.20` was unavailable for migration
- `git diff --check`: passed

Closes #1616.