### PR TITLE
Mail: reject CR and LF in POP3 credentials sent to backend

### DIFF
--- a/src/mail/ngx_mail_proxy_module.c
+++ b/src/mail/ngx_mail_proxy_module.c
@@ -25,6 +25,8 @@ typedef struct {
 
 static void ngx_mail_proxy_block_read(ngx_event_t *rev);
 static void ngx_mail_proxy_pop3_handler(ngx_event_t *rev);
+static ngx_int_t ngx_mail_proxy_check_pop3_credential(ngx_mail_session_t *s,
+    ngx_str_t *value);
 static void ngx_mail_proxy_imap_handler(ngx_event_t *rev);
 static void ngx_mail_proxy_smtp_handler(ngx_event_t *rev);
 static void ngx_mail_proxy_write_handler(ngx_event_t *wev);
@@ -281,6 +283,11 @@ ngx_mail_proxy_pop3_handler(ngx_event_t *rev)
 
         s->connection->log->action = "sending user name to upstream";
 
+        if (ngx_mail_proxy_check_pop3_credential(s, &s->login) != NGX_OK) {
+            ngx_mail_proxy_internal_server_error(s);
+            return;
+        }
+
         line.len = sizeof("USER ")  - 1 + s->login.len + 2;
         line.data = ngx_pnalloc(c->pool, line.len);
         if (line.data == NULL) {
@@ -299,6 +306,11 @@ ngx_mail_proxy_pop3_handler(ngx_event_t *rev)
         ngx_log_debug0(NGX_LOG_DEBUG_MAIL, rev->log, 0, "mail proxy send pass");
 
         s->connection->log->action = "sending password to upstream";
+
+        if (ngx_mail_proxy_check_pop3_credential(s, &s->passwd) != NGX_OK) {
+            ngx_mail_proxy_internal_server_error(s);
+            return;
+        }
 
         line.len = sizeof("PASS ")  - 1 + s->passwd.len + 2;
         line.data = ngx_pnalloc(c->pool, line.len);
@@ -360,6 +372,32 @@ ngx_mail_proxy_pop3_handler(ngx_event_t *rev)
 
     s->proxy->buffer->pos = s->proxy->buffer->start;
     s->proxy->buffer->last = s->proxy->buffer->start;
+}
+
+
+static ngx_int_t
+ngx_mail_proxy_check_pop3_credential(ngx_mail_session_t *s, ngx_str_t *value)
+{
+    /*
+     * POP3 USER/PASS arguments are terminated by CRLF and the protocol
+     * has no way to carry a CR or LF within them; such a byte in a
+     * credential (only possible via a SASL-decoded value) would be relayed
+     * as an additional command line into the authenticated upstream session.
+     * The auth server is the authority on credential validity, but since the
+     * downstream protocol cannot represent these bytes, reject them here
+     * rather than emit a request that is known to be invalid.  IMAP (counted
+     * literals) and SMTP (base64 AUTH) are not affected.
+     */
+
+    if (ngx_strlchr(value->data, value->data + value->len, CR) != NULL
+        || ngx_strlchr(value->data, value->data + value->len, LF) != NULL)
+    {
+        ngx_log_error(NGX_LOG_ERR, s->connection->log, 0,
+                      "upstream POP3 credential contains CR or LF");
+        return NGX_ERROR;
+    }
+
+    return NGX_OK;
 }
 
 


### PR DESCRIPTION
## Problem

The POP3 proxy relays credentials to the backend by copying `s->login` and
`s->passwd` verbatim into `USER <login>` and `PASS <passwd>` command lines.
These lines are terminated by CRLF, and POP3 has no syntax -- no counted
literal, no quoting -- that can carry a CR or LF inside a command argument.

A credential can nevertheless contain those bytes: with plain `USER`/`PASS`
client authentication the values come from a parsed command line and cannot,
but a SASL-decoded value (`AUTH PLAIN`, `AUTH LOGIN`, `AUTH EXTERNAL`,
`AUTH CRAM-MD5`) is arbitrary binary. Such a credential turns one command
into two command lines to the backend, with two consequences:

1. Response accounting with the backend breaks. The extra line elicits an
   extra response, so nginx reads the wrong reply for the wrong command.
   Observed against a backend that answers unknown commands: authentication
   fails and the client is handed `-ERR unknown command`, which is the
   backend's reply to the injected line, not to `PASS`.

2. The trailing part of the credential is delivered as a command line in the
   authenticated backend session.

Credentials are validated by the auth server, which is the authority in
nginx's model (`ngx_mail_auth_http_module`), so this is defence in depth
rather than a gap in that contract. The point is narrower: when the
downstream protocol provably cannot represent a value, emitting it anyway is
never right, and nginx already applies this reasoning to the SMTP `XCLIENT`
`LOGIN=` argument, which is escaped before it is sent.

## Solution

Reject CR and LF where the backend command line is built, in
`ngx_mail_proxy_pop3_handler()`: before `USER` (checking `s->login`) and
before `PASS` (checking `s->passwd`). On such a value the upstream attempt is
aborted with `ngx_mail_proxy_internal_server_error()`, so nothing is relayed,
and the reason is logged.

The check is deliberately placed at the relay layer and scoped to POP3,
because that is where the constraint actually exists:

- POP3 -- raw value in a CRLF-terminated command line, no way to represent
  these bytes. Affected, and guarded.
- IMAP -- credentials are sent as counted literals (`{n}` CRLF, then exactly
  `n` bytes), so a CR or LF is literal data and not a command separator. Not
  affected, and left unchanged.
- SMTP -- credentials go base64-encoded in `AUTH PLAIN`, and the `XCLIENT`
  `LOGIN=` argument is escaped. Not affected, and left unchanged.

Two alternatives were considered and rejected. Checking in the SASL decoders
instead would reject values that are legitimate elsewhere: RFC 4616 permits
LF and CR in SASL PLAIN productions (control characters are prohibited for
`passwd` and `authcid`, but for `authzid` the applicable rules come from the
SASL profile), and it would also constrain IMAP, where these bytes transit
correctly. Escaping rather than rejecting has no meaning here, as POP3
defines no escape for them.

## Testing

Built with `-Werror`.

- Manual: with an auth server that accepts such a credential and a backend
  that records the lines it receives, `AUTH PLAIN` with a CR/LF in the login
  causes the backend to receive the injected line before the change, and
  after the change the upstream attempt is aborted, the client gets an error,
  and the backend receives nothing. The same holds for a CR/LF in the
  password, on the `PASS` path.
- Functional: new `mail_proxy_pop3.t`, covering both the login and the
  password path. The backend daemon records any command line it did not
  expect, retrievable by the client after login, so the assertions do not
  depend on response timing. Verified failing before the change and passing
  after it; the new cases are `TODO` until the change is released.
- Regression: the full mail suite passes on the patched binary (277 tests),
  including `mail_pop3.t`, `mail_imap.t`, `mail_smtp.t`,
  `mail_smtp_xclient.t` and `mail_proxy_protocol.t`.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

Test PR: nginx/nginx-tests#93

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

Bugfix: a CR or LF in a SASL-decoded credential was sent to the POP3 backend
as an additional command line, breaking the proxied authentication. Such
credentials are now rejected. IMAP and SMTP are not affected.
