### PR TITLE
HTTP/3: reject frame length that does not fit ngx_uint_t

### DIFF
--- a/src/http/v3/ngx_http_v3_parse.c
+++ b/src/http/v3/ngx_http_v3_parse.c
@@ -304,6 +304,12 @@ ngx_http_v3_parse_headers(ngx_connection_t *c, ngx_http_v3_parse_headers_t *st,
                 return rc;
             }
 
+            /* a frame length exceeding ngx_uint_t would be truncated */
+
+            if (st->vlint.value > (uint64_t) NGX_MAX_INT_T_VALUE) {
+                return NGX_HTTP_V3_ERR_FRAME_ERROR;
+            }
+
             st->length = st->vlint.value;
 
             ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
@@ -1251,6 +1257,12 @@ ngx_http_v3_parse_control(ngx_connection_t *c, ngx_http_v3_parse_control_t *st,
             ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
                            "http3 parse frame len:%uL", st->vlint.value);
 
+            /* a frame length exceeding ngx_uint_t would be truncated */
+
+            if (st->vlint.value > (uint64_t) NGX_MAX_INT_T_VALUE) {
+                return NGX_HTTP_V3_ERR_FRAME_ERROR;
+            }
+
             st->length = st->vlint.value;
             if (st->length == 0) {
                 st->state = sw_type;
@@ -1852,6 +1864,12 @@ ngx_http_v3_parse_data(ngx_connection_t *c, ngx_http_v3_parse_data_t *st,
             rc = ngx_http_v3_parse_varlen_int(c, &st->vlint, b);
             if (rc != NGX_DONE) {
                 return rc;
+            }
+
+            /* a frame length exceeding ngx_uint_t would be truncated */
+
+            if (st->vlint.value > (uint64_t) NGX_MAX_INT_T_VALUE) {
+                return NGX_HTTP_V3_ERR_FRAME_ERROR;
             }
 
             st->length = st->vlint.value;


### PR DESCRIPTION
An HTTP/3 frame length is a QUIC variable-length integer of up to 62 bits, but the parser stored it in the `ngx_uint_t` field `st->length`. On 32-bit builds the upper bits were silently truncated, so a frame declaring a length above `NGX_MAX_INT_T_VALUE` was parsed with a wrong length, driving the HEADERS/DATA/skip state machines with a truncated value.

This adds a bounds check at the three frame-length parse sites (`ngx_http_v3_parse_headers`, `ngx_http_v3_parse_control`, `ngx_http_v3_parse_data`), rejecting such a frame length with `H3_FRAME_ERROR` before it is narrowed.

Notes:

- This is a robustness fix, not a security fix. The frame length is never used to size an allocation -- it only bounds reads and skips -- so truncation cannot cause memory corruption; the observable effect on 32-bit is a truncated/misparsed frame.
- 64-bit builds are unaffected: a 62-bit varint always fits in `ngx_uint_t`, so `value > NGX_MAX_INT_T_VALUE` is never true and parsing is unchanged.
- Consistent with existing over-large-value guards, e.g. the `NGX_MAX_INT_T_VALUE / 8` check in `ngx_http_v3_parse_literal` and the response content-length check in `ngx_http_v3_filter_module`.
