### PR TITLE
Upstream: reject zero `WINDOW_UPDATE` increments

### DIFF
--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -3865,6 +3865,12 @@ ngx_http_grpc_parse_window_update(ngx_http_request_t *r,
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "grpc window update: %ui", ctx->window_update);
 
+    if (ctx->window_update == 0) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "upstream sent zero window update");
+        return NGX_ERROR;
+    }
+
     if (ctx->stream_id) {
 
         if (ctx->window_update > (size_t) NGX_HTTP_V2_MAX_WINDOW

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -3690,6 +3690,12 @@ ngx_http_proxy_v2_parse_window_update(ngx_http_request_t *r,
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http proxy window update: %ui", ctx->window_update);
 
+    if (ctx->window_update == 0) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "upstream sent zero window update");
+        return NGX_ERROR;
+    }
+
     if (ctx->stream_id) {
 
         if (ctx->window_update > (size_t) NGX_HTTP_V2_MAX_WINDOW


### PR DESCRIPTION
## Problem

The HTTP/2 proxy and gRPC upstream clients accepted `WINDOW_UPDATE` frames with a zero flow-control window increment.

[RFC 9113 Section 6.9](https://datatracker.ietf.org/doc/html/rfc9113#name-window_update) defines the legal increment range as $1$ through $2^{31} - 1$. A zero increment must be treated as a `PROTOCOL_ERROR`, at either stream or connection scope.

Previously, nginx added the zero increment to the corresponding window and continued processing the upstream response. A malformed upstream could therefore send an invalid frame and still complete the request successfully.

  ## Solution

  Reject zero-increment `WINDOW_UPDATE` frames in both HTTP/2 upstream
  implementations.

  The frame is logged as invalid and processing returns `NGX_ERROR`,
  causing the malformed upstream response to be rejected instead of
  forwarded as successful.

  ## Testing

  Companion regression tests: [nginx/nginx-tests#95](https://github.com/nginx/nginx-tests/pull/95)

  The tests cover all four combinations:

  - HTTP/2 proxy, stream-scoped `WINDOW_UPDATE`
  - HTTP/2 proxy, connection-scoped `WINDOW_UPDATE`
  - gRPC upstream, stream-scoped `WINDOW_UPDATE`
  - gRPC upstream, connection-scoped `WINDOW_UPDATE`

  Against nginx without this change, all four cases fail because nginx
  returns `200 OK`. With this change, nginx rejects each malformed
  upstream response with `502 Bad Gateway`.

  Relevant test suites pass:

  ```text
  grpc.t ................... ok
  proxy_h2_body_discard.t .. ok
  All tests successful.
  Files=2, Tests=161
  Result: PASS
```
