### PR TITLE
HTTP: enforce max_headers for selected virtual server

### DIFF
--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -1560,6 +1560,21 @@ ngx_http_process_request_headers(ngx_event_t *rev)
 
             r->request_length += r->header_in->pos - r->header_name_start;
 
+            /*
+             * the host header could have changed the server configuration
+             * context; recheck the total header count against the
+             * selected virtual server's max_headers
+             */
+
+            if (r->headers_in.count > cscf->max_headers) {
+                r->lingering_close = 1;
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "client sent too many header lines");
+                ngx_http_finalize_request(r,
+                                          NGX_HTTP_REQUEST_HEADER_TOO_LARGE);
+                break;
+            }
+
             r->http_state = NGX_HTTP_PROCESS_REQUEST_STATE;
 
             rc = ngx_http_process_request_header(r);


### PR DESCRIPTION
 ## Problem

  For HTTP/1.x origin-form requests, the Host header can change the virtual
  server configuration while request headers are being parsed.

  If Host is the final header, preceding headers are checked against the
  default server's max_headers value. A permissive default server therefore
  allows a request to exceed the selected virtual server's stricter limit.

  ## Solution

  Recheck the completed request header count after virtual server selection,
  before processing the request.

  ## Testing

  - [x] Manual Testing
  - [x] Functional Testing (nginx-tests)

  Verified with a standalone Host-first/Host-last reproducer and the
  `http_max_headers.t` and `http_host.t` tests.

Reproducer shell script is available as [gist](https://gist.github.com/felix314159/c25cbbb09621c3f7aea5436850c19e1e).
