### PR TITLE
HTTP/3: cleared frame length after skipping a frame

### DIFF
--- a/src/http/v3/ngx_http_v3_parse.c
+++ b/src/http/v3/ngx_http_v3_parse.c
@@ -90,6 +90,7 @@ ngx_http_v3_parse_skip(ngx_buf_t *b, ngx_uint_t *length)
     }
 
     b->pos += *length;
+    *length = 0;
     return NGX_DONE;
 }
 


### PR DESCRIPTION
## Problem

Over HTTP/3, nginx wrongly rejects a valid request with `400 client prematurely closed stream` when the client sends a reserved ("GREASE") frame on a request stream whose body nginx reads. If such a frame appears between DATA frames, framing bytes are spliced into the request body instead. Instead, unknown frames should be skipped entirely.

## Solution

`ngx_http_v3_parse_skip()` advances past a skipped frame's payload but leaves the `st.length` set in one of its branches. That value is only reassigned when the next frame's length is read, so if the buffer ends right after the skipped frame the counter stays stale. `ngx_http_v3_request_body_filter()` then reads it, either as a truncated body (the 400) or as body bytes still owed (the splice).

We adjust `*length = 0` to correctly signal a full skip inside of `ngx_http_v3_parse_skip()`.

## Testing

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests)) (will add soon)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes — in nginx-tests
- [x] All existing tests pass
- [x] I have updated documentation where necessary — N/A (bug fix, no directive/behaviour docs)
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards