### PR TITLE
Fixed overflow detection in chunked parser

### DIFF
--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -2420,7 +2420,7 @@ data:
     ctx->state = state;
     b->pos = pos;
 
-    if (ctx->size > NGX_MAX_OFF_T_VALUE - 5) {
+    if (ctx->size > NGX_MAX_OFF_T_VALUE - 9) {
         goto invalid;
     }
 


### PR DESCRIPTION
This was broken in f405ef11f (1.29.4).

Reported by Matt Suiche, Tolmo Inc.
