### PR TITLE
HTTP: accept HTAB as OWS in Accept-Encoding

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -2279,7 +2279,11 @@ ngx_http_gzip_accept_encoding(ngx_str_t *ae)
             return NGX_DECLINED;
         }
 
-        if (p == start || (*(p - 1) == ',' || *(p - 1) == ' ')) {
+        if (p == start
+            || *(p - 1) == ','
+            || *(p - 1) == ' '
+            || *(p - 1) == '\t')
+        {
             break;
         }
 
@@ -2295,6 +2299,7 @@ ngx_http_gzip_accept_encoding(ngx_str_t *ae)
         case ';':
             goto quantity;
         case ' ':
+        case '\t':
             continue;
         default:
             return NGX_DECLINED;
@@ -2311,6 +2316,7 @@ quantity:
         case 'Q':
             goto equal;
         case ' ':
+        case '\t':
             continue;
         default:
             return NGX_DECLINED;
@@ -2353,7 +2359,7 @@ ngx_http_gzip_quantity(u_char *p, u_char *last)
 
     c = *p++;
 
-    if (c == ',' || c == ' ') {
+    if (c == ',' || c == ' ' || c == '\t') {
         return q;
     }
 
@@ -2366,7 +2372,7 @@ ngx_http_gzip_quantity(u_char *p, u_char *last)
     while (p < last) {
         c = *p++;
 
-        if (c == ',' || c == ' ') {
+        if (c == ',' || c == ' ' || c == '\t') {
             break;
         }
 


### PR DESCRIPTION
The gzip filter helper in `ngx_http_core_module.c` carries its own
boundary check on Accept-Encoding tokens, and was deliberately
left unchanged in the recent multi-header parser rework
(nginx#1577, currently OPEN with Vadim actively iterating on the
review thread as of 2026-08-08).

Per RFC 9110 §5.6.2 / §5.6.3, optional whitespace is SP / HTAB and
the field grammar (`#rule`) accepts OWS around commas and around
the q-value separator. Extending the boundary check and the two
single-character switches to recognise HTAB brings the helper in
line with the HTTP/1 parser (RFC 9112 §2.2) and the multi-header
parser that nginx#1577 is teaching to recognise HTAB.

The malformed-input case (two tokens joined by HTAB only, no comma)
continues to be rejected; RFC 9110 §5.6.2 requires comma separators
between elements, and whitespace alone is not enough. That assertion
is held as a baseline regression in [nginx-tests#97](https://github.com/nginx/nginx-tests/pull/97),
alongside the forward-looking TODO cases for the three HTAB positions
that currently fall through to the `default` branch.

## Testing

Built with `auto/configure --with-debug && make -j$(nproc)` and run
via the nginx-tests harness at [nginx-tests#97](https://github.com/nginx/nginx-tests/pull/97):

```text
# Master (no patch): 9 tests, 3 TODO-fail, suite PASS
# Patched: 9/9 pass, all 3 TODO cases succeed
# gzip.t regression on patched: 10/10 pass
```

The TODO block in [nginx-tests#97](https://github.com/nginx/nginx-tests/pull/97) documents the three HTAB positions
that need the patch to pass:

- HTAB before comma (`gzip\t,deflate`)
- HTAB inside the quantity scan (`gzip;\tq=0.5`)
- HTAB after the q-value before the comma (`gzip;q=0.5\t,deflate`)

Plus the regression baseline for the malformed-input case
(`gzip\tdeflate`, no comma), which continues to be rejected.

## Companion test PR

[nginx-tests#97](https://github.com/nginx/nginx-tests/pull/97): Tests: gzip Accept-Encoding HTAB whitespace
(marked Ready for Review).

## References

- nginx#1577: multi-header parser rework by Vadim, currently
  OPEN. Vadim explicitly carved `ngx_http_gzip_accept_encoding()`
  out because the helper carries its own boundary check.
  See also Vadim's note that Copilot review caught a real
  regression in an earlier revision of that PR, motivating the
  careful audit of pre-existing vs. introduced defects.
- RFC 9110 §5.6.2: optional whitespace definition (OWS = SP / HTAB).
- RFC 9110 §5.6.3: Accept-Encoding field grammar (`#rule`).
- RFC 9112 §2.2: OWS strip at field-value boundary in HTTP/1.
