### PR TITLE
Core: set PR_SET_DUMPABLE only when a core dump can be produced

### DIFF
--- a/src/os/unix/ngx_process_cycle.c
+++ b/src/os/unix/ngx_process_cycle.c
@@ -749,6 +749,41 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
 }
 
 
+#if (NGX_HAVE_PR_SET_DUMPABLE)
+
+static ngx_int_t
+ngx_core_pattern_is_pipe(void)
+{
+    u_char    c;
+    ssize_t   n;
+    ngx_fd_t  fd;
+
+    /*
+     * A core_pattern starting with '|' pipes the dump to a handler, and
+     * the kernel applies no RLIMIT_CORE on that path: coredump_pipe()
+     * sets the limit to RLIM_INFINITY, and the limit is consulted only
+     * when dumping to a file.  There the dumpable flag alone decides
+     * whether a crash is captured, so it must be left set whatever the
+     * limit says.  If the value cannot be read, keep the old behaviour.
+     */
+
+    fd = ngx_open_file("/proc/sys/kernel/core_pattern", NGX_FILE_RDONLY,
+                       NGX_FILE_OPEN, 0);
+
+    if (fd == NGX_INVALID_FILE) {
+        return 1;
+    }
+
+    n = ngx_read_fd(fd, &c, 1);
+
+    ngx_close_file(fd);
+
+    return (n == 1 && c == '|');
+}
+
+#endif
+
+
 static void
 ngx_worker_process_init(ngx_cycle_t *cycle, ngx_int_t worker)
 {
@@ -860,11 +895,27 @@ ngx_worker_process_init(ngx_cycle_t *cycle, ngx_int_t worker)
 
 #if (NGX_HAVE_PR_SET_DUMPABLE)
 
-    /* allow coredump after setuid() in Linux 2.4.x */
+    /*
+     * Allow coredump after setuid() in Linux 2.4.x, but only when a core
+     * dump can actually be written.  A dumpable process is attachable
+     * with ptrace(2) and its /proc/<pid>/mem is readable by any process
+     * running under the worker's user, which the kernel prevents at
+     * setuid() by clearing the flag.
+     *
+     * The effective RLIMIT_CORE is the condition, rather than whether
+     * worker_rlimit_core was configured: nginx leaves RLIMIT_CORE alone
+     * when the directive is absent, so an inherited limit governs.  A
+     * failing getrlimit() preserves the previous behaviour.
+     */
 
-    if (prctl(PR_SET_DUMPABLE, 1, 0, 0, 0) == -1) {
-        ngx_log_error(NGX_LOG_ALERT, cycle->log, ngx_errno,
-                      "prctl(PR_SET_DUMPABLE) failed");
+    if (ngx_core_pattern_is_pipe()
+        || getrlimit(RLIMIT_CORE, &rlmt) == -1
+        || rlmt.rlim_cur != 0)
+    {
+        if (prctl(PR_SET_DUMPABLE, 1, 0, 0, 0) == -1) {
+            ngx_log_error(NGX_LOG_ALERT, cycle->log, ngx_errno,
+                          "prctl(PR_SET_DUMPABLE) failed");
+        }
     }
 
 #endif


### PR DESCRIPTION
## Problem

`ngx_worker_process_init()` calls `prctl(PR_SET_DUMPABLE, 1, ...)` unconditionally after the
privilege drop. The comment above it reads *"allow coredump after setuid() in Linux 2.4.x"*, so the
intent is to make `worker_rlimit_core` usable — but the flag is restored in every deployment,
including those where no core dump can be written at all.

The dumpable flag governs more than core dumps. When a process changes credentials the kernel resets
it — `commit_creds()` sets it to `fs.suid_dumpable`, `0` by default — so a process that has dropped
privilege is no longer attachable by processes that merely share its new user. `__ptrace_may_access()`
and `task_dump_owner()` both key off it. Restoring it also restores `PTRACE_ATTACH` and read access
to `/proc/<pid>/mem` for any process running as the worker's user, commonly a shared account such as
`www-data` that other components on the host may also run under.

Two things bound that exposure, and both are measured below.

Yama gates the same access: `kernel.yama.ptrace_scope` defaults to `1`, which admits only an
ancestor, so a same-user non-ancestor is refused whatever the dumpable flag says. Debian 12/13 and
Ubuntu 24.04 run at `1`. The value that matters here is `0`, and on Fedora and RHEL 9 that is what a
host gets once a debugger is installed: `elfutils-default-yama-scope` ships
`/usr/lib/sysctl.d/10-default-yama-scope.conf` containing `kernel.yama.ptrace_scope = 0`, and it is a
hard `Requires` of `elfutils-libs`, which `gdb`, `strace` and `perf` all pull in. On those hosts the
`0` is a consequence of installing `strace`, not a decision that every process running as `www-data`
may read the worker's address space.

And the effective `RLIMIT_CORE` decides whether the flag buys anything at all. Under systemd a
service gets a soft limit of `0` by default — `systemctl show --property=DefaultLimitCORESoft --value`
returns `0`, and the packaged `nginx.service` sets no `LimitCORE` — so on a stock systemd host with a
file `core_pattern`, nginx today leaves the worker attachable by its own user while the kernel will
not write a core for it under any circumstance.

## Solution

Gate the `prctl()` on whether a core dump could actually be produced:

```c
    if (ngx_core_pattern_is_pipe()
        || getrlimit(RLIMIT_CORE, &rlmt) == -1
        || rlmt.rlim_cur != 0)
    {
        if (prctl(PR_SET_DUMPABLE, 1, 0, 0, 0) == -1) {
            ngx_log_error(NGX_LOG_ALERT, cycle->log, ngx_errno,
                          "prctl(PR_SET_DUMPABLE) failed");
        }
    }
```

nginx leaves `RLIMIT_CORE` alone unless `worker_rlimit_core` is configured, so the inherited limit is
what decides whether a core can be written to a file. The gate runs after the existing
`worker_rlimit_core` `setrlimit()` block and reuses the `rlmt` already declared in the function, so
`worker_rlimit_core` needs no special case.

The `core_pattern` test is there because `RLIMIT_CORE` does not govern the pipe path. In
`fs/coredump.c`, `coredump_skip()` consults only the dumpable flag; the limit comparison
(`cprm->limit < binfmt->min_coredump`) lives inside `coredump_file()`; and `coredump_pipe()` sets
`cprm->limit = RLIM_INFINITY` outright, commented *"core limits are irrelevant to pipes"*. So
wherever `core_pattern` begins with `|` — which is what `systemd-coredump` installs, along with
`fs.suid_dumpable=2` — the dumpable flag is the only thing deciding whether a crash is captured, and
it has to be left set. Both `getrlimit()` and the `core_pattern` read fail open, preserving current
behaviour.

Two earlier revisions of this PR were wrong and are worth recording. The first gated on
`ccf->rlimit_core != NGX_CONF_UNSET`; @ac000 reported that it removed core dumps from anyone relying
on an inherited `ulimit -c` and that `worker_rlimit_core 0;` would still have set the flag, and both
reproduced. The second fixed those but still cleared the flag on pipe `core_pattern` hosts, which
would have stopped `systemd-coredump` from capturing worker crashes on Fedora, RHEL and any other
host using a handler. That is the regression this revision removes.

## Testing

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

Three binaries built from the same tree with identical `configure` arguments, differing only in this
commit's contents: `master`, the previous revision of this PR, and this one. Every arm asserts the
`sha256` of `/proc/<worker>/exe` against the binary it meant to start, so no arm can silently measure
a different build. "dumpable" below is read as the ownership of `/proc/<worker>/mem`, which
`task_dump_owner()` forces to `root:root` when the flag is clear.

```
core_pattern = /var/…/core.%e.%p          (a file)
    master        ulimit -c=0          RLIMIT_CORE=0          -> dumpable
    prev revision ulimit -c=0          RLIMIT_CORE=0          -> not dumpable
    this revision ulimit -c=0          RLIMIT_CORE=0          -> not dumpable
    master        ulimit -c=unlimited  RLIMIT_CORE=unlimited  -> dumpable
    prev revision ulimit -c=unlimited  RLIMIT_CORE=unlimited  -> dumpable
    this revision ulimit -c=unlimited  RLIMIT_CORE=unlimited  -> dumpable

core_pattern = |/bin/dd of=… bs=1M        (a handler)
    master        ulimit -c=0          RLIMIT_CORE=0          -> dumpable
    prev revision ulimit -c=0          RLIMIT_CORE=0          -> not dumpable   <-- the regression
    this revision ulimit -c=0          RLIMIT_CORE=0          -> dumpable       <-- fixed
    master        ulimit -c=unlimited  RLIMIT_CORE=unlimited  -> dumpable
    prev revision ulimit -c=unlimited  RLIMIT_CORE=unlimited  -> dumpable
    this revision ulimit -c=unlimited  RLIMIT_CORE=unlimited  -> dumpable
```

One cell out of eight separates this revision from the previous one, and it is the defect.

The four configurations raised on this PR, against master and against this revision, with a file
`core_pattern`:

| | inherited `ulimit -c` | `worker_rlimit_core` | master | this PR |
|---|---|---|---|---|
| **A** | unlimited | — | dumpable · core written | dumpable · core written |
| **B** | 0 | — | dumpable · no core written | **not dumpable** · no core written |
| **C** | unlimited | `0;` | dumpable · no core written | **not dumpable** · no core written |
| **D** | unlimited | `50m;` | dumpable · core written | dumpable · core written |
| **E** | 0 | `50m;` | dumpable · core written | dumpable · core written |

A is the setup @ac000 reported against the first revision — preserved. C is the inversion he spotted
— fixed. E confirms the gate reads the limit after `worker_rlimit_core` has raised it. In B and C
master leaves the worker attachable by its own user while `RLIMIT_CORE` is `0`, so no core is
produced in either build — the flag buys nothing there and costs the barrier the kernel put up at
`setuid()`.

With `kernel.yama.ptrace_scope = 0`, a probe running as the worker's user and started independently
of nginx reads the worker's memory and attaches when the worker is dumpable:

```
    open(/proc/887/mem)   = OK, pread@0x5e78585a7000 READ 32 BYTES: 7f 45 4c 46 02 01 01 00
    PTRACE_ATTACH        = SUCCEEDED
```

and is refused when it is not:

```
    open(/proc/1196/mem)   = DENIED  errno=Permission denied
    PTRACE_ATTACH        = DENIED  errno=Operation not permitted
```

At `ptrace_scope = 1` both probes are denied in every arm, including against a dumpable worker.

nginx-tests, all three builds, same machine, same session, as an unprivileged user:

```
                   files   tests   failing files
  master             493    2498               1   auth_basic.t
  prev revision      493    2498               1   auth_basic.t
  this revision      493    2498               1   auth_basic.t
  regressions (failing here but not on master)      0
```

`auth_basic.t` fails identically in all three and is unrelated to this change.

## What still changes, stated in full

One configuration loses something: a file `core_pattern`, an effective `RLIMIT_CORE` of `0`, and a
debugger running as the worker's own user without `CAP_SYS_PTRACE`. There, nginx today leaves the
worker attachable on a host where the kernel will not write a core anyway; after this change it does
not. Debugging as root is unaffected in every configuration — `CAP_SYS_PTRACE` bypasses the dumpable
check in `__ptrace_may_access()` — so `gdb`, `strace` and `gcore` as root behave exactly as before.

One limitation is worth naming: the gate is evaluated once, at worker init. Raising the limit later
with `prlimit(1)` does not re-run it, so a worker started with an effective limit of `0` stays
non-dumpable for its lifetime. Root-side `gcore` still works on it; a kernel-written crash dump does
not.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards

No test was added because the behaviour is a process attribute set before any request is served and
nginx-tests has no harness for inspecting `/proc/<worker>` attributes; happy to add one if you would
like it. No documentation change seemed necessary since `PR_SET_DUMPABLE` is not documented, but the
default-behaviour change is described under Release Notes and I will send an `nginx.org` patch if you
would rather it were written down.

## Release Notes

Worker processes are made dumpable only when a core dump could actually be produced — when the
effective `RLIMIT_CORE` is non-zero, whether from `worker_rlimit_core` or inherited, or when
`kernel.core_pattern` pipes dumps to a handler, where the kernel ignores the limit. Hosts that
produce worker core dumps today continue to. Where no core dump is possible, the worker is no longer
left attachable by other processes running under the worker's user.
