### PR TITLE
Upstream: fixed MSVC compilation after dea68dbf126f

### DIFF
--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -811,6 +811,9 @@ ngx_http_grpc_create_request(ngx_http_request_t *r)
     /* :authority header */
 
     host.len = 0;
+#if (NGX_SUPPRESS_WARN)
+    host.data = NULL;
+#endif
 
     if (glcf->host_value
         && ngx_http_complex_value(r, glcf->host_value, &host) != NGX_OK)

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -1226,6 +1226,9 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
     ctx = ngx_http_get_module_ctx(r, ngx_http_proxy_module);
 
     host.len = 0;
+#if (NGX_SUPPRESS_WARN)
+    host.data = NULL;
+#endif
 
     if (plcf->host_value
         && ngx_http_complex_value(r, plcf->host_value, &host) != NGX_OK)

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -446,6 +446,9 @@ ngx_http_proxy_v2_create_request(ngx_http_request_t *r)
     /* :authority header */
 
     host.len = 0;
+#if (NGX_SUPPRESS_WARN)
+    host.data = NULL;
+#endif
 
     if (plcf->host_value
         && ngx_http_complex_value(r, plcf->host_value, &host) != NGX_OK)


### PR DESCRIPTION
Since dea68dbf126f, both windows-2022 msvc buildbot jobs on master fail with C4701 in ngx_http_proxy_create_request(), treated as an error due to -WX.  Fixed by initializing host.data under NGX_SUPPRESS_WARN; all three modules with this pattern (proxy, gRPC, proxy v2) are affected.