### PR TITLE
ci: remove unnecessary actions:write permission from stale workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,7 +12,6 @@ jobs:
     if: ${{ github.repository == 'nginx/nginx' }}
     runs-on: ubuntu-24.04
     permissions:
-      actions: write
       issues: write
 
     name: Mark stale


### PR DESCRIPTION
## Summary

The `mark_stale` job in `.github/workflows/stale.yaml` is granted both `actions: write` and `issues: write` permissions.

The job runs the `actions/stale` action with:
- `days-before-pr-stale: -1` — PR staleness is disabled
- `days-before-close: -1` — Auto-close is disabled

This means the workflow **only** marks GitHub issues as stale by adding a label and posting a comment. For this operation, only `issues: write` is required.

`actions: write` grants the ability to cancel/delete/approve GitHub Actions workflow runs — capabilities entirely unrelated to issue management. Granting it here violates the principle of least privilege and unnecessarily widens the token scope.

## Change

Remove `actions: write` from the job-level permissions block. The `issues: write` permission is sufficient for all current and intended functionality of this workflow.

## Testing

No functional change to the workflow's behaviour. The `actions/stale` action (already pinned to `@b5d41d4e`) will continue to operate identically with only `issues: write`.