### PR TITLE
Memcached: respect the end marker in the maximum supported length

### DIFF
--- a/src/http/modules/ngx_http_memcached_module.c
+++ b/src/http/modules/ngx_http_memcached_module.c
@@ -413,7 +413,11 @@ found:
         p = line.data + line.len;
 
         u->headers_in.content_length_n = ngx_atoof(start, p - start);
-        if (u->headers_in.content_length_n == NGX_ERROR) {
+
+        if (u->headers_in.content_length_n == NGX_ERROR
+            || u->headers_in.content_length_n
+               > NGX_MAX_OFF_T_VALUE - (off_t) NGX_HTTP_MEMCACHED_END)
+        {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                           "memcached sent invalid length in response \"%V\" "
                           "for key \"%V\"",


### PR DESCRIPTION
The length in the `VALUE` line of an upstream memcached response is parsed with
`ngx_atoof()` and accepted up to `NGX_MAX_OFF_T_VALUE`, while
`ngx_http_memcached_filter_init()` adds the size of the response trailer
(`"\r\nEND\r\n"`, 7 bytes) to it:

```c
u->length = u->headers_in.content_length_n + NGX_HTTP_MEMCACHED_END;
```

With lengths close to the maximum this overflows `u->length` and it becomes
negative, so the check in `ngx_http_memcached_filter()`

```c
if (bytes <= (ssize_t) (u->length - NGX_HTTP_MEMCACHED_END)) {
    u->length -= bytes;
```

always passes, the trailer is never validated, and `u->length -= bytes`
underflows -- undefined behaviour, which aborts binaries built with
`-fsanitize=signed-integer-overflow`:

```
src/http/modules/ngx_http_memcached_module.c:539:19: runtime error:
    signed integer overflow: -9223372036854775802 - 14 cannot be
    represented in type 'long int'
    #0 ngx_http_memcached_filter ngx_http_memcached_module.c:539
    #1 ngx_http_upstream_send_response ngx_http_upstream.c:3374
```

reproduced with an upstream response of

```
VALUE key 0 9223372036854775807\r\nAAAAAAA\r\nEND\r\n
```

Without the sanitizer there is no out-of-bounds access: nginx streams the
response until the upstream closes the connection and then returns 502.

The fix rejects such lengths where the length is already validated, similarly
to other invalid lengths, in the spirit of e419e28c9. With the patch the
response above is rejected with

```
memcached sent invalid length in response "VALUE key 0 9223372036854775807"
for key "key" while reading response header from upstream
```

and the request fails with 502, while normal responses are unaffected. Checked
the boundary: a length of `NGX_MAX_OFF_T_VALUE - 7` is still accepted, and
`NGX_MAX_OFF_T_VALUE - 6` is the first one rejected.

Note this is reachable only from the upstream memcached server, which nginx
trusts, so it is a robustness fix rather than a security issue.

Regression test: https://github.com/nginx/nginx-tests/pull/99