### PR TITLE
QUIC: rejected CRYPTO frames received in 1-RTT packets

### DIFF
--- a/src/event/quic/ngx_event_quic_ssl.c
+++ b/src/event/quic/ngx_event_quic_ssl.c
@@ -638,6 +638,15 @@ ngx_quic_handle_crypto_frame(ngx_connection_t *c, ngx_quic_header_t *pkt,
         return NGX_OK;
     }
 
+    if (c->ssl->handshaked) {
+        /* QUIC doesn't define post-handshake messages for a client */
+
+        qc->error = NGX_QUIC_ERR_CRYPTO(SSL_AD_UNEXPECTED_MESSAGE);
+        qc->error_reason = "unexpected CRYPTO frame";
+
+        return NGX_ERROR;
+    }
+
     ctx = ngx_quic_get_send_ctx(qc, pkt->level);
     f = &frame->u.crypto;
 


### PR DESCRIPTION
`ngx_quic_handle_crypto_frame()` passes CRYPTO frames to `ngx_quic_handshake()`.
After the handshake is complete, `SSL_do_handshake()` reports success and
`SSL_is_init_finished()` is true, so the handshake completion block runs again
for a CRYPTO frame received in a 1-RTT packet.

Notably, this posts `qc->key_update` a second time while the previous key update
has not been switched to yet. In `ngx_quic_keys_update()` the current secrets
have already been zeroed by the first run, so the second run derives from a
zero-length secret into a zero-length output and fails:

```
quic key update
SSL_do_handshake: 1
quic key update
ngx_hkdf_expand(tls13 quic ku) failed
    (SSL: error:1C800069:Provider routines::invalid key length)
quic close initiated rc:-1
```

reproduced with an aioquic client that writes a TLS message to the 1-RTT crypto
stream after the handshake.

The check above already ignores CRYPTO frames on levels whose keys have been
discarded:

```c
if (!ngx_quic_keys_available(qc->keys, pkt->level, 0)) {
    return NGX_OK;
}
```

That covers handshake level, since the handshake keys are discarded in the same
block that sets `c->ssl->handshaked`. It does not cover application level: the
packet was decrypted with those keys, so they are available by definition.

A client has nothing to send in a CRYPTO frame once the handshake is complete --
TLS KeyUpdate is prohibited by RFC 9001, 6, post-handshake authentication by
4.4, and NewSessionTicket is only sent by a server -- so such frames are
rejected rather than ignored, with `unexpected_message`: TLS 1.3 uses that alert
for handshake messages received out of sequence (RFC 8446, 6.2), and RFC 9001, 6
requires exactly it for KeyUpdate. Rejecting before parsing means we never learn
which message it was, so the general rule is the applicable one.

With the patch the same proof of concept produces one key update instead of two,
and the connection ends with

```
quic close immediate term:1 drain:0 error:266 "unexpected CRYPTO frame"
quic frame tx app:1 CONNECTION_CLOSE err:266 unexpected CRYPTO frame ft:0
```

266 is 0x010a, that is CRYPTO_ERROR with unexpected_message. The worker is
unaffected.