### PR TITLE
HTTP/3: skipped stream cancellation during connection shutdown

### DIFF
--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -412,7 +412,7 @@ ngx_http_v3_reset_stream(ngx_connection_t *c)
 
     h3c = ngx_http_v3_get_session(c);
 
-    if (!c->read->eof && !h3c->hq
+    if (!c->close && !c->read->eof && !h3c->hq
         && h3c->known_streams[NGX_HTTP_V3_STREAM_SERVER_DECODER]
         && (c->quic->id & NGX_QUIC_STREAM_UNIDIRECTIONAL) == 0)
     {


### PR DESCRIPTION
After QUIC connection shutdown, unfinished stream cancellations are still triggered, however at this stage all stream states are disgarded.

Closes: #1550 

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

