### PR TITLE
WebSocket and Tunnel over HTTP/2 and HTTP/3

### DIFF
--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -89,6 +89,10 @@ static ngx_int_t
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_proxy_internal_chunked_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_uint_t ngx_http_proxy_is_websocket_header(u_char *data, size_t len);
+static u_char *ngx_http_proxy_websocket_key(u_char *p);
+static ngx_int_t ngx_http_proxy_websocket_response(ngx_http_request_t *r,
+    ngx_http_upstream_t *u);
 static ngx_int_t ngx_http_proxy_parse_cookie(ngx_str_t *value,
     ngx_array_t *attrs);
 static ngx_int_t ngx_http_proxy_rewrite_cookie_value(ngx_http_request_t *r,
@@ -758,6 +762,11 @@ static char  ngx_http_proxy_version[] = " HTTP/1.0" CRLF;
 static char  ngx_http_proxy_version_11[] = " HTTP/1.1" CRLF;
 
 
+static char  ngx_http_proxy_header_upgrade[] = "Upgrade: websocket" CRLF;
+static char  ngx_http_proxy_header_connection[] = "Connection: Upgrade" CRLF;
+static char  ngx_http_proxy_sec_websocket_key[] = "Sec-WebSocket-Key";
+
+
 static ngx_keyval_t  ngx_http_proxy_headers[] = {
     { ngx_string("Host"), ngx_string("") },
     { ngx_string("Connection"), ngx_string("") },
@@ -965,6 +974,10 @@ ngx_http_proxy_handler(ngx_http_request_t *r)
             || plcf->http_version == NGX_HTTP_VERSION_11))
     {
         r->request_body_no_buffering = 1;
+    }
+
+    if (r->stream_connect == NGX_HTTP_PROTOCOL_WEBSOCKET) {
+        u->allow_stream_connect = 1;
     }
 
     rc = ngx_http_read_client_request_body(r, ngx_http_upstream_init);
@@ -1185,6 +1198,7 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
 {
     size_t                        len, uri_len, loc_len, body_len, headers_len,
                                   key_len, val_len;
+    u_char                       *p;
     uintptr_t                     escape;
     ngx_buf_t                    *b;
     ngx_str_t                     method, host;
@@ -1218,6 +1232,11 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
         if (ngx_http_complex_value(r, plcf->method, &method) != NGX_OK) {
             return NGX_ERROR;
         }
+
+    } else if (r->method == NGX_HTTP_CONNECT
+               && r->stream_connect == NGX_HTTP_PROTOCOL_WEBSOCKET)
+    {
+        ngx_str_set(&method, "GET");
 
     } else {
         method = r->method_name;
@@ -1303,6 +1322,9 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
         ctx->internal_body_length = body_len;
         len += body_len;
 
+    } else if (r->stream_connect) {
+        ctx->internal_body_length = -1;
+
     } else if (r->headers_in.chunked && r->reading_body) {
         ctx->internal_body_length = -1;
         ctx->internal_chunked = 1;
@@ -1361,9 +1383,24 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
                 continue;
             }
 
+            if (r->stream_connect == NGX_HTTP_PROTOCOL_WEBSOCKET
+                && ngx_http_proxy_is_websocket_header(header[i].key.data,
+                                                      header[i].key.len))
+            {
+                continue;
+            }
+
             len += header[i].key.len + sizeof(": ") - 1
                 + header[i].value.len + sizeof(CRLF) - 1;
         }
+    }
+
+    if (r->stream_connect == NGX_HTTP_PROTOCOL_WEBSOCKET) {
+        len += sizeof(ngx_http_proxy_header_upgrade) - 1
+               + sizeof(ngx_http_proxy_header_connection) - 1
+               + sizeof(ngx_http_proxy_sec_websocket_key) - 1
+               + sizeof(": ") - 1 + ngx_base64_encoded_length(16)
+               + sizeof(CRLF) - 1;
     }
 
 
@@ -1465,8 +1502,12 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
             continue;
         }
 
+        p = e.pos;
+
         code = *(ngx_http_script_code_pt *) e.ip;
         code((ngx_http_script_engine_t *) &e);
+
+        key_len = e.pos - p;
 
         if (e.status) {
             return NGX_ERROR;
@@ -1493,6 +1534,12 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
         }
 
         *e.pos++ = CR; *e.pos++ = LF;
+
+        if (r->stream_connect == NGX_HTTP_PROTOCOL_WEBSOCKET
+            && ngx_http_proxy_is_websocket_header(p, key_len))
+        {
+            e.pos = p;
+        }
     }
 
     b->last = e.pos;
@@ -1520,6 +1567,13 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
                 continue;
             }
 
+            if (r->stream_connect == NGX_HTTP_PROTOCOL_WEBSOCKET
+                && ngx_http_proxy_is_websocket_header(header[i].key.data,
+                                                      header[i].key.len))
+            {
+                continue;
+            }
+
             b->last = ngx_copy(b->last, header[i].key.data, header[i].key.len);
 
             *b->last++ = ':'; *b->last++ = ' ';
@@ -1535,6 +1589,18 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
         }
     }
 
+
+    if (r->stream_connect == NGX_HTTP_PROTOCOL_WEBSOCKET) {
+        b->last = ngx_cpymem(b->last, ngx_http_proxy_header_upgrade,
+                             sizeof(ngx_http_proxy_header_upgrade) - 1);
+        b->last = ngx_cpymem(b->last, ngx_http_proxy_header_connection,
+                             sizeof(ngx_http_proxy_header_connection) - 1);
+        b->last = ngx_cpymem(b->last, ngx_http_proxy_sec_websocket_key,
+                             sizeof(ngx_http_proxy_sec_websocket_key) - 1);
+        *b->last++ = ':'; *b->last++ = ' ';
+        b->last = ngx_http_proxy_websocket_key(b->last);
+        *b->last++ = CR; *b->last++ = LF;
+    }
 
     /* add "\r\n" at the header end */
     *b->last++ = CR; *b->last++ = LF;
@@ -2042,6 +2108,20 @@ ngx_http_proxy_process_header(ngx_http_request_t *r)
                 if (r->headers_in.upgrade) {
                     u->upgrade = 1;
                 }
+
+                if (r->stream_connect == NGX_HTTP_PROTOCOL_WEBSOCKET) {
+                    rc = ngx_http_proxy_websocket_response(r, u);
+
+                    if (rc != NGX_OK) {
+                        return rc;
+                    }
+                }
+
+            } else if (r->stream_connect == NGX_HTTP_PROTOCOL_WEBSOCKET
+                       && u->headers_in.status_n == NGX_HTTP_OK)
+            {
+                u->headers_in.status_n = NGX_HTTP_BAD_GATEWAY;
+                ngx_str_null(&u->headers_in.status_line);
             }
 
             return NGX_OK;
@@ -2876,6 +2956,97 @@ ngx_http_proxy_internal_chunked_variable(ngx_http_request_t *r,
 
     v->data = (u_char *) "chunked";
     v->len = sizeof("chunked") - 1;
+
+    return NGX_OK;
+}
+
+
+static ngx_uint_t
+ngx_http_proxy_is_websocket_header(u_char *data, size_t len)
+{
+    if (len == 7 && ngx_strncasecmp(data, (u_char *) "Upgrade", 7) == 0) {
+        return 1;
+    }
+
+    if (len == 10 && ngx_strncasecmp(data, (u_char *) "Connection", 10) == 0) {
+        return 1;
+    }
+
+    if (len == 17
+        && ngx_strncasecmp(data, (u_char *) "Sec-WebSocket-Key", 17) == 0)
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
+
+static u_char *
+ngx_http_proxy_websocket_key(u_char *p)
+{
+    ngx_str_t  src, dst;
+    uint64_t   nonce[2];
+
+#if (NGX_OPENSSL)
+    if (RAND_bytes((u_char *) nonce, 16) != 1)
+#endif
+    {
+        nonce[0] = ((uint64_t) ngx_random() << 32) | (uint32_t) ngx_random();
+        nonce[1] = ((uint64_t) ngx_random() << 32) | (uint32_t) ngx_random();
+    }
+
+    src.len = 16;
+    src.data = (u_char *) nonce;
+
+    dst.data = p;
+    ngx_encode_base64(&dst, &src);
+
+    return p + dst.len;
+}
+
+
+static ngx_int_t
+ngx_http_proxy_websocket_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
+{
+    u_char           *key;
+    size_t            len;
+    ngx_uint_t        i;
+    ngx_list_part_t  *part;
+    ngx_table_elt_t  *h;
+
+    part = &u->headers_in.headers.part;
+    h = part->elts;
+
+    for (i = 0; /* void */ ; i++) {
+
+        if (i >= part->nelts) {
+            if (part->next == NULL) {
+                break;
+            }
+
+            part = part->next;
+            h = part->elts;
+            i = 0;
+        }
+
+        if (h[i].hash == 0) {
+            continue;
+        }
+
+        len = h[i].key.len;
+        key = h[i].lowcase_key;
+
+        if ((len == 7 && ngx_memcmp(key, "upgrade", 7) == 0)
+            || (len == 20 && ngx_memcmp(key, "sec-websocket-accept", 20) == 0))
+        {
+            h[i].hash = 0;
+        }
+    }
+
+    u->headers_in.content_length_n = -1;
+
+    u->upgrade = 1;
 
     return NGX_OK;
 }

--- a/src/http/modules/ngx_http_tunnel_module.c
+++ b/src/http/modules/ngx_http_tunnel_module.c
@@ -189,6 +189,10 @@ ngx_http_tunnel_handler(ngx_http_request_t *r)
         return NGX_HTTP_NOT_ALLOWED;
     }
 
+    if (r->stream_connect && r->stream_connect != NGX_HTTP_PROTOCOL_TUNNEL) {
+        return NGX_HTTP_NOT_ALLOWED;
+    }
+
     if (ngx_http_upstream_create(r) != NGX_OK) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
@@ -210,6 +214,10 @@ ngx_http_tunnel_handler(ngx_http_request_t *r)
     u->process_header = ngx_http_tunnel_process_header;
     u->abort_request = ngx_http_tunnel_abort_request;
     u->finalize_request = ngx_http_tunnel_finalize_request;
+
+    if (r->stream_connect == NGX_HTTP_PROTOCOL_TUNNEL) {
+        u->allow_stream_connect = 1;
+    }
 
     rc = ngx_http_read_client_request_body(r, ngx_http_upstream_init);
 

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -47,6 +47,10 @@
 #define NGX_HTTP_CONNECTION_CLOSE          1
 #define NGX_HTTP_CONNECTION_KEEP_ALIVE     2
 
+#define NGX_HTTP_PROTOCOL_NONE             0
+#define NGX_HTTP_PROTOCOL_TUNNEL           1
+#define NGX_HTTP_PROTOCOL_WEBSOCKET        2
+
 
 #define NGX_NONE                           1
 
@@ -577,6 +581,7 @@ struct ngx_http_request_s {
 
     unsigned                          background:1;
     unsigned                          health_check:1;
+    unsigned                          stream_connect:2;
 
     /* used to parse HTTP headers */
 
@@ -620,7 +625,9 @@ typedef struct {
 
 #define ngx_http_ephemeral(r)   (void *) (&r->uri_start)
 
-#define ngx_http_proxy_auth(r)  ((r)->method == NGX_HTTP_CONNECT)
+#define ngx_http_proxy_auth(r)                                                \
+    ((r)->method == NGX_HTTP_CONNECT                                          \
+     && (r)->stream_connect < NGX_HTTP_PROTOCOL_WEBSOCKET)
 
 
 extern ngx_http_header_t       ngx_http_headers_in[];

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -48,6 +48,12 @@ ngx_http_read_client_request_body(ngx_http_request_t *r,
         return NGX_OK;
     }
 
+    if (r->stream_connect && !(r->upstream && r->upstream->upgrade)) {
+        r->request_body_no_buffering = 0;
+        post_handler(r);
+        return NGX_OK;
+    }
+
     if (ngx_http_test_expect(r) != NGX_OK) {
         rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
         goto done;

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -70,6 +70,10 @@ static void ngx_http_upstream_upgraded_read_upstream(ngx_http_request_t *r,
     ngx_http_upstream_t *u);
 static void ngx_http_upstream_upgraded_write_upstream(ngx_http_request_t *r,
     ngx_http_upstream_t *u);
+static ssize_t ngx_http_upstream_recv_downstream(ngx_http_request_t *r,
+    u_char *buf, size_t size);
+static ngx_int_t ngx_http_upstream_send_downstream(ngx_http_request_t *r,
+    ngx_chain_t *in);
 static void ngx_http_upstream_process_upgraded(ngx_http_request_t *r,
     ngx_uint_t from_upstream, ngx_uint_t do_write);
 static void
@@ -600,6 +604,13 @@ ngx_http_upstream_init_request(ngx_http_request_t *r)
     }
 
     u = r->upstream;
+
+    if (r->stream_connect && !u->allow_stream_connect) {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "CONNECT method not allowed");
+        ngx_http_finalize_request(r, NGX_HTTP_NOT_ALLOWED);
+        return;
+    }
 
 #if (NGX_HTTP_CACHE)
 
@@ -3618,6 +3629,8 @@ ngx_http_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
 static void
 ngx_http_upstream_upgrade(ngx_http_request_t *r, ngx_http_upstream_t *u)
 {
+    ssize_t                    n;
+    ngx_int_t                  rc;
     ngx_connection_t          *c;
     ngx_http_core_loc_conf_t  *clcf;
 
@@ -3636,10 +3649,48 @@ ngx_http_upstream_upgrade(ngx_http_request_t *r, ngx_http_upstream_t *u)
     r->keepalive = 0;
     c->log->action = "proxying upgraded connection";
 
+    if (r->stream_connect) {
+        r->request_body_no_buffering = 1;
+
+        rc = ngx_http_read_client_request_body(r,
+                                              ngx_http_request_empty_handler);
+
+        if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+            ngx_http_upstream_finalize_request(r, u, rc);
+            return;
+        }
+
+        r->main->count--;
+
+        if (!r->reading_body && r->request_body->buf) {
+            r->request_body_no_buffering = 1;
+            r->reading_body = 1;
+        }
+
+        if (c->read->timer_set) {
+            ngx_del_timer(c->read);
+        }
+    }
+
     u->read_event_handler = ngx_http_upstream_upgraded_read_upstream;
     u->write_event_handler = ngx_http_upstream_upgraded_write_upstream;
     r->read_event_handler = ngx_http_upstream_upgraded_read_downstream;
     r->write_event_handler = ngx_http_upstream_upgraded_write_downstream;
+
+    if (r->stream_connect) {
+
+        if (u->input_filter == NULL) {
+            u->input_filter = ngx_http_upstream_non_buffered_filter;
+            u->input_filter_ctx = r;
+        }
+
+        u->read_event_handler = ngx_http_upstream_process_non_buffered_upstream;
+        r->write_event_handler =
+                             ngx_http_upstream_process_non_buffered_downstream;
+
+        r->limit_rate = 0;
+        r->limit_rate_set = 1;
+    }
 
     if (clcf->tcp_nodelay) {
 
@@ -3654,6 +3705,25 @@ ngx_http_upstream_upgrade(ngx_http_request_t *r, ngx_http_upstream_t *u)
         }
     }
 
+    if (r->stream_connect) {
+        n = u->buffer.last - u->buffer.pos;
+
+        if (n) {
+            u->buffer.last = u->buffer.pos;
+
+            u->state->response_length += n;
+
+            if (u->input_filter(u->input_filter_ctx, n) == NGX_ERROR) {
+                ngx_http_upstream_finalize_request(r, u, NGX_ERROR);
+                return;
+            }
+
+        } else {
+            u->buffer.pos = u->buffer.start;
+            u->buffer.last = u->buffer.start;
+        }
+    }
+
     if (ngx_http_send_special(r, NGX_HTTP_FLUSH) == NGX_ERROR) {
         ngx_http_upstream_finalize_request(r, u, NGX_ERROR);
         return;
@@ -3663,11 +3733,11 @@ ngx_http_upstream_upgrade(ngx_http_request_t *r, ngx_http_upstream_t *u)
         || u->buffer.pos != u->buffer.last)
     {
         ngx_post_event(c->read, &ngx_posted_events);
-        ngx_http_upstream_process_upgraded(r, 1, 1);
+        r->write_event_handler(r);
         return;
     }
 
-    ngx_http_upstream_process_upgraded(r, 0, 1);
+    u->write_event_handler(r, u);
 }
 
 
@@ -3698,6 +3768,95 @@ ngx_http_upstream_upgraded_write_upstream(ngx_http_request_t *r,
     ngx_http_upstream_t *u)
 {
     ngx_http_upstream_process_upgraded(r, 0, 1);
+}
+
+
+static ssize_t
+ngx_http_upstream_recv_downstream(ngx_http_request_t *r, u_char *buf,
+    size_t size)
+{
+    size_t             n, len, rest;
+    ngx_int_t          rc;
+    ngx_buf_t         *b;
+    ngx_chain_t       *out, *cl;
+    ngx_connection_t  *c;
+
+    c = r->connection;
+
+    c->read->timedout = 0;
+
+    out = r->request_body->bufs;
+
+    if (out == NULL && r->reading_body) {
+        rc = ngx_http_read_unbuffered_request_body(r);
+
+        if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+            return NGX_ERROR;
+        }
+
+        out = r->request_body->bufs;
+    }
+
+    if (c->read->timer_set) {
+        ngx_del_timer(c->read);
+    }
+
+    len = 0;
+    rest = size;
+
+    while (out && rest) {
+        b = out->buf;
+
+        n = b->last - b->pos;
+
+        if (n > rest) {
+            n = rest;
+        }
+
+        if (n) {
+            buf = ngx_cpymem(buf, b->pos, n);
+            b->pos += n;
+
+            len += n;
+            rest -= n;
+        }
+
+        if (b->pos == b->last) {
+            cl = out;
+            out = out->next;
+            ngx_free_chain(r->pool, cl);
+        }
+    }
+
+    r->request_body->bufs = out;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http upstream recv downstream: %uz of %uz", len, size);
+
+    if (len > 0) {
+        return len;
+    }
+
+    if (r->reading_body) {
+        return NGX_AGAIN;
+    }
+
+    c->read->eof = 1;
+
+    return 0;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_send_downstream(ngx_http_request_t *r, ngx_chain_t *in)
+{
+#if (NGX_HTTP_V3)
+    if (r->http_version == NGX_HTTP_VERSION_30) {
+        return ngx_http_v3_body_filter(r, in);
+    }
+#endif
+
+    return ngx_http_write_filter(r, in);
 }
 
 
@@ -3745,7 +3904,7 @@ ngx_http_upstream_process_upgraded(ngx_http_request_t *r,
         dst = upstream;
         b = &u->from_client;
 
-        if (r->header_in->last > r->header_in->pos) {
+        if (!r->stream_connect && r->header_in->last > r->header_in->pos) {
             b = r->header_in;
             b->end = b->last;
             do_write = 1;
@@ -3794,9 +3953,17 @@ ngx_http_upstream_process_upgraded(ngx_http_request_t *r,
 
         size = b->end - b->last;
 
-        if (size && src->read->ready) {
+        if (size) {
 
-            n = src->recv(src, b->last, size);
+            if (r->stream_connect && !from_upstream) {
+                n = ngx_http_upstream_recv_downstream(r, b->last, size);
+
+            } else if (src->read->ready) {
+                n = src->recv(src, b->last, size);
+
+            } else {
+                n = 0;
+            }
 
             if (n == NGX_AGAIN || n == 0) {
                 break;
@@ -3970,7 +4137,13 @@ ngx_http_upstream_process_non_buffered_request(ngx_http_request_t *r,
         if (do_write) {
 
             if (u->out_bufs || u->busy_bufs || downstream->buffered) {
-                rc = ngx_http_output_filter(r, u->out_bufs);
+
+                if (r->stream_connect && u->upgrade) {
+                    rc = ngx_http_upstream_send_downstream(r, u->out_bufs);
+
+                } else {
+                    rc = ngx_http_output_filter(r, u->out_bufs);
+                }
 
                 if (rc == NGX_ERROR) {
                     ngx_http_upstream_finalize_request(r, u, NGX_ERROR);

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -416,6 +416,7 @@ struct ngx_http_upstream_s {
     unsigned                         buffering:1;
     unsigned                         keepalive:1;
     unsigned                         upgrade:1;
+    unsigned                         allow_stream_connect:1;
     unsigned                         error:1;
 
     unsigned                         request_sent:1;

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -3633,12 +3633,50 @@ ngx_http_v2_parse_protocol(ngx_http_request_t *r, ngx_str_t *value)
 static ngx_int_t
 ngx_http_v2_construct_request_line(ngx_http_request_t *r)
 {
-    u_char  *p;
+    u_char                    *p;
+    ngx_int_t                  rc;
+    ngx_str_t                  target;
+    ngx_http_core_srv_conf_t  *cscf;
 
     static const u_char ending[] = " HTTP/2.0";
+    static ngx_str_t    path = ngx_string("/");
 
     if (r->request_line.len) {
         return NGX_OK;
+    }
+
+    if (r->method == NGX_HTTP_CONNECT
+        && r->stream_connect == NGX_HTTP_PROTOCOL_NONE)
+    {
+        if (r->schema.len) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent CONNECT with :scheme header");
+            goto failed;
+        }
+
+        if (r->unparsed_uri.len) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent CONNECT with :path header");
+            goto failed;
+        }
+
+        if (r->host_start == NULL) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent CONNECT without :authority header");
+            goto failed;
+        }
+
+        if (r->port == 0) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent CONNECT without port in :authority "
+                          "header");
+            goto failed;
+        }
+
+        target.len = r->host_end - r->host_start;
+        target.data = r->host_start;
+
+        goto construct;
     }
 
     if (r->method_name.len == 0
@@ -3662,8 +3700,12 @@ ngx_http_v2_construct_request_line(ngx_http_request_t *r)
         return NGX_ERROR;
     }
 
+    target = r->unparsed_uri;
+
+construct:
+
     r->request_line.len = r->method_name.len + 1
-                          + r->unparsed_uri.len
+                          + target.len
                           + sizeof(ending) - 1;
 
     p = ngx_pnalloc(r->pool, r->request_line.len + 1);
@@ -3678,14 +3720,39 @@ ngx_http_v2_construct_request_line(ngx_http_request_t *r)
 
     *p++ = ' ';
 
-    p = ngx_cpymem(p, r->unparsed_uri.data, r->unparsed_uri.len);
+    p = ngx_cpymem(p, target.data, target.len);
 
     ngx_memcpy(p, ending, sizeof(ending));
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http2 request line: \"%V\"", &r->request_line);
 
+    if (r->method == NGX_HTTP_CONNECT
+        && r->stream_connect == NGX_HTTP_PROTOCOL_NONE)
+    {
+        rc = ngx_http_v2_parse_path(r, &path);
+
+        if (rc == NGX_ABORT) {
+            return NGX_ERROR;
+        }
+
+        if (rc != NGX_OK) {
+            goto failed;
+        }
+
+        cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+
+        if (cscf->allow_connect) {
+            r->stream_connect = NGX_HTTP_PROTOCOL_TUNNEL;
+        }
+    }
+
     return NGX_OK;
+
+failed:
+
+    ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+    return NGX_ERROR;
 }
 
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -155,6 +155,8 @@ static ngx_int_t ngx_http_v2_parse_scheme(ngx_http_request_t *r,
     ngx_str_t *value);
 static ngx_int_t ngx_http_v2_parse_authority(ngx_http_request_t *r,
     ngx_str_t *value);
+static ngx_int_t ngx_http_v2_parse_protocol(ngx_http_request_t *r,
+    ngx_str_t *value);
 static ngx_int_t ngx_http_v2_construct_request_line(ngx_http_request_t *r);
 static ngx_int_t ngx_http_v2_cookie(ngx_http_request_t *r,
     ngx_http_v2_header_t *header);
@@ -3350,6 +3352,13 @@ ngx_http_v2_pseudo_header(ngx_http_request_t *r, ngx_http_v2_header_t *header)
 
         break;
 
+    case 8:
+        if (ngx_memcmp(header->name.data, "protocol", 8) == 0) {
+            return ngx_http_v2_parse_protocol(r, &header->value);
+        }
+
+        break;
+
     case 9:
         if (ngx_memcmp(header->name.data, "authority", sizeof("authority") - 1)
             == 0)
@@ -3589,6 +3598,35 @@ ngx_http_v2_parse_authority(ngx_http_request_t *r, ngx_str_t *value)
     r->port = port;
 
     return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_v2_parse_protocol(ngx_http_request_t *r, ngx_str_t *value)
+{
+    if (r->stream_connect) {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent duplicate :protocol header");
+
+        return NGX_DECLINED;
+    }
+
+    if (value->len == 0) {
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent empty :protocol header");
+
+        return NGX_DECLINED;
+    }
+
+    if (value->len == 9 && ngx_memcmp(value->data, "websocket", 9) == 0) {
+        r->stream_connect = NGX_HTTP_PROTOCOL_WEBSOCKET;
+        return NGX_OK;
+    }
+
+    ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                  "client sent unsupported :protocol header: \"%V\"", value);
+
+    return NGX_DECLINED;
 }
 
 
@@ -3950,8 +3988,39 @@ ngx_http_v2_run_request(ngx_http_request_t *r)
     }
 
     if (r->method == NGX_HTTP_CONNECT) {
-        ngx_log_error(NGX_LOG_INFO, fc->log, 0, "client sent CONNECT method");
-        ngx_http_finalize_request(r, NGX_HTTP_NOT_ALLOWED);
+        if (!r->stream_connect) {
+            ngx_log_error(NGX_LOG_INFO, fc->log, 0,
+                          "client sent CONNECT method");
+            ngx_http_finalize_request(r, NGX_HTTP_NOT_ALLOWED);
+            goto failed;
+        }
+
+        if (r->stream_connect >= NGX_HTTP_PROTOCOL_WEBSOCKET
+            && h2scf->extended_connect == NGX_HTTP_V2_EXTENDED_CONNECT_OFF)
+        {
+            ngx_log_error(NGX_LOG_INFO, fc->log, 0,
+                          "client sent CONNECT method with :protocol header");
+            ngx_http_finalize_request(r, NGX_HTTP_NOT_ALLOWED);
+            goto failed;
+        }
+
+        if (r->headers_in.content_length_n > 0) {
+            ngx_log_error(NGX_LOG_INFO, fc->log, 0,
+                          "client sent CONNECT request with body");
+            ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+            goto failed;
+        }
+
+        if (r->headers_in.content_length_n == 0) {
+            r->headers_in.content_length_n = -1;
+            r->headers_in.chunked = !r->stream->in_closed;
+        }
+
+    } else if (r->stream_connect) {
+        ngx_log_error(NGX_LOG_INFO, fc->log, 0,
+                      "client sent %V with :protocol header",
+                      &r->method_name);
+        ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
         goto failed;
     }
 
@@ -4288,6 +4357,9 @@ ngx_http_v2_filter_request_body(ngx_http_request_t *r)
 
                 return NGX_HTTP_BAD_REQUEST;
             }
+
+        } else if (r->stream_connect && r->upstream && r->upstream->upgrade) {
+            /* skip client_max_body_size */
 
         } else {
             clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -43,6 +43,7 @@
 #define NGX_HTTP_V2_MAX_STREAMS_SETTING          0x3
 #define NGX_HTTP_V2_INIT_WINDOW_SIZE_SETTING     0x4
 #define NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING       0x5
+#define NGX_HTTP_V2_ENABLE_CONNECT_PROTOCOL      0x8
 
 #define NGX_HTTP_V2_FRAME_BUFFER_SIZE            24
 
@@ -2737,6 +2738,13 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
 
     len = NGX_HTTP_V2_SETTINGS_PARAM_SIZE * 3;
 
+    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                         ngx_http_v2_module);
+
+    if (h2scf->extended_connect == NGX_HTTP_V2_EXTENDED_CONNECT_ADVERTISE) {
+        len += NGX_HTTP_V2_SETTINGS_PARAM_SIZE;
+    }
+
     buf = ngx_create_temp_buf(h2c->pool, NGX_HTTP_V2_FRAME_HEADER_SIZE + len);
     if (buf == NULL) {
         return NGX_ERROR;
@@ -2763,9 +2771,6 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
 
     buf->last = ngx_http_v2_write_sid(buf->last, 0);
 
-    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
-                                         ngx_http_v2_module);
-
     buf->last = ngx_http_v2_write_uint16(buf->last,
                                          NGX_HTTP_V2_MAX_STREAMS_SETTING);
     buf->last = ngx_http_v2_write_uint32(buf->last,
@@ -2779,6 +2784,12 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
                                          NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING);
     buf->last = ngx_http_v2_write_uint32(buf->last,
                                          NGX_HTTP_V2_MAX_FRAME_SIZE);
+
+    if (h2scf->extended_connect == NGX_HTTP_V2_EXTENDED_CONNECT_ADVERTISE) {
+        buf->last = ngx_http_v2_write_uint16(buf->last,
+                                         NGX_HTTP_V2_ENABLE_CONNECT_PROTOCOL);
+        buf->last = ngx_http_v2_write_uint32(buf->last, 1);
+    }
 
     ngx_http_v2_queue_blocked_frame(h2c, frame);
 

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -20,6 +20,10 @@
 #define NGX_HTTP_V2_DEFAULT_FRAME_SIZE   (1 << 14)
 #define NGX_HTTP_V2_MAX_FRAME_SIZE       ((1 << 24) - 1)
 
+#define NGX_HTTP_V2_EXTENDED_CONNECT_OFF        0
+#define NGX_HTTP_V2_EXTENDED_CONNECT_ON         1
+#define NGX_HTTP_V2_EXTENDED_CONNECT_ADVERTISE  2
+
 #define NGX_HTTP_V2_INT_OCTETS           4
 #define NGX_HTTP_V2_MAX_FIELD                                                 \
     (127 + (1 << (NGX_HTTP_V2_INT_OCTETS - 1) * 7) - 1)
@@ -65,6 +69,7 @@ typedef struct {
     ngx_flag_t                       enable;
     size_t                           pool_size;
     ngx_uint_t                       concurrent_streams;
+    ngx_uint_t                       extended_connect;
     size_t                           preread_size;
     ngx_uint_t                       streams_index_mask;
 } ngx_http_v2_srv_conf_t;

--- a/src/http/v2/ngx_http_v2_filter_module.c
+++ b/src/http/v2/ngx_http_v2_filter_module.c
@@ -163,6 +163,14 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
         r->header_only = 1;
     }
 
+    if (r->headers_out.status == NGX_HTTP_SWITCHING_PROTOCOLS
+        && r->stream_connect == NGX_HTTP_PROTOCOL_WEBSOCKET
+        && r->upstream && r->upstream->upgrade)
+    {
+        r->headers_out.status = NGX_HTTP_OK;
+        ngx_str_null(&r->headers_out.status_line);
+    }
+
     switch (r->headers_out.status) {
 
     case NGX_HTTP_OK:

--- a/src/http/v2/ngx_http_v2_module.c
+++ b/src/http/v2/ngx_http_v2_module.c
@@ -71,6 +71,14 @@ static ngx_conf_post_t  ngx_http_v2_chunk_size_post =
     { ngx_http_v2_chunk_size };
 
 
+static ngx_conf_enum_t  ngx_http_v2_extended_connect[] = {
+    { ngx_string("off"), NGX_HTTP_V2_EXTENDED_CONNECT_OFF },
+    { ngx_string("on"), NGX_HTTP_V2_EXTENDED_CONNECT_ON },
+    { ngx_string("advertise"), NGX_HTTP_V2_EXTENDED_CONNECT_ADVERTISE },
+    { ngx_null_string, 0 }
+};
+
+
 static ngx_command_t  ngx_http_v2_commands[] = {
 
     { ngx_string("http2"),
@@ -135,6 +143,13 @@ static ngx_command_t  ngx_http_v2_commands[] = {
       NGX_HTTP_SRV_CONF_OFFSET,
       offsetof(ngx_http_v2_srv_conf_t, preread_size),
       &ngx_http_v2_preread_size_post },
+
+    { ngx_string("http2_extended_connect"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_enum_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_v2_srv_conf_t, extended_connect),
+      &ngx_http_v2_extended_connect },
 
     { ngx_string("http2_streams_index_size"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
@@ -327,6 +342,8 @@ ngx_http_v2_create_srv_conf(ngx_conf_t *cf)
 
     h2scf->preread_size = NGX_CONF_UNSET_SIZE;
 
+    h2scf->extended_connect = NGX_CONF_UNSET_UINT;
+
     h2scf->streams_index_mask = NGX_CONF_UNSET_UINT;
 
     return h2scf;
@@ -347,6 +364,9 @@ ngx_http_v2_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
                               prev->concurrent_streams, 128);
 
     ngx_conf_merge_size_value(conf->preread_size, prev->preread_size, 65536);
+
+    ngx_conf_merge_uint_value(conf->extended_connect, prev->extended_connect,
+                              NGX_HTTP_V2_EXTENDED_CONNECT_ON);
 
     ngx_conf_merge_uint_value(conf->streams_index_mask,
                               prev->streams_index_mask, 32 - 1);

--- a/src/http/v3/ngx_http_v3.h
+++ b/src/http/v3/ngx_http_v3.h
@@ -159,6 +159,7 @@ void ngx_http_v3_shutdown(ngx_connection_t *c);
 
 ngx_int_t ngx_http_v3_read_request_body(ngx_http_request_t *r);
 ngx_int_t ngx_http_v3_read_unbuffered_request_body(ngx_http_request_t *r);
+ngx_int_t ngx_http_v3_body_filter(ngx_http_request_t *r, ngx_chain_t *in);
 
 
 extern ngx_module_t  ngx_http_v3_module;

--- a/src/http/v3/ngx_http_v3.h
+++ b/src/http/v3/ngx_http_v3.h
@@ -42,8 +42,13 @@
 #define NGX_HTTP_V3_PARAM_MAX_TABLE_CAPACITY       0x01
 #define NGX_HTTP_V3_PARAM_MAX_FIELD_SECTION_SIZE   0x06
 #define NGX_HTTP_V3_PARAM_BLOCKED_STREAMS          0x07
+#define NGX_HTTP_V3_PARAM_ENABLE_CONNECT_PROTOCOL  0x08
 
 #define NGX_HTTP_V3_MAX_TABLE_CAPACITY             4096
+
+#define NGX_HTTP_V3_EXTENDED_CONNECT_OFF           0
+#define NGX_HTTP_V3_EXTENDED_CONNECT_ON            1
+#define NGX_HTTP_V3_EXTENDED_CONNECT_ADVERTISE     2
 
 #define NGX_HTTP_V3_STREAM_CLIENT_CONTROL          0
 #define NGX_HTTP_V3_STREAM_SERVER_CONTROL          1
@@ -107,6 +112,7 @@ typedef struct {
     ngx_flag_t                    enable_hq;
     size_t                        max_table_capacity;
     ngx_uint_t                    max_blocked_streams;
+    ngx_uint_t                    extended_connect;
     ngx_uint_t                    max_concurrent_streams;
     ngx_quic_conf_t               quic;
 } ngx_http_v3_srv_conf_t;

--- a/src/http/v3/ngx_http_v3_filter_module.c
+++ b/src/http/v3/ngx_http_v3_filter_module.c
@@ -38,8 +38,6 @@ typedef struct {
 
 static ngx_int_t ngx_http_v3_header_filter(ngx_http_request_t *r);
 static ngx_int_t ngx_http_v3_early_hints_filter(ngx_http_request_t *r);
-static ngx_int_t ngx_http_v3_body_filter(ngx_http_request_t *r,
-    ngx_chain_t *in);
 static ngx_chain_t *ngx_http_v3_create_trailers(ngx_http_request_t *r,
     ngx_http_v3_filter_ctx_t *ctx);
 static ngx_int_t ngx_http_v3_filter_init(ngx_conf_t *cf);
@@ -117,6 +115,14 @@ ngx_http_v3_header_filter(ngx_http_request_t *r)
 
     if (r->method == NGX_HTTP_HEAD) {
         r->header_only = 1;
+    }
+
+    if (r->headers_out.status == NGX_HTTP_SWITCHING_PROTOCOLS
+        && r->stream_connect == NGX_HTTP_PROTOCOL_WEBSOCKET
+        && r->upstream && r->upstream->upgrade)
+    {
+        r->headers_out.status = NGX_HTTP_OK;
+        ngx_str_null(&r->headers_out.status_line);
     }
 
     if (r->headers_out.last_modified_time != -1) {
@@ -735,7 +741,7 @@ ngx_http_v3_early_hints_filter(ngx_http_request_t *r)
 }
 
 
-static ngx_int_t
+ngx_int_t
 ngx_http_v3_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
     u_char                    *chunk;

--- a/src/http/v3/ngx_http_v3_module.c
+++ b/src/http/v3/ngx_http_v3_module.c
@@ -20,6 +20,14 @@ static char *ngx_http_quic_host_key(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 
 
+static ngx_conf_enum_t  ngx_http_v3_extended_connect[] = {
+    { ngx_string("off"), NGX_HTTP_V3_EXTENDED_CONNECT_OFF },
+    { ngx_string("on"), NGX_HTTP_V3_EXTENDED_CONNECT_ON },
+    { ngx_string("advertise"), NGX_HTTP_V3_EXTENDED_CONNECT_ADVERTISE },
+    { ngx_null_string, 0 }
+};
+
+
 static ngx_command_t  ngx_http_v3_commands[] = {
 
     { ngx_string("http3"),
@@ -42,6 +50,13 @@ static ngx_command_t  ngx_http_v3_commands[] = {
       NGX_HTTP_SRV_CONF_OFFSET,
       offsetof(ngx_http_v3_srv_conf_t, max_concurrent_streams),
       NULL },
+
+    { ngx_string("http3_extended_connect"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_enum_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_v3_srv_conf_t, extended_connect),
+      &ngx_http_v3_extended_connect },
 
     { ngx_string("http3_stream_buffer_size"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
@@ -200,6 +215,7 @@ ngx_http_v3_create_srv_conf(ngx_conf_t *cf)
     h3scf->enable_hq = NGX_CONF_UNSET;
     h3scf->max_table_capacity = NGX_HTTP_V3_MAX_TABLE_CAPACITY;
     h3scf->max_concurrent_streams = NGX_CONF_UNSET_UINT;
+    h3scf->extended_connect = NGX_CONF_UNSET_UINT;
 
     h3scf->quic.stream_buffer_size = NGX_CONF_UNSET_SIZE;
     h3scf->quic.max_concurrent_streams_bidi = NGX_CONF_UNSET_UINT;
@@ -234,6 +250,9 @@ ngx_http_v3_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
                               prev->max_concurrent_streams, 128);
 
     conf->max_blocked_streams = conf->max_concurrent_streams;
+
+    ngx_conf_merge_uint_value(conf->extended_connect, prev->extended_connect,
+                              NGX_HTTP_V3_EXTENDED_CONNECT_ON);
 
     ngx_conf_merge_size_value(conf->quic.stream_buffer_size,
                               prev->quic.stream_buffer_size,

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -937,11 +937,14 @@ failed:
 static ngx_int_t
 ngx_http_v3_init_pseudo_headers(ngx_http_request_t *r)
 {
-    size_t      len;
-    u_char     *p;
-    ngx_int_t   rc;
-    ngx_str_t   host;
-    in_port_t   port;
+    size_t                     len;
+    u_char                    *p;
+    ngx_int_t                  rc;
+    ngx_str_t                  host, target;
+    in_port_t                  port;
+    ngx_http_core_srv_conf_t  *cscf;
+
+    static ngx_str_t  path = ngx_string("/");
 
     if (r->request_line.len) {
         return NGX_OK;
@@ -951,6 +954,48 @@ ngx_http_v3_init_pseudo_headers(ngx_http_request_t *r)
         ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                       "client sent no \":method\" header");
         goto failed;
+    }
+
+    if (r->method == NGX_HTTP_CONNECT
+        && r->stream_connect == NGX_HTTP_PROTOCOL_NONE)
+    {
+        if (r->schema.len) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent CONNECT with \":scheme\" header");
+            goto failed;
+        }
+
+        if (r->uri_start != NULL) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent CONNECT with \":path\" header");
+            goto failed;
+        }
+
+        if (r->host_start == NULL) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent CONNECT without \":authority\" header");
+            goto failed;
+        }
+
+        host.len = r->host_end - r->host_start;
+        host.data = r->host_start;
+
+        if (ngx_http_validate_host(&host, &port, r->pool, 0) != NGX_OK) {
+            ngx_str_set(&target, "-");
+            goto construct;
+        }
+
+        if (port == 0) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent CONNECT without port in \":authority\" "
+                          "header");
+            goto failed;
+        }
+
+        target.len = r->host_end - r->host_start;
+        target.data = r->host_start;
+
+        goto construct;
     }
 
     if (r->schema.len == 0) {
@@ -965,8 +1010,13 @@ ngx_http_v3_init_pseudo_headers(ngx_http_request_t *r)
         goto failed;
     }
 
+    target.len = r->uri_end - r->uri_start;
+    target.data = r->uri_start;
+
+construct:
+
     len = r->method_name.len + 1
-          + (r->uri_end - r->uri_start) + 1
+          + target.len + 1
           + sizeof("HTTP/3.0") - 1;
 
     p = ngx_pnalloc(r->pool, len);
@@ -979,7 +1029,7 @@ ngx_http_v3_init_pseudo_headers(ngx_http_request_t *r)
 
     p = ngx_cpymem(p, r->method_name.data, r->method_name.len);
     *p++ = ' ';
-    p = ngx_cpymem(p, r->uri_start, r->uri_end - r->uri_start);
+    p = ngx_cpymem(p, target.data, target.len);
     *p++ = ' ';
     p = ngx_cpymem(p, "HTTP/3.0", sizeof("HTTP/3.0") - 1);
 
@@ -989,6 +1039,13 @@ ngx_http_v3_init_pseudo_headers(ngx_http_request_t *r)
                    "http3 request line: \"%V\"", &r->request_line);
 
     ngx_str_set(&r->http_protocol, "HTTP/3.0");
+
+    if (r->method == NGX_HTTP_CONNECT
+        && r->stream_connect == NGX_HTTP_PROTOCOL_NONE)
+    {
+        r->uri_start = path.data;
+        r->uri_end = path.data + path.len;
+    }
 
     if (ngx_http_process_request_uri(r) != NGX_OK) {
         return NGX_ERROR;
@@ -1018,6 +1075,16 @@ ngx_http_v3_init_pseudo_headers(ngx_http_request_t *r)
 
         r->headers_in.server = host;
         r->port = port;
+    }
+
+    if (r->method == NGX_HTTP_CONNECT
+        && r->stream_connect == NGX_HTTP_PROTOCOL_NONE)
+    {
+        cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+
+        if (cscf->allow_connect) {
+            r->stream_connect = NGX_HTTP_PROTOCOL_TUNNEL;
+        }
     }
 
     if (ngx_list_init(&r->headers_in.headers, r->pool, 20,

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -896,6 +896,34 @@ ngx_http_v3_process_pseudo_header(ngx_http_request_t *r, ngx_str_t *name,
         return NGX_OK;
     }
 
+    if (name->len == 9 && ngx_strncmp(name->data, ":protocol", 9) == 0) {
+
+        if (r->stream_connect) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent duplicate \":protocol\" header");
+            goto failed;
+        }
+
+        if (value->len == 0) {
+            ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                          "client sent empty \":protocol\" header");
+            goto failed;
+        }
+
+        if (value->len == 9 && ngx_memcmp(value->data, "websocket", 9) == 0) {
+            r->stream_connect = NGX_HTTP_PROTOCOL_WEBSOCKET;
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http3 protocol \"%V\"", value);
+            return NGX_OK;
+        }
+
+        ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
+                      "client sent unsupported \":protocol\" header: \"%V\"",
+                      value);
+        goto failed;
+    }
+
     ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                   "client sent unknown pseudo-header \"%V\"", name);
 
@@ -1137,8 +1165,40 @@ ngx_http_v3_process_request_header(ngx_http_request_t *r)
     }
 
     if (r->method == NGX_HTTP_CONNECT) {
-        ngx_log_error(NGX_LOG_INFO, c->log, 0, "client sent CONNECT method");
-        ngx_http_finalize_request(r, NGX_HTTP_NOT_ALLOWED);
+        if (!r->stream_connect) {
+            ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                          "client sent CONNECT method");
+            ngx_http_finalize_request(r, NGX_HTTP_NOT_ALLOWED);
+            return NGX_ERROR;
+        }
+
+        if (r->stream_connect >= NGX_HTTP_PROTOCOL_WEBSOCKET
+            && h3scf->extended_connect == NGX_HTTP_V3_EXTENDED_CONNECT_OFF)
+        {
+            ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                          "client sent CONNECT method with \":protocol\" "
+                          "header");
+            ngx_http_finalize_request(r, NGX_HTTP_NOT_ALLOWED);
+            return NGX_ERROR;
+        }
+
+        if (r->headers_in.content_length_n > 0) {
+            ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                          "client sent CONNECT request with body");
+            ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
+            return NGX_ERROR;
+        }
+
+        if (r->headers_in.content_length_n == 0) {
+            r->headers_in.content_length_n = -1;
+            r->headers_in.chunked = 1;
+        }
+
+    } else if (r->stream_connect) {
+        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                      "client sent %V with \":protocol\" header",
+                      &r->method_name);
+        ngx_http_finalize_request(r, NGX_HTTP_BAD_REQUEST);
         return NGX_ERROR;
     }
 
@@ -1575,7 +1635,10 @@ ngx_http_v3_request_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
     max = r->headers_in.content_length_n;
 
-    if (max == -1 && clcf->client_max_body_size) {
+    if (r->stream_connect && r->upstream && r->upstream->upgrade) {
+        /* skip client_max_body_size */
+
+    } else if (max == -1 && clcf->client_max_body_size) {
         max = clcf->client_max_body_size;
     }
 

--- a/src/http/v3/ngx_http_v3_uni.c
+++ b/src/http/v3/ngx_http_v3_uni.c
@@ -396,7 +396,7 @@ failed:
 ngx_int_t
 ngx_http_v3_send_settings(ngx_connection_t *c)
 {
-    u_char                  *p, buf[NGX_HTTP_V3_VARLEN_INT_LEN * 6];
+    u_char                  *p, buf[NGX_HTTP_V3_VARLEN_INT_LEN * 8];
     size_t                   n;
     ngx_connection_t        *cc;
     ngx_http_v3_session_t   *h3c;
@@ -417,6 +417,12 @@ ngx_http_v3_send_settings(ngx_connection_t *c)
     n += ngx_http_v3_encode_varlen_int(NULL, NGX_HTTP_V3_PARAM_BLOCKED_STREAMS);
     n += ngx_http_v3_encode_varlen_int(NULL, h3scf->max_blocked_streams);
 
+    if (h3scf->extended_connect == NGX_HTTP_V3_EXTENDED_CONNECT_ADVERTISE) {
+        n += ngx_http_v3_encode_varlen_int(NULL,
+                                    NGX_HTTP_V3_PARAM_ENABLE_CONNECT_PROTOCOL);
+        n += ngx_http_v3_encode_varlen_int(NULL, 1);
+    }
+
     p = (u_char *) ngx_http_v3_encode_varlen_int(buf,
                                                  NGX_HTTP_V3_FRAME_SETTINGS);
     p = (u_char *) ngx_http_v3_encode_varlen_int(p, n);
@@ -426,6 +432,13 @@ ngx_http_v3_send_settings(ngx_connection_t *c)
     p = (u_char *) ngx_http_v3_encode_varlen_int(p,
                                             NGX_HTTP_V3_PARAM_BLOCKED_STREAMS);
     p = (u_char *) ngx_http_v3_encode_varlen_int(p, h3scf->max_blocked_streams);
+
+    if (h3scf->extended_connect == NGX_HTTP_V3_EXTENDED_CONNECT_ADVERTISE) {
+        p = (u_char *) ngx_http_v3_encode_varlen_int(p,
+                                    NGX_HTTP_V3_PARAM_ENABLE_CONNECT_PROTOCOL);
+        p = (u_char *) ngx_http_v3_encode_varlen_int(p, 1);
+    }
+
     n = p - buf;
 
     h3c = ngx_http_v3_get_session(c);


### PR DESCRIPTION
## Problem

`nginx` has no support for WebSocket over HTTP/2 or HTTP/3.

Some users asked support several years ago in [Websocket over HTTP/2 support](https://trac.nginx.org/nginx/ticket/1992).

And tunnel over HTTP/2 or HTTP/3 should be supported too as in #1277.


## Solution

### Added http2_extended_connect and http3_extended_connect directives.

```
    off:        extended CONNECT is rejected
    on:         extended CONNECT is accepted (default)
    advertise:  extended CONNECT is accepted and advertised
```

Chrome / Firefox requires `advertise` to use WebSocket over HTTP/2.

### Upstream: WebSocket over HTTP/2 and HTTP/3.

The request is bridged to an HTTP/1.1 WebSocket handshake to the upstream
and the 101 response is mapped back to 200.

### CONNECT method support for HTTP/2 and HTTP/3.


## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] WebSocket over HTTP/2 Testing with Chrome / Firefox
- [x] WebSocket over HTTP/2 and HTTP/3 Testing with WebSocket tunnel
- [x] Tunnel over HTTP/2 Testing with Chrome / Firefox
- [x] Tunnel over HTTP/2 and HTTP/3 Testing with curl
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [ ] I have updated documentation where necessary
- [ ] My branch is rebased on the latest master
- [ ] This PR targets the master branch from my fork
- [ ] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Behaviour change for plain CONNECT

The status codes now match HTTP/1.1 exactly. Measured, h2 and h3 identical:

| Request form | HTTP/1.1 (unchanged) | h2/h3 before | h2/h3 after |
| --- | --- | --- | --- |
| conforming CONNECT, no `tunnel_pass` | 405 | ~400~ `no :scheme` | **405** |
| conforming CONNECT, `tunnel_pass` set | 200 | ~400~ | **200** |
| `:authority` missing | — | 400 | 400 |
| `:authority` without port | 400 | 400 | 400 |
| `:scheme` present | 400 | 400 | 400 |
| `:path` present | 400 | 400 | 400 |
| both `:scheme` and `:path` | 400 | ~405~ | **400** |