### PR TITLE
Preinitialize ngx_pagesize with max uint value

### DIFF
--- a/src/os/unix/ngx_alloc.c
+++ b/src/os/unix/ngx_alloc.c
@@ -9,7 +9,7 @@
 #include <ngx_core.h>
 
 
-ngx_uint_t  ngx_pagesize;
+ngx_uint_t  ngx_pagesize = NGX_MAX_UINT32_VALUE;
 ngx_uint_t  ngx_pagesize_shift;
 ngx_uint_t  ngx_cacheline_size;
 

--- a/src/os/win32/ngx_alloc.c
+++ b/src/os/win32/ngx_alloc.c
@@ -9,7 +9,7 @@
 #include <ngx_core.h>
 
 
-ngx_uint_t  ngx_pagesize;
+ngx_uint_t  ngx_pagesize = NGX_MAX_UINT32_VALUE;
 ngx_uint_t  ngx_pagesize_shift;
 ngx_uint_t  ngx_cacheline_size;
 


### PR DESCRIPTION
## Problem
Since `ngx_create_pool` uses `ngx_pagesize - 1` and it's called before `ngx_pagesize` is initialized with actual OS page size it leads to underflow when trying to create pool for `init_cycle.log` which is required to get OS page size. This situation causes UBSan to report underflow when there's no actual problem with exsisting code.

## Solution

The fix is preintialize `ngx_pagesize` with `NGX_MAX_UINT32_VALUE` so underflow never happens (so UBSan is happy) and code acts the same as before.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1646

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)