### PR TITLE
FastCGI, uWSGI: support for multibyte parameter name lengths

### DIFF
--- a/src/core/nginx.h
+++ b/src/core/nginx.h
@@ -9,8 +9,8 @@
 #define _NGINX_H_INCLUDED_
 
 
-#define nginx_version      1031004
-#define NGINX_VERSION      "1.31.4"
+#define nginx_version      1031005
+#define NGINX_VERSION      "1.31.5"
 #define NGINX_VER          "nginx/" NGINX_VERSION
 
 #ifdef NGX_BUILD

--- a/src/http/modules/ngx_http_fastcgi_module.c
+++ b/src/http/modules/ngx_http_fastcgi_module.c
@@ -915,7 +915,8 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
                 continue;
             }
 
-            params_len += 1 + key_len + ((val_len > 127) ? 4 : 1) + val_len;
+            params_len += ((key_len > 127) ? 4 : 1) + key_len
+                          + ((val_len > 127) ? 4 : 1) + val_len;
         }
 
         len += params_len;
@@ -1083,7 +1084,7 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
         while (*(uintptr_t *) le.ip) {
 
             lcode = *(ngx_http_script_len_code_pt *) le.ip;
-            key_len = (u_char) lcode(&le);
+            key_len = lcode(&le);
 
             lcode = *(ngx_http_script_len_code_pt *) le.ip;
             skip_empty = lcode(&le);
@@ -1107,13 +1108,23 @@ ngx_http_fastcgi_create_request(ngx_http_request_t *r)
                 continue;
             }
 
-            if (ngx_http_script_check_length(&e, 1 + ((val_len > 127) ? 4 : 1))
+            if (ngx_http_script_check_length(&e,
+                                             ((key_len > 127) ? 4 : 1)
+                                             + ((val_len > 127) ? 4 : 1))
                 != NGX_OK)
             {
                 return NGX_ERROR;
             }
 
-            *e.pos++ = (u_char) key_len;
+            if (key_len > 127) {
+                *e.pos++ = (u_char) (((key_len >> 24) & 0x7f) | 0x80);
+                *e.pos++ = (u_char) ((key_len >> 16) & 0xff);
+                *e.pos++ = (u_char) ((key_len >> 8) & 0xff);
+                *e.pos++ = (u_char) (key_len & 0xff);
+
+            } else {
+                *e.pos++ = (u_char) key_len;
+            }
 
             if (val_len > 127) {
                 *e.pos++ = (u_char) (((val_len >> 24) & 0x7f) | 0x80);

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -1075,7 +1075,7 @@ ngx_http_uwsgi_create_request(ngx_http_request_t *r)
         while (*(uintptr_t *) le.ip) {
 
             lcode = *(ngx_http_script_len_code_pt *) le.ip;
-            key_len = (u_char) lcode(&le);
+            key_len = lcode(&le);
 
             lcode = *(ngx_http_script_len_code_pt *) le.ip;
             skip_empty = lcode(&le);


### PR DESCRIPTION
Long configured parameter names are not encoded: the name length is truncated to one byte before the per-parameter length field is written:

```c
key_len = (u_char) lcode(&le);
...
*e.pos++ = (u_char) key_len;          /* fastcgi */
```

while the length pass uses the full length and the name itself is copied in full by the script codes. A `fastcgi_param` name of 128 bytes or longer, or a `uwsgi_param` name of 256 bytes or longer, is therefore encoded with a wrong length, and the request sent upstream is malformed.

Captured from the wire with a 260-byte parameter name, before the change:

```
fastcgi:  key length field  04              (should be 80 00 01 04)
uwsgi:    key length field  04 00 == 4      (should be 04 01 == 260)
```

with all 260 name bytes copied in both cases. Real backends reject this -- PHP-CGI resets the connection and uWSGI closes it, so nginx answers 502 for every request to that location.

The FastCGI length pass also reserved a single byte for the field unconditionally, so the four-byte form needs accounting for there as well. Both paths now follow what the request header path in the same functions already does.

Long names are barely used in practice, so this is an implementation limitation rather than a bug -- but it is easy to support them, and the length is now encoded up to the allowed length.

Note the equivalent code for request headers is already correct in both modules -- `ngx_http_fastcgi_create_request()` emits the four-byte form for header names longer than 127 bytes, and the uWSGI header path writes the 16-bit field without a cast. Only the configured-parameter path was affected. SCGI is not affected: it uses netstrings, with no fixed-width per-parameter length field.

After the change, captured the same way:

```
fastcgi:  80 00 01 04  -> 260
uwsgi:    04 01        -> 260
```

and a 127-byte name still uses the one-byte form (`7f`), so the boundary is unchanged.

Reported by Vu Duc Truong, with reproduction and validation by Pham Quang Minh.



Split into two commits, one per module, as suggested in review.