### PR TITLE
SSL: removed OpenSSL 0.9.8 and 1.0.0 compatibility.

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -444,11 +444,7 @@ ngx_show_version_info(void)
             ngx_write_stderr((char *) (uintptr_t) ngx_ssl_version());
             ngx_write_stderr(")" NGX_LINEFEED);
         }
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
         ngx_write_stderr("TLS SNI support enabled" NGX_LINEFEED);
-#else
-        ngx_write_stderr("TLS SNI support disabled" NGX_LINEFEED);
-#endif
 #endif
 
         ngx_write_stderr("configure arguments:" NGX_CONFIGURE NGX_LINEFEED);

--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -462,11 +462,7 @@ ngx_show_version_info(void)
             ngx_write_stderr((char *) (uintptr_t) ngx_ssl_version());
             ngx_write_stderr(")" NGX_LINEFEED);
         }
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
         ngx_write_stderr("TLS SNI support enabled" NGX_LINEFEED);
-#else
-        ngx_write_stderr("TLS SNI support disabled" NGX_LINEFEED);
-#endif
 #endif
 
         ngx_write_stderr("configure arguments:" NGX_CONFIGURE NGX_LINEFEED);

--- a/src/core/ngx_proxy_protocol.c
+++ b/src/core/ngx_proxy_protocol.c
@@ -838,8 +838,6 @@ ngx_proxy_protocol_v2_eval_ssl(ngx_connection_t *c, ngx_array_t *tlvs,
 static ngx_int_t
 ngx_proxy_protocol_v2_authority(ngx_connection_t *c, ngx_str_t *out)
 {
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-
     const char  *sni;
 
     sni = SSL_get_servername(c->ssl->connection, TLSEXT_NAMETYPE_host_name);
@@ -849,11 +847,8 @@ ngx_proxy_protocol_v2_authority(ngx_connection_t *c, ngx_str_t *out)
 
     out->data = (u_char *) sni;
     out->len = ngx_strlen(sni);
-    return NGX_OK;
 
-#else
-    return NGX_DECLINED;
-#endif
+    return NGX_OK;
 }
 
 

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -64,13 +64,11 @@ static void ngx_ssl_expire_sessions(ngx_ssl_session_cache_t *cache,
 static void ngx_ssl_session_rbtree_insert_value(ngx_rbtree_node_t *temp,
     ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
 
-#ifdef SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB
 static int ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
     unsigned char *name, unsigned char *iv, EVP_CIPHER_CTX *ectx,
     HMAC_CTX *hctx, int enc);
 static ngx_int_t ngx_ssl_rotate_ticket_keys(SSL_CTX *ssl_ctx, ngx_log_t *log);
 static void ngx_ssl_ticket_keys_cleanup(void *data);
-#endif
 
 #ifndef X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT
 static ngx_int_t ngx_ssl_check_name(ngx_str_t *name, ASN1_STRING *str);
@@ -197,24 +195,6 @@ ngx_ssl_init(ngx_log_t *log)
 
 #endif
 
-#ifndef SSL_OP_NO_COMPRESSION
-    {
-    /*
-     * Disable gzip compression in OpenSSL prior to 1.0.0 version,
-     * this saves about 522K per connection.
-     */
-    int                  n;
-    STACK_OF(SSL_COMP)  *ssl_comp_methods;
-
-    ssl_comp_methods = SSL_COMP_get_compression_methods();
-    n = sk_SSL_COMP_num(ssl_comp_methods);
-
-    while (n--) {
-        (void) sk_SSL_COMP_pop(ssl_comp_methods);
-    }
-    }
-#endif
-
     ngx_ssl_connection_index = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
 
     if (ngx_ssl_connection_index == -1) {
@@ -336,13 +316,12 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
     SSL_CTX_set_options(ssl->ctx, SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS);
 #endif
 
+    /* not needed since OpenSSL 1.0.1r and 1.0.2f */
     SSL_CTX_set_options(ssl->ctx, SSL_OP_SINGLE_DH_USE);
 
-#if OPENSSL_VERSION_NUMBER >= 0x009080dfL
-    /* only in 0.9.8m+ */
     SSL_CTX_clear_options(ssl->ctx,
-                          SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1);
-#endif
+                          SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1
+                          |SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1_2);
 
     if (!(protocols & NGX_SSL_SSLv2)) {
         SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_SSLv2);
@@ -353,18 +332,12 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
     if (!(protocols & NGX_SSL_TLSv1)) {
         SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_TLSv1);
     }
-#ifdef SSL_OP_NO_TLSv1_1
-    SSL_CTX_clear_options(ssl->ctx, SSL_OP_NO_TLSv1_1);
     if (!(protocols & NGX_SSL_TLSv1_1)) {
         SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_TLSv1_1);
     }
-#endif
-#ifdef SSL_OP_NO_TLSv1_2
-    SSL_CTX_clear_options(ssl->ctx, SSL_OP_NO_TLSv1_2);
     if (!(protocols & NGX_SSL_TLSv1_2)) {
         SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_TLSv1_2);
     }
-#endif
 #ifdef SSL_OP_NO_TLSv1_3
     SSL_CTX_clear_options(ssl->ctx, SSL_OP_NO_TLSv1_3);
     if (!(protocols & NGX_SSL_TLSv1_3)) {
@@ -382,9 +355,7 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
     SSL_CTX_set_max_proto_version(ssl->ctx, TLS1_3_VERSION);
 #endif
 
-#ifdef SSL_OP_NO_COMPRESSION
     SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_COMPRESSION);
-#endif
 
 #ifdef SSL_OP_NO_ANTI_REPLAY
     SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_ANTI_REPLAY);
@@ -398,13 +369,9 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
     SSL_CTX_set_options(ssl->ctx, SSL_OP_IGNORE_UNEXPECTED_EOF);
 #endif
 
-#ifdef SSL_MODE_RELEASE_BUFFERS
     SSL_CTX_set_mode(ssl->ctx, SSL_MODE_RELEASE_BUFFERS);
-#endif
 
-#ifdef SSL_MODE_NO_AUTO_CHAIN
     SSL_CTX_set_mode(ssl->ctx, SSL_MODE_NO_AUTO_CHAIN);
-#endif
 
     SSL_CTX_set_read_ahead(ssl->ctx, 1);
 
@@ -1994,11 +1961,8 @@ ngx_ssl_try_early_data(ngx_connection_t *c)
 void
 ngx_ssl_handshake_log(ngx_connection_t *c)
 {
-    char         buf[129], *s, *d;
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-    const
-#endif
-    SSL_CIPHER  *cipher;
+    char               buf[129], *s, *d;
+    const SSL_CIPHER  *cipher;
 
     if (!(c->log->log_level & NGX_LOG_DEBUG_EVENT)) {
         return;
@@ -3385,9 +3349,7 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
 #ifdef SSL_R_LENGTH_TOO_SHORT
             || n == SSL_R_LENGTH_TOO_SHORT                           /*  160 */
 #endif
-#ifdef SSL_R_NO_RENEGOTIATION
             || n == SSL_R_NO_RENEGOTIATION                           /*  182 */
-#endif
 #ifdef SSL_R_NO_CIPHERS_PASSED
             || n == SSL_R_NO_CIPHERS_PASSED                          /*  182 */
 #endif
@@ -3404,12 +3366,8 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
 #ifdef SSL_R_TOO_MANY_WARNING_ALERTS
             || n == SSL_R_TOO_MANY_WARNING_ALERTS                    /*  220 */
 #endif
-#ifdef SSL_R_CLIENTHELLO_TLSEXT
             || n == SSL_R_CLIENTHELLO_TLSEXT                         /*  226 */
-#endif
-#ifdef SSL_R_PARSE_TLSEXT
             || n == SSL_R_PARSE_TLSEXT                               /*  227 */
-#endif
 #ifdef SSL_R_CALLBACK_FAILED
             || n == SSL_R_CALLBACK_FAILED                            /*  234 */
 #endif
@@ -3460,23 +3418,15 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
 #ifdef SSL_R_SSL3_SESSION_ID_TOO_LONG
             || n == SSL_R_SSL3_SESSION_ID_TOO_LONG                   /*  300 */
 #endif
-#ifdef SSL_R_BAD_ECPOINT
             || n == SSL_R_BAD_ECPOINT                                /*  306 */
-#endif
 #ifdef SSL_R_RENEGOTIATE_EXT_TOO_LONG
             || n == SSL_R_RENEGOTIATE_EXT_TOO_LONG                   /*  335 */
             || n == SSL_R_RENEGOTIATION_ENCODING_ERR                 /*  336 */
             || n == SSL_R_RENEGOTIATION_MISMATCH                     /*  337 */
 #endif
-#ifdef SSL_R_UNSAFE_LEGACY_RENEGOTIATION_DISABLED
             || n == SSL_R_UNSAFE_LEGACY_RENEGOTIATION_DISABLED       /*  338 */
-#endif
-#ifdef SSL_R_SCSV_RECEIVED_WHEN_RENEGOTIATING
             || n == SSL_R_SCSV_RECEIVED_WHEN_RENEGOTIATING           /*  345 */
-#endif
-#ifdef SSL_R_INAPPROPRIATE_FALLBACK
             || n == SSL_R_INAPPROPRIATE_FALLBACK                     /*  373 */
-#endif
 #ifdef SSL_R_NO_SHARED_SIGNATURE_ALGORITHMS
             || n == SSL_R_NO_SHARED_SIGNATURE_ALGORITHMS             /*  376 */
 #endif
@@ -3496,7 +3446,6 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
             || n == SSL_R_BAD_RECORD_TYPE                            /*  443 */
 #endif
             || n == 1000 /* SSL_R_SSLV3_ALERT_CLOSE_NOTIFY */
-#ifdef SSL_R_SSLV3_ALERT_UNEXPECTED_MESSAGE
             || n == SSL_R_SSLV3_ALERT_UNEXPECTED_MESSAGE             /* 1010 */
             || n == SSL_R_SSLV3_ALERT_BAD_RECORD_MAC                 /* 1020 */
             || n == SSL_R_TLSV1_ALERT_DECRYPTION_FAILED              /* 1021 */
@@ -3520,7 +3469,6 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
             || n == SSL_R_TLSV1_ALERT_INTERNAL_ERROR                 /* 1080 */
             || n == SSL_R_TLSV1_ALERT_USER_CANCELLED                 /* 1090 */
             || n == SSL_R_TLSV1_ALERT_NO_RENEGOTIATION               /* 1100 */
-#endif
             )
         {
             switch (c->log_error) {
@@ -4294,8 +4242,6 @@ ngx_ssl_session_rbtree_insert_value(ngx_rbtree_node_t *temp,
 }
 
 
-#ifdef SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB
-
 ngx_int_t
 ngx_ssl_session_ticket_keys(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *paths)
 {
@@ -4517,14 +4463,10 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
             return -1;
         }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
         if (HMAC_Init_ex(hctx, key[0].hmac_key, size, digest, NULL) != 1) {
             ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
             return -1;
         }
-#else
-        HMAC_Init_ex(hctx, key[0].hmac_key, size, digest, NULL);
-#endif
 
         ngx_memcpy(name, key[0].name, 16);
 
@@ -4560,14 +4502,10 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
             size = 32;
         }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
         if (HMAC_Init_ex(hctx, key[i].hmac_key, size, digest, NULL) != 1) {
             ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
             return -1;
         }
-#else
-        HMAC_Init_ex(hctx, key[i].hmac_key, size, digest, NULL);
-#endif
 
         if (EVP_DecryptInit_ex(ectx, cipher, NULL, key[i].aes_key, iv) != 1) {
             ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
@@ -4731,21 +4669,6 @@ ngx_ssl_ticket_keys_cleanup(void *data)
     ngx_explicit_memzero(keys->elts,
                          keys->nelts * sizeof(ngx_ssl_ticket_key_t));
 }
-
-#else
-
-ngx_int_t
-ngx_ssl_session_ticket_keys(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_array_t *paths)
-{
-    if (paths) {
-        ngx_log_error(NGX_LOG_WARN, ssl->log, 0,
-                      "\"ssl_session_ticket_key\" ignored, not supported");
-    }
-
-    return NGX_OK;
-}
-
-#endif
 
 
 void
@@ -5212,8 +5135,6 @@ ngx_ssl_get_early_data(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 ngx_int_t
 ngx_ssl_get_server_name(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 {
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-
     size_t       len;
     const char  *name;
 
@@ -5232,8 +5153,6 @@ ngx_ssl_get_server_name(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 
         return NGX_OK;
     }
-
-#endif
 
     s->len = 0;
     return NGX_OK;

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -211,24 +211,6 @@ ngx_ssl_init(ngx_log_t *log)
 
 #endif
 
-#ifndef SSL_OP_NO_COMPRESSION
-    {
-    /*
-     * Disable gzip compression in OpenSSL prior to 1.0.0 version,
-     * this saves about 522K per connection.
-     */
-    int                  n;
-    STACK_OF(SSL_COMP)  *ssl_comp_methods;
-
-    ssl_comp_methods = SSL_COMP_get_compression_methods();
-    n = sk_SSL_COMP_num(ssl_comp_methods);
-
-    while (n--) {
-        (void) sk_SSL_COMP_pop(ssl_comp_methods);
-    }
-    }
-#endif
-
     ngx_ssl_connection_index = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
 
     if (ngx_ssl_connection_index == -1) {
@@ -365,13 +347,12 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
     SSL_CTX_set_options(ssl->ctx, SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS);
 #endif
 
+    /* not needed since OpenSSL 1.0.1r and 1.0.2f */
     SSL_CTX_set_options(ssl->ctx, SSL_OP_SINGLE_DH_USE);
 
-#if OPENSSL_VERSION_NUMBER >= 0x009080dfL
-    /* only in 0.9.8m+ */
     SSL_CTX_clear_options(ssl->ctx,
-                          SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1);
-#endif
+                          SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1
+                          |SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1_2);
 
     if (!(protocols & NGX_SSL_SSLv2)) {
         SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_SSLv2);
@@ -382,18 +363,12 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
     if (!(protocols & NGX_SSL_TLSv1)) {
         SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_TLSv1);
     }
-#ifdef SSL_OP_NO_TLSv1_1
-    SSL_CTX_clear_options(ssl->ctx, SSL_OP_NO_TLSv1_1);
     if (!(protocols & NGX_SSL_TLSv1_1)) {
         SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_TLSv1_1);
     }
-#endif
-#ifdef SSL_OP_NO_TLSv1_2
-    SSL_CTX_clear_options(ssl->ctx, SSL_OP_NO_TLSv1_2);
     if (!(protocols & NGX_SSL_TLSv1_2)) {
         SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_TLSv1_2);
     }
-#endif
 #ifdef SSL_OP_NO_TLSv1_3
     SSL_CTX_clear_options(ssl->ctx, SSL_OP_NO_TLSv1_3);
     if (!(protocols & NGX_SSL_TLSv1_3)) {
@@ -411,9 +386,7 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
     SSL_CTX_set_max_proto_version(ssl->ctx, TLS1_3_VERSION);
 #endif
 
-#ifdef SSL_OP_NO_COMPRESSION
     SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_COMPRESSION);
-#endif
 
 #ifdef SSL_OP_NO_TX_CERTIFICATE_COMPRESSION
     SSL_CTX_set_options(ssl->ctx, SSL_OP_NO_TX_CERTIFICATE_COMPRESSION);
@@ -432,13 +405,9 @@ ngx_ssl_create(ngx_ssl_t *ssl, ngx_uint_t protocols, void *data)
     SSL_CTX_set_options(ssl->ctx, SSL_OP_IGNORE_UNEXPECTED_EOF);
 #endif
 
-#ifdef SSL_MODE_RELEASE_BUFFERS
     SSL_CTX_set_mode(ssl->ctx, SSL_MODE_RELEASE_BUFFERS);
-#endif
 
-#ifdef SSL_MODE_NO_AUTO_CHAIN
     SSL_CTX_set_mode(ssl->ctx, SSL_MODE_NO_AUTO_CHAIN);
-#endif
 
     SSL_CTX_set_read_ahead(ssl->ctx, 1);
 
@@ -2492,11 +2461,8 @@ ngx_ssl_try_early_data(ngx_connection_t *c)
 void
 ngx_ssl_handshake_log(ngx_connection_t *c)
 {
-    char         buf[129], *s, *d;
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-    const
-#endif
-    SSL_CIPHER  *cipher;
+    char               buf[129], *s, *d;
+    const SSL_CIPHER  *cipher;
 
     if (!(c->log->log_level & NGX_LOG_DEBUG_EVENT)) {
         return;
@@ -3883,9 +3849,7 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
 #ifdef SSL_R_LENGTH_TOO_SHORT
             || n == SSL_R_LENGTH_TOO_SHORT                           /*  160 */
 #endif
-#ifdef SSL_R_NO_RENEGOTIATION
             || n == SSL_R_NO_RENEGOTIATION                           /*  182 */
-#endif
 #ifdef SSL_R_NO_CIPHERS_PASSED
             || n == SSL_R_NO_CIPHERS_PASSED                          /*  182 */
 #endif
@@ -3905,12 +3869,8 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
 #ifdef SSL_R_TOO_MANY_WARNING_ALERTS
             || n == SSL_R_TOO_MANY_WARNING_ALERTS                    /*  220 */
 #endif
-#ifdef SSL_R_CLIENTHELLO_TLSEXT
             || n == SSL_R_CLIENTHELLO_TLSEXT                         /*  226 */
-#endif
-#ifdef SSL_R_PARSE_TLSEXT
             || n == SSL_R_PARSE_TLSEXT                               /*  227 */
-#endif
 #ifdef SSL_R_CALLBACK_FAILED
             || n == SSL_R_CALLBACK_FAILED                            /*  234 */
 #endif
@@ -3963,9 +3923,7 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
 #elif (defined SSL_R_TLS_SESSION_ID_TOO_LONG)
             || n == SSL_R_TLS_SESSION_ID_TOO_LONG                    /*  300 */
 #endif
-#ifdef SSL_R_BAD_ECPOINT
             || n == SSL_R_BAD_ECPOINT                                /*  306 */
-#endif
 #ifdef SSL_R_RECORD_LAYER_FAILURE
             || n == SSL_R_RECORD_LAYER_FAILURE                       /*  313 */
 #endif
@@ -3974,15 +3932,9 @@ ngx_ssl_connection_error(ngx_connection_t *c, int sslerr, ngx_err_t err,
             || n == SSL_R_RENEGOTIATION_ENCODING_ERR                 /*  336 */
             || n == SSL_R_RENEGOTIATION_MISMATCH                     /*  337 */
 #endif
-#ifdef SSL_R_UNSAFE_LEGACY_RENEGOTIATION_DISABLED
             || n == SSL_R_UNSAFE_LEGACY_RENEGOTIATION_DISABLED       /*  338 */
-#endif
-#ifdef SSL_R_SCSV_RECEIVED_WHEN_RENEGOTIATING
             || n == SSL_R_SCSV_RECEIVED_WHEN_RENEGOTIATING           /*  345 */
-#endif
-#ifdef SSL_R_INAPPROPRIATE_FALLBACK
             || n == SSL_R_INAPPROPRIATE_FALLBACK                     /*  373 */
-#endif
 #ifdef SSL_R_NO_SHARED_SIGNATURE_ALGORITHMS
             || n == SSL_R_NO_SHARED_SIGNATURE_ALGORITHMS             /*  376 */
 #endif
@@ -4997,14 +4949,10 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
             return -1;
         }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
         if (HMAC_Init_ex(hctx, key[0].hmac_key, size, digest, NULL) != 1) {
             ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
             return -1;
         }
-#else
-        HMAC_Init_ex(hctx, key[0].hmac_key, size, digest, NULL);
-#endif
 
         ngx_memcpy(name, key[0].name, 16);
 
@@ -5040,14 +4988,10 @@ ngx_ssl_ticket_key_callback(ngx_ssl_conn_t *ssl_conn,
             size = 32;
         }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
         if (HMAC_Init_ex(hctx, key[i].hmac_key, size, digest, NULL) != 1) {
             ngx_ssl_error(NGX_LOG_ALERT, c->log, 0, "HMAC_Init_ex() failed");
             return -1;
         }
-#else
-        HMAC_Init_ex(hctx, key[i].hmac_key, size, digest, NULL);
-#endif
 
         if (EVP_DecryptInit_ex(ectx, cipher, NULL, key[i].aes_key, iv) != 1) {
             ngx_ssl_error(NGX_LOG_ALERT, c->log, 0,
@@ -5838,8 +5782,6 @@ ngx_ssl_get_early_data(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 ngx_int_t
 ngx_ssl_get_server_name(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 {
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-
     size_t       len;
     const char  *name;
 
@@ -5858,8 +5800,6 @@ ngx_ssl_get_server_name(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
 
         return NGX_OK;
     }
-
-#endif
 
     s->len = 0;
     return NGX_OK;

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -186,12 +186,7 @@ typedef struct {
 #define NGX_SSL_TLSv1_2  0x0020
 #define NGX_SSL_TLSv1_3  0x0040
 
-
-#if (defined SSL_OP_NO_TLSv1_2 || defined SSL_OP_NO_TLSv1_3)
 #define NGX_SSL_DEFAULT_PROTOCOLS  (NGX_SSL_TLSv1_2|NGX_SSL_TLSv1_3)
-#else
-#define NGX_SSL_DEFAULT_PROTOCOLS  (NGX_SSL_TLSv1|NGX_SSL_TLSv1_1)
-#endif
 
 
 #define NGX_SSL_BUFFER   1

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -210,12 +210,7 @@ typedef struct {
 #define NGX_SSL_TLSv1_2  0x0020
 #define NGX_SSL_TLSv1_3  0x0040
 
-
-#if (defined SSL_OP_NO_TLSv1_2 || defined SSL_OP_NO_TLSv1_3)
 #define NGX_SSL_DEFAULT_PROTOCOLS  (NGX_SSL_TLSv1_2|NGX_SSL_TLSv1_3)
-#else
-#define NGX_SSL_DEFAULT_PROTOCOLS  (NGX_SSL_TLSv1|NGX_SSL_TLSv1_1)
-#endif
 
 
 #define NGX_SSL_BUFFER   1

--- a/src/event/ngx_event_openssl_stapling.c
+++ b/src/event/ngx_event_openssl_stapling.c
@@ -247,12 +247,7 @@ ngx_ssl_stapling_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl, X509 *cert,
     SSL_CTX_select_current_cert(ssl->ctx, cert);
 #endif
 
-#ifdef SSL_CTRL_GET_EXTRA_CHAIN_CERTS
-    /* OpenSSL 1.0.1+ */
     SSL_CTX_get_extra_chain_certs(ssl->ctx, &staple->chain);
-#else
-    staple->chain = ssl->ctx->extra_certs;
-#endif
 
     staple->ssl_ctx = ssl->ctx;
     staple->timeout = 60000;
@@ -468,11 +463,7 @@ ngx_ssl_stapling_responder(ngx_conf_t *cf, ngx_ssl_t *ssl,
             return NGX_DECLINED;
         }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
         s = sk_OPENSSL_STRING_value(aia, 0);
-#else
-        s = sk_value(aia, 0);
-#endif
         if (s == NULL) {
             ngx_log_error(NGX_LOG_WARN, ssl->log, 0,
                           "\"ssl_stapling\" ignored, "
@@ -1175,11 +1166,7 @@ ngx_ssl_ocsp_responder(ngx_connection_t *c, ngx_ssl_ocsp_ctx_t *ctx)
         return NGX_ERROR;
     }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
     s = sk_OPENSSL_STRING_value(aia, 0);
-#else
-    s = sk_value(aia, 0);
-#endif
     if (s == NULL) {
         ngx_log_error(NGX_LOG_ERR, c->log, 0,
                       "no OCSP responder URL in certificate");

--- a/src/event/ngx_event_openssl_stapling.c
+++ b/src/event/ngx_event_openssl_stapling.c
@@ -248,12 +248,7 @@ ngx_ssl_stapling_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl, X509 *cert,
     SSL_CTX_select_current_cert(ssl->ctx, cert);
 #endif
 
-#ifdef SSL_CTRL_GET_EXTRA_CHAIN_CERTS
-    /* OpenSSL 1.0.1+ */
     SSL_CTX_get_extra_chain_certs(ssl->ctx, &staple->chain);
-#else
-    staple->chain = ssl->ctx->extra_certs;
-#endif
 
     staple->ssl_ctx = ssl->ctx;
     staple->timeout = 60000;
@@ -469,11 +464,7 @@ ngx_ssl_stapling_responder(ngx_conf_t *cf, ngx_ssl_t *ssl,
             return NGX_DECLINED;
         }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
         s = sk_OPENSSL_STRING_value(aia, 0);
-#else
-        s = sk_value(aia, 0);
-#endif
         if (s == NULL) {
             ngx_log_error(NGX_LOG_WARN, ssl->log, 0,
                           "\"ssl_stapling\" ignored, "
@@ -1176,11 +1167,7 @@ ngx_ssl_ocsp_responder(ngx_connection_t *c, ngx_ssl_ocsp_ctx_t *ctx)
         return NGX_ERROR;
     }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
     s = sk_OPENSSL_STRING_value(aia, 0);
-#else
-    s = sk_value(aia, 0);
-#endif
     if (s == NULL) {
         ngx_log_error(NGX_LOG_ERR, c->log, 0,
                       "no OCSP responder URL in certificate");

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -737,19 +737,8 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     cln->handler = ngx_ssl_cleanup_ctx;
     cln->data = &conf->ssl;
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-
-    if (SSL_CTX_set_tlsext_servername_callback(conf->ssl.ctx,
-                                               ngx_http_ssl_servername)
-        == 0)
-    {
-        ngx_log_error(NGX_LOG_WARN, cf->log, 0,
-            "nginx was built with SNI support, however, now it is linked "
-            "dynamically to an OpenSSL library which has no tlsext support, "
-            "therefore SNI is not available");
-    }
-
-#endif
+    SSL_CTX_set_tlsext_servername_callback(conf->ssl.ctx,
+                                           ngx_http_ssl_servername);
 
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
     SSL_CTX_set_alpn_select_cb(conf->ssl.ctx, ngx_http_ssl_alpn_select, NULL);
@@ -871,11 +860,9 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_value(conf->session_tickets, prev->session_tickets, 1);
 
-#ifdef SSL_OP_NO_TICKET
     if (!conf->session_tickets) {
         SSL_CTX_set_options(conf->ssl.ctx, SSL_OP_NO_TICKET);
     }
-#endif
 
     ngx_conf_merge_ptr_value(conf->session_ticket_keys,
                          prev->session_ticket_keys, NULL);

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -774,7 +774,6 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     cln->handler = ngx_ssl_cleanup_ctx;
     cln->data = &conf->ssl;
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
     {
     static ngx_ssl_client_hello_arg cb = { ngx_http_ssl_servername };
 
@@ -782,17 +781,9 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
         return NGX_CONF_ERROR;
     }
 
-    if (SSL_CTX_set_tlsext_servername_callback(conf->ssl.ctx,
-                                               ngx_http_ssl_servername)
-        == 0)
-    {
-        ngx_log_error(NGX_LOG_WARN, cf->log, 0,
-            "nginx was built with SNI support, however, now it is linked "
-            "dynamically to an OpenSSL library which has no tlsext support, "
-            "therefore SNI is not available");
+    SSL_CTX_set_tlsext_servername_callback(conf->ssl.ctx,
+                                           ngx_http_ssl_servername);
     }
-    }
-#endif
 
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
     SSL_CTX_set_alpn_select_cb(conf->ssl.ctx, ngx_http_ssl_alpn_select, NULL);
@@ -925,11 +916,9 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_value(conf->session_tickets, prev->session_tickets, 1);
 
-#ifdef SSL_OP_NO_TICKET
     if (!conf->session_tickets) {
         SSL_CTX_set_options(conf->ssl.ctx, SSL_OP_NO_TICKET);
     }
-#endif
 
     ngx_conf_merge_ptr_value(conf->session_ticket_keys,
                          prev->session_ticket_keys, NULL);

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -90,7 +90,7 @@ ngx_int_t ngx_http_add_listen(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
 void ngx_http_init_connection(ngx_connection_t *c);
 void ngx_http_close_connection(ngx_connection_t *c);
 
-#if (NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME)
+#if (NGX_HTTP_SSL)
 int ngx_http_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg);
 #endif
 #if (NGX_HTTP_SSL && defined SSL_R_CERT_CB_ERROR)

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -91,7 +91,7 @@ ngx_int_t ngx_http_add_listen(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
 void ngx_http_init_connection(ngx_connection_t *c);
 void ngx_http_close_connection(ngx_connection_t *c);
 
-#if (NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME)
+#if (NGX_HTTP_SSL)
 int ngx_http_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg);
 #endif
 #if (NGX_HTTP_SSL && defined SSL_R_CERT_CB_ERROR)

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -869,8 +869,6 @@ ngx_http_ssl_handshake_handler(ngx_connection_t *c)
 }
 
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-
 int
 ngx_http_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
 {
@@ -987,11 +985,8 @@ ngx_http_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
 
         SSL_set_verify_depth(ssl_conn, SSL_CTX_get_verify_depth(sscf->ssl.ctx));
 
-#if OPENSSL_VERSION_NUMBER >= 0x009080dfL
-        /* only in 0.9.8m+ */
         SSL_clear_options(ssl_conn, SSL_get_options(ssl_conn) &
                                     ~SSL_CTX_get_options(sscf->ssl.ctx));
-#endif
 
         SSL_set_options(ssl_conn, SSL_CTX_get_options(sscf->ssl.ctx));
 
@@ -1025,8 +1020,6 @@ error:
     *ad = SSL_AD_INTERNAL_ERROR;
     return SSL_TLSEXT_ERR_ALERT_FATAL;
 }
-
-#endif
 
 
 #ifdef SSL_R_CERT_CB_ERROR
@@ -2271,7 +2264,7 @@ ngx_http_set_virtual_server(ngx_http_request_t *r, ngx_str_t *host)
 
     hc = r->http_connection;
 
-#if (NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME)
+#if (NGX_HTTP_SSL)
 
     if (hc->ssl_servername) {
         if (hc->ssl_servername->len == host->len
@@ -2302,7 +2295,7 @@ ngx_http_set_virtual_server(ngx_http_request_t *r, ngx_str_t *host)
         return NGX_ERROR;
     }
 
-#if (NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME)
+#if (NGX_HTTP_SSL)
 
     if (hc->ssl_servername) {
         ngx_http_ssl_srv_conf_t  *sscf;
@@ -2369,7 +2362,7 @@ ngx_http_find_virtual_server(ngx_connection_t *c,
 
         sn = virtual_names->regex;
 
-#if (NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME)
+#if (NGX_HTTP_SSL)
 
         if (r == NULL) {
             ngx_http_connection_t  *hc;
@@ -2401,7 +2394,7 @@ ngx_http_find_virtual_server(ngx_connection_t *c,
             return NGX_DECLINED;
         }
 
-#endif /* NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME */
+#endif
 
         for (i = 0; i < virtual_names->nregex; i++) {
 

--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -880,8 +880,6 @@ ngx_http_ssl_handshake_handler(ngx_connection_t *c)
 }
 
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-
 int
 ngx_http_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
 {
@@ -994,11 +992,8 @@ ngx_http_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
 
         SSL_set_verify_depth(ssl_conn, SSL_CTX_get_verify_depth(sscf->ssl.ctx));
 
-#if OPENSSL_VERSION_NUMBER >= 0x009080dfL
-        /* only in 0.9.8m+ */
         SSL_clear_options(ssl_conn, SSL_get_options(ssl_conn) &
                                     ~SSL_CTX_get_options(sscf->ssl.ctx));
-#endif
 
         SSL_set_options(ssl_conn, SSL_CTX_get_options(sscf->ssl.ctx));
 
@@ -1033,8 +1028,6 @@ error:
     *ad = SSL_AD_INTERNAL_ERROR;
     return SSL_TLSEXT_ERR_ALERT_FATAL;
 }
-
-#endif
 
 
 #ifdef SSL_R_CERT_CB_ERROR
@@ -2485,7 +2478,7 @@ ngx_http_set_virtual_server(ngx_http_request_t *r, ngx_str_t *host)
 
     hc = r->http_connection;
 
-#if (NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME)
+#if (NGX_HTTP_SSL)
 
     if (hc->ssl_servername) {
         if (hc->ssl_servername->len == host->len
@@ -2516,7 +2509,7 @@ ngx_http_set_virtual_server(ngx_http_request_t *r, ngx_str_t *host)
         return NGX_ERROR;
     }
 
-#if (NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME)
+#if (NGX_HTTP_SSL)
 
     if (hc->ssl_servername) {
         ngx_http_ssl_srv_conf_t  *sscf;
@@ -2583,7 +2576,7 @@ ngx_http_find_virtual_server(ngx_connection_t *c,
 
         sn = virtual_names->regex;
 
-#if (NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME)
+#if (NGX_HTTP_SSL)
 
         if (r == NULL) {
             ngx_http_connection_t  *hc;
@@ -2615,7 +2608,7 @@ ngx_http_find_virtual_server(ngx_connection_t *c,
             return NGX_DECLINED;
         }
 
-#endif /* NGX_HTTP_SSL && defined SSL_CTRL_SET_TLSEXT_HOSTNAME */
+#endif
 
         for (i = 0; i < virtual_names->nregex; i++) {
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -1942,8 +1942,6 @@ ngx_http_upstream_ssl_name(ngx_http_request_t *r, ngx_http_upstream_t *u,
         goto done;
     }
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-
     /* as per RFC 6066, literal IPv4 and IPv6 addresses are not permitted */
 
     if (name.len == 0 || *name.data == '[') {
@@ -1979,8 +1977,6 @@ ngx_http_upstream_ssl_name(ngx_http_request_t *r, ngx_http_upstream_t *u,
                       "SSL_set_tlsext_host_name(\"%s\") failed", name.data);
         return NGX_ERROR;
     }
-
-#endif
 
 done:
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -1981,8 +1981,6 @@ ngx_http_upstream_ssl_name(ngx_http_request_t *r, ngx_http_upstream_t *u,
         goto done;
     }
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-
     /* as per RFC 6066, literal IPv4 and IPv6 addresses are not permitted */
 
     if (name.len == 0 || *name.data == '[') {
@@ -2018,8 +2016,6 @@ ngx_http_upstream_ssl_name(ngx_http_request_t *r, ngx_http_upstream_t *u,
                       "SSL_set_tlsext_host_name(\"%s\") failed", name.data);
         return NGX_ERROR;
     }
-
-#endif
 
 done:
 

--- a/src/mail/ngx_mail_ssl_module.c
+++ b/src/mail/ngx_mail_ssl_module.c
@@ -505,11 +505,9 @@ ngx_mail_ssl_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->session_tickets,
                          prev->session_tickets, 1);
 
-#ifdef SSL_OP_NO_TICKET
     if (!conf->session_tickets) {
         SSL_CTX_set_options(conf->ssl.ctx, SSL_OP_NO_TICKET);
     }
-#endif
 
     ngx_conf_merge_ptr_value(conf->session_ticket_keys,
                          prev->session_ticket_keys, NULL);

--- a/src/mail/ngx_mail_ssl_module.c
+++ b/src/mail/ngx_mail_ssl_module.c
@@ -523,11 +523,9 @@ ngx_mail_ssl_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->session_tickets,
                          prev->session_tickets, 1);
 
-#ifdef SSL_OP_NO_TICKET
     if (!conf->session_tickets) {
         SSL_CTX_set_options(conf->ssl.ctx, SSL_OP_NO_TICKET);
     }
-#endif
 
     ngx_conf_merge_ptr_value(conf->session_ticket_keys,
                          prev->session_ticket_keys, NULL);

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -1347,8 +1347,6 @@ ngx_stream_proxy_ssl_name(ngx_stream_session_t *s)
         goto done;
     }
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-
     /* as per RFC 6066, literal IPv4 and IPv6 addresses are not permitted */
 
     if (name.len == 0 || *name.data == '[') {
@@ -1384,8 +1382,6 @@ ngx_stream_proxy_ssl_name(ngx_stream_session_t *s)
                       "SSL_set_tlsext_host_name(\"%s\") failed", name.data);
         return NGX_ERROR;
     }
-
-#endif
 
 done:
 

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -1473,8 +1473,6 @@ ngx_stream_proxy_ssl_name(ngx_stream_session_t *s)
         goto done;
     }
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-
     /* as per RFC 6066, literal IPv4 and IPv6 addresses are not permitted */
 
     if (name.len == 0 || *name.data == '[') {
@@ -1510,8 +1508,6 @@ ngx_stream_proxy_ssl_name(ngx_stream_session_t *s)
                       "SSL_set_tlsext_host_name(\"%s\") failed", name.data);
         return NGX_ERROR;
     }
-
-#endif
 
 done:
 

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -22,10 +22,8 @@ static ngx_int_t ngx_stream_ssl_handler(ngx_stream_session_t *s);
 static ngx_int_t ngx_stream_ssl_init_connection(ngx_ssl_t *ssl,
     ngx_connection_t *c);
 static void ngx_stream_ssl_handshake_handler(ngx_connection_t *c);
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
 static int ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad,
     void *arg);
-#endif
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
 static int ngx_stream_ssl_alpn_select(ngx_ssl_conn_t *ssl_conn,
     const unsigned char **out, unsigned char *outlen,
@@ -528,8 +526,6 @@ ngx_stream_ssl_handshake_handler(ngx_connection_t *c)
 }
 
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-
 static int
 ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
 {
@@ -633,11 +629,8 @@ ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
 
         SSL_set_verify_depth(ssl_conn, SSL_CTX_get_verify_depth(sscf->ssl.ctx));
 
-#if OPENSSL_VERSION_NUMBER >= 0x009080dfL
-        /* only in 0.9.8m+ */
         SSL_clear_options(ssl_conn, SSL_get_options(ssl_conn) &
                                     ~SSL_CTX_get_options(sscf->ssl.ctx));
-#endif
 
         SSL_set_options(ssl_conn, SSL_CTX_get_options(sscf->ssl.ctx));
 
@@ -663,8 +656,6 @@ error:
     *ad = SSL_AD_INTERNAL_ERROR;
     return SSL_TLSEXT_ERR_ALERT_FATAL;
 }
-
-#endif
 
 
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
@@ -990,10 +981,8 @@ ngx_stream_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     cln->handler = ngx_ssl_cleanup_ctx;
     cln->data = &conf->ssl;
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
     SSL_CTX_set_tlsext_servername_callback(conf->ssl.ctx,
                                            ngx_stream_ssl_servername);
-#endif
 
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
     if (conf->alpn.len) {
@@ -1117,11 +1106,9 @@ ngx_stream_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->session_tickets,
                          prev->session_tickets, 1);
 
-#ifdef SSL_OP_NO_TICKET
     if (!conf->session_tickets) {
         SSL_CTX_set_options(conf->ssl.ctx, SSL_OP_NO_TICKET);
     }
-#endif
 
     ngx_conf_merge_ptr_value(conf->session_ticket_keys,
                          prev->session_ticket_keys, NULL);

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -22,10 +22,8 @@ static ngx_int_t ngx_stream_ssl_handler(ngx_stream_session_t *s);
 static ngx_int_t ngx_stream_ssl_init_connection(ngx_ssl_t *ssl,
     ngx_connection_t *c);
 static void ngx_stream_ssl_handshake_handler(ngx_connection_t *c);
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
 static int ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad,
     void *arg);
-#endif
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
 static int ngx_stream_ssl_alpn_select(ngx_ssl_conn_t *ssl_conn,
     const unsigned char **out, unsigned char *outlen,
@@ -568,8 +566,6 @@ ngx_stream_ssl_handshake_handler(ngx_connection_t *c)
 }
 
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-
 static int
 ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
 {
@@ -669,11 +665,8 @@ ngx_stream_ssl_servername(ngx_ssl_conn_t *ssl_conn, int *ad, void *arg)
 
         SSL_set_verify_depth(ssl_conn, SSL_CTX_get_verify_depth(sscf->ssl.ctx));
 
-#if OPENSSL_VERSION_NUMBER >= 0x009080dfL
-        /* only in 0.9.8m+ */
         SSL_clear_options(ssl_conn, SSL_get_options(ssl_conn) &
                                     ~SSL_CTX_get_options(sscf->ssl.ctx));
-#endif
 
         SSL_set_options(ssl_conn, SSL_CTX_get_options(sscf->ssl.ctx));
 
@@ -700,8 +693,6 @@ error:
     *ad = SSL_AD_INTERNAL_ERROR;
     return SSL_TLSEXT_ERR_ALERT_FATAL;
 }
-
-#endif
 
 
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
@@ -1034,7 +1025,6 @@ ngx_stream_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     cln->handler = ngx_ssl_cleanup_ctx;
     cln->data = &conf->ssl;
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
     {
     static ngx_ssl_client_hello_arg cb = { ngx_stream_ssl_servername };
 
@@ -1045,7 +1035,6 @@ ngx_stream_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     SSL_CTX_set_tlsext_servername_callback(conf->ssl.ctx,
                                            ngx_stream_ssl_servername);
     }
-#endif
 
 #ifdef TLSEXT_TYPE_application_layer_protocol_negotiation
     if (conf->alpn.len) {
@@ -1180,11 +1169,9 @@ ngx_stream_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->session_tickets,
                          prev->session_tickets, 1);
 
-#ifdef SSL_OP_NO_TICKET
     if (!conf->session_tickets) {
         SSL_CTX_set_options(conf->ssl.ctx, SSL_OP_NO_TICKET);
     }
-#endif
 
     ngx_conf_merge_ptr_value(conf->session_ticket_keys,
                          prev->session_ticket_keys, NULL);


### PR DESCRIPTION
notes:
1.0.1 is chosen as having the TLSv1.2 support base minimum.