### PR TITLE
Request body: fixed $request_length for discarded body

### DIFF
--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -677,6 +677,8 @@ ngx_http_discard_request_body(ngx_http_request_t *r)
             return rc;
         }
 
+        r->request_length += size - (r->header_in->last - r->header_in->pos);
+
         if (r->headers_in.content_length_n == 0) {
             return NGX_OK;
         }
@@ -825,6 +827,8 @@ ngx_http_read_discarded_request_body(ngx_http_request_t *r)
 
         b.pos = buffer;
         b.last = buffer + n;
+
+        r->request_length += n;
 
         rc = ngx_http_discard_request_body_filter(r, &b);
 


### PR DESCRIPTION
## Problem

`$request_length` misses the request body bytes whenever nginx discards the request body (a handler that does not read the body, e.g. static files, `return`, redirects, special responses), because the discard path never adds them to `r->request_length`, unlike the normal reading path.

For HTTP/1.1 pipelined requests it can even become negative: `ngx_http_copy_pipelined_header()` subtracts the pipelined bytes it moves to the next request, bytes that were never added in the first place.

## Solution

Mirror the accounting of the normal reading path in `src/http/ngx_http_request_body.c`:

- `ngx_http_discard_request_body()`: count the pre-read bytes consumed from `r->header_in` by `ngx_http_discard_request_body_filter()`;
- `ngx_http_read_discarded_request_body()`: count the bytes received from the socket.

Based on the patch attached to the issue by @zengjinji.

## Testing

Built and compared against the reproducer from the issue (PUT with chunked body against a static location, plus a pipelined pair):

| request | expected | before | after |
|---|---|---|---|
| pipelined #1 (empty chunked body) | 1127 | **-2969** | 1127 |
| pipelined #2 (8 KiB chunked body) | 9322 | 1117 | 9322 |
| single (8 KiB chunked body) | 9322 | 1117 | 9322 |

Before: negative value and missing body bytes (1117 is the header size only). After: byte-exact match on all three.

- [x] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests)) — a test for this will be submitted to nginx-tests separately

**Closes:** #1546

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes — see note above, tests live in nginx-tests
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards
