### PR TITLE
Support percentage values for proxy_cache_path min_free

### DIFF
--- a/src/http/ngx_http_cache.h
+++ b/src/http/ngx_http_cache.h
@@ -163,6 +163,8 @@ struct ngx_http_file_cache_s {
     ngx_path_t                      *path;
 
     off_t                            min_free;
+    ngx_int_t                        min_free_percent;
+    off_t                            total_fs_size;
     off_t                            max_size;
     size_t                           bsize;
 

--- a/src/http/ngx_http_file_cache.c
+++ b/src/http/ngx_http_file_cache.c
@@ -2560,11 +2560,41 @@ ngx_http_file_cache_set_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             s.len = value[i].len - 9;
             s.data = value[i].data + 9;
 
-            min_free = ngx_parse_offset(&s);
-            if (min_free < 0) {
-                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                                   "invalid min_free value \"%V\"", &value[i]);
-                return NGX_CONF_ERROR;
+            ngx_uint_t percent;
+            off_t      total;
+
+            if (s.len >= 2 && s.len <= 4 && s.data[s.len - 1] == '%') {
+
+                percent = ngx_atoi(s.data, s.len - 1);
+
+                if (percent == (ngx_uint_t) NGX_ERROR || percent > 100) {
+                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                       "invalid min_free value \"%V\"",
+                                       &value[i]);
+                    return NGX_CONF_ERROR;
+                }
+
+                total = ngx_fs_size(cache->path->name.data);
+
+                if (total == NGX_MAX_OFF_T_VALUE) {
+                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                       "failed to determine filesystem size "
+                                       "for \"%V\"", &cache->path->name);
+                    return NGX_CONF_ERROR;
+                }
+
+                min_free = (total / 100) * percent;
+
+            } else {
+
+                min_free = ngx_parse_offset(&s);
+
+                if (min_free < 0) {
+                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                       "invalid min_free value \"%V\"",
+                                       &value[i]);
+                    return NGX_CONF_ERROR;
+                }
             }
 
 #else

--- a/src/http/ngx_http_file_cache.c
+++ b/src/http/ngx_http_file_cache.c
@@ -2051,6 +2051,20 @@ ngx_http_file_cache_manager(void *data)
                        "http file cache size: %O c:%ui w:%i",
                        size, count, (ngx_int_t) watermark);
 
+        if (cache->min_free_percent >= 0) {
+          cache->total_fs_size = ngx_fs_size(cache->path->name.data);
+
+          if (cache->total_fs_size == NGX_MAX_OFF_T_VALUE) {
+            ngx_log_error(NGX_LOG_EMERG, ngx_cycle->log, 0,
+                               "failed to determine filesystem size "
+                               "for \"%V\"",
+                               &cache->path->name);
+            break;
+          }
+
+          cache->min_free = (cache->total_fs_size / 100) * cache->min_free_percent;
+        }
+
         if (size < cache->max_size && count < watermark) {
 
             if (!cache->min_free) {
@@ -2385,7 +2399,7 @@ ngx_http_file_cache_set_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     time_t                  inactive;
     ssize_t                 size;
     ngx_str_t               s, name, *value;
-    ngx_int_t               loader_files, manager_files;
+    ngx_int_t               loader_files, manager_files, percent;
     ngx_msec_t              loader_sleep, manager_sleep, loader_threshold,
                             manager_threshold;
     ngx_uint_t              i, n, use_temp_path;
@@ -2418,6 +2432,7 @@ ngx_http_file_cache_set_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     size = 0;
     max_size = NGX_MAX_OFF_T_VALUE;
     min_free = 0;
+    percent = -1;
 
     value = cf->args->elts;
 
@@ -2560,30 +2575,16 @@ ngx_http_file_cache_set_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             s.len = value[i].len - 9;
             s.data = value[i].data + 9;
 
-            ngx_uint_t percent;
-            off_t      total;
-
             if (s.len >= 2 && s.len <= 4 && s.data[s.len - 1] == '%') {
 
                 percent = ngx_atoi(s.data, s.len - 1);
 
-                if (percent == (ngx_uint_t) NGX_ERROR || percent > 100) {
+                if (percent == (ngx_int_t) NGX_ERROR || percent > 100) {
                     ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                        "invalid min_free value \"%V\"",
                                        &value[i]);
                     return NGX_CONF_ERROR;
                 }
-
-                total = ngx_fs_size(cache->path->name.data);
-
-                if (total == NGX_MAX_OFF_T_VALUE) {
-                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                                       "failed to determine filesystem size "
-                                       "for \"%V\"", &cache->path->name);
-                    return NGX_CONF_ERROR;
-                }
-
-                min_free = (total / 100) * percent;
 
             } else {
 
@@ -2738,6 +2739,7 @@ ngx_http_file_cache_set_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     cache->inactive = inactive;
     cache->max_size = max_size;
     cache->min_free = min_free;
+    cache->min_free_percent = percent;
 
     caches = (ngx_array_t *) (confp + cmd->offset);
 

--- a/src/os/unix/ngx_files.c
+++ b/src/os/unix/ngx_files.c
@@ -901,6 +901,18 @@ ngx_fs_available(u_char *name)
     return (off_t) fs.f_bavail * fs.f_bsize;
 }
 
+off_t
+ngx_fs_size(u_char *name)
+{
+    struct statfs fs;
+
+    if (statfs((char *) name, &fs) == -1) {
+        return NGX_MAX_OFF_T_VALUE;
+    }
+
+    return (off_t) fs.f_blocks * fs.f_bsize;
+}
+
 #elif (NGX_HAVE_STATVFS)
 
 size_t
@@ -938,6 +950,18 @@ ngx_fs_available(u_char *name)
     return (off_t) fs.f_bavail * fs.f_frsize;
 }
 
+off_t
+ngx_fs_size(u_char *name)
+{
+    struct statvfs fs;
+
+    if (statvfs((char *) name, &fs) == -1) {
+        return NGX_MAX_OFF_T_VALUE;
+    }
+
+    return (off_t) fs.f_blocks * fs.f_frsize;
+}
+
 #else
 
 size_t
@@ -949,6 +973,12 @@ ngx_fs_bsize(u_char *name)
 
 off_t
 ngx_fs_available(u_char *name)
+{
+    return NGX_MAX_OFF_T_VALUE;
+}
+
+off_t
+ngx_fs_size(u_char *name)
 {
     return NGX_MAX_OFF_T_VALUE;
 }

--- a/src/os/unix/ngx_files.h
+++ b/src/os/unix/ngx_files.h
@@ -350,6 +350,7 @@ ngx_int_t ngx_directio_off(ngx_fd_t fd);
 
 size_t ngx_fs_bsize(u_char *name);
 off_t ngx_fs_available(u_char *name);
+off_t ngx_fs_size(u_char *name);
 
 
 #if (NGX_HAVE_OPENAT)

--- a/src/os/win32/ngx_files.c
+++ b/src/os/win32/ngx_files.c
@@ -1027,6 +1027,25 @@ ngx_fs_available(u_char *name)
     return (off_t) navail.QuadPart;
 }
 
+off_t
+ngx_fs_size(u_char *name)
+{
+    ULARGE_INTEGER free_bytes;
+    ULARGE_INTEGER total_bytes;
+    ULARGE_INTEGER total_free_bytes;
+
+    if (GetDiskFreeSpaceEx((LPCSTR) name,
+                           &free_bytes,
+                           &total_bytes,
+                           &total_free_bytes)
+        == 0)
+    {
+        return 0;
+    }
+
+    return (off_t) total_bytes.QuadPart;
+}
+
 
 static ngx_int_t
 ngx_win32_check_filename(u_short *u, size_t len, ngx_uint_t dirname)

--- a/src/os/win32/ngx_files.h
+++ b/src/os/win32/ngx_files.h
@@ -261,6 +261,7 @@ ngx_int_t ngx_directio_off(ngx_fd_t fd);
 
 size_t ngx_fs_bsize(u_char *name);
 off_t ngx_fs_available(u_char *name);
+off_t ngx_fs_size(u_char *name);
 
 
 #define ngx_stdout               GetStdHandle(STD_OUTPUT_HANDLE)


### PR DESCRIPTION
## Problem

This PR contains the feature described in this issue: https://github.com/nginx/nginx/issues/1010

## Solution

just a simple conversion section between the percentage and the absolute size of the fs + a helper function that fetches the total size of the fs in bytes

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1010

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)