### PR TITLE
HTTP/3: implement RFC 9218 Extensible Prioritization Scheme for HTTP

### DIFF
--- a/auto/modules
+++ b/auto/modules
@@ -77,7 +77,8 @@ if [ $HTTP = YES ]; then
                          src/http/ngx_http_variables.h \
                          src/http/ngx_http_script.h \
                          src/http/ngx_http_upstream.h \
-                         src/http/ngx_http_upstream_round_robin.h"
+                         src/http/ngx_http_upstream_round_robin.h \
+                         src/http/ngx_http_priority.h"
         ngx_module_srcs="src/http/ngx_http.c \
                          src/http/ngx_http_core_module.c \
                          src/http/ngx_http_special_response.c \
@@ -88,7 +89,8 @@ if [ $HTTP = YES ]; then
                          src/http/ngx_http_variables.c \
                          src/http/ngx_http_script.c \
                          src/http/ngx_http_upstream.c \
-                         src/http/ngx_http_upstream_round_robin.c"
+                         src/http/ngx_http_upstream_round_robin.c \
+                         src/http/ngx_http_priority.c"
         ngx_module_libs=
         ngx_module_link=YES
 

--- a/src/event/quic/ngx_event_quic.h
+++ b/src/event/quic/ngx_event_quic.h
@@ -43,6 +43,9 @@
 #define NGX_QUIC_STREAM_SERVER_INITIATED     0x01
 #define NGX_QUIC_STREAM_UNIDIRECTIONAL       0x02
 
+/* RFC 9218 default urgency for a stream with no explicit priority */
+#define NGX_QUIC_STREAM_DEFAULT_URGENCY      3
+
 
 typedef ngx_int_t (*ngx_quic_init_pt)(ngx_connection_t *c);
 typedef void (*ngx_quic_shutdown_pt)(ngx_connection_t *c);
@@ -122,6 +125,25 @@ struct ngx_quic_stream_s {
     ngx_quic_buffer_t              recv;
     ngx_quic_stream_send_state_e   send_state;
     ngx_quic_stream_recv_state_e   recv_state;
+
+    /*
+     * RFC 9218 extensible priority, pushed down from the application layer
+     * (e.g. HTTP/3) via ngx_quic_set_stream_priority().  Kept protocol-
+     * agnostic so the QUIC layer does not depend on HTTP types.  Lower
+     * urgency value means higher priority (0..7, default 3).
+     */
+    ngx_uint_t                     urgency;
+
+    unsigned                       incremental:1;
+
+    /*
+     * Set by the application layer once it has attached its per-stream
+     * object to c->data (for HTTP/3, the ngx_http_request_t).  Before this
+     * is set, c->data still points at the connection-level object, so code
+     * reaching a stream by id (e.g. an out-of-band PRIORITY_UPDATE) must not
+     * treat c->data as the application's per-stream object.
+     */
+    unsigned                       app_ready:1;
     unsigned                       cancelable:1;
     unsigned                       fin_acked:1;
 };
@@ -130,6 +152,14 @@ struct ngx_quic_stream_s {
 void ngx_quic_recvmsg(ngx_event_t *ev);
 void ngx_quic_run(ngx_connection_t *c, ngx_quic_conf_t *conf);
 ngx_connection_t *ngx_quic_open_stream(ngx_connection_t *c, ngx_uint_t bidi);
+ngx_connection_t *ngx_quic_find_stream_connection(ngx_connection_t *pc,
+    uint64_t id);
+ngx_int_t ngx_quic_client_bidi_stream_id_allowed(ngx_connection_t *pc,
+    uint64_t id);
+void ngx_quic_set_stream_app_ready(ngx_connection_t *c);
+ngx_int_t ngx_quic_stream_app_ready(ngx_connection_t *c);
+void ngx_quic_set_stream_priority(ngx_connection_t *c, ngx_uint_t urgency,
+    ngx_uint_t incremental);
 void ngx_quic_finalize_connection(ngx_connection_t *c, ngx_uint_t err,
     const char *reason);
 void ngx_quic_shutdown_connection(ngx_connection_t *c, ngx_uint_t err,

--- a/src/event/quic/ngx_event_quic_ack.c
+++ b/src/event/quic/ngx_event_quic_ack.c
@@ -838,7 +838,18 @@ ngx_quic_resend_frames(ngx_connection_t *c, ngx_quic_send_ctx_t *ctx)
                 break;
             }
 
-            /* fall through */
+            /*
+             * Refresh the frame's priority from the stream (it may have
+             * changed via PRIORITY_UPDATE since the frame was first sent) and
+             * requeue through ngx_quic_queue_frame() so the retransmitted
+             * STREAM frame is re-inserted by urgency (RFC 9218) rather than
+             * dropped at the tail behind lower-priority traffic.
+             */
+            f->urgency = qs->urgency;
+            f->incremental = qs->incremental;
+
+            ngx_quic_queue_frame(qc, f);
+            break;
 
         default:
             ngx_queue_insert_tail(&ctx->frames, &f->queue);

--- a/src/event/quic/ngx_event_quic_connection.h
+++ b/src/event/quic/ngx_event_quic_connection.h
@@ -168,6 +168,21 @@ typedef struct {
 
     ngx_uint_t                        initialized;
                                                  /* unsigned  initialized:1; */
+
+    /*
+     * Reusable scratch array for ngx_quic_flush_streams_by_priority(), grown
+     * on demand and freed only when the connection is destroyed, so the
+     * scheduler does not allocate from the connection pool on every flush.
+     */
+    ngx_quic_stream_t               **sched;
+    ngx_uint_t                        sched_nalloc;
+
+    /*
+     * Round-robin cursor (a stream id) for incremental RFC 9218 groups,
+     * preserved across flushes so successive small MAX_DATA increases advance
+     * different streams instead of always starting at the group's lowest id.
+     */
+    uint64_t                          sched_rr_next;
 } ngx_quic_streams_t;
 
 

--- a/src/event/quic/ngx_event_quic_frames.c
+++ b/src/event/quic/ngx_event_quic_frames.c
@@ -295,6 +295,159 @@ ngx_quic_free_frames(ngx_connection_t *c, ngx_queue_t *frames)
 }
 
 
+#define ngx_quic_stream_frame_prioritized(f)                                  \
+    ((f)->type == NGX_QUIC_FT_STREAM                                           \
+     && !((f)->u.stream.stream_id & NGX_QUIC_STREAM_UNIDIRECTIONAL))
+
+/*
+ * Frame types a prioritized request STREAM frame may safely be reordered
+ * ahead of.  PADDING and PING carry no ordering dependency on STREAM data
+ * and no transport state that a peer waits on, so delaying them is harmless.
+ *
+ * ACK/ACK_ECN are deliberately NOT reorderable: although an ACK carries no
+ * dependency on STREAM data, moving request frames ahead of it repeatedly
+ * would let a sustained run of newly queued, more-urgent STREAM frames keep
+ * inserting themselves before a queued ACK, delaying that ACK by an unbounded
+ * frame prefix rather than a single frame and risking a max_ack_delay
+ * violation.  Treating ACK as a barrier bounds acknowledgement latency;
+ * priority reordering still applies freely within each run of STREAM frames.
+ *
+ * Everything else -- flow-control grants (MAX_DATA, MAX_STREAM_DATA,
+ * MAX_STREAMS), path validation (PATH_CHALLENGE, PATH_RESPONSE),
+ * HANDSHAKE_DONE, connection-id and stream-state control, CONNECTION_CLOSE,
+ * and unidirectional STREAM (HTTP/3 control/QPACK) -- is likewise a barrier
+ * so it is never starved behind a growing stream prefix.
+ */
+#define ngx_quic_frame_reorderable(f)                                         \
+    ((f)->type == NGX_QUIC_FT_PADDING                                         \
+     || (f)->type == NGX_QUIC_FT_PING)
+
+
+void
+ngx_quic_queue_stream_frame(ngx_quic_send_ctx_t *ctx, ngx_quic_frame_t *frame)
+{
+    ngx_queue_t       *q;
+    ngx_quic_frame_t  *f;
+
+    /*
+     * RFC 9218: order request (client-initiated bidirectional) STREAM frames
+     * on the wire by urgency (lower value is more urgent).
+     *
+     * A prioritized frame is walked from the tail towards the head and
+     * stopped as soon as we find a frame f that must remain ahead of it.
+     * The queue holds frames of a single encryption level, so only these
+     * frame kinds are relevant:
+     *
+     *   - PING and PADDING carry no ordering dependency on STREAM data and no
+     *     transport state the peer waits on, so a request frame may be
+     *     prioritized past them.  They are skipped rather than treated as
+     *     barriers.
+     *
+     *   - ACK/ACK_ECN are treated as barriers.  Skipping them would let a
+     *     sustained run of newly queued, more-urgent request frames keep
+     *     inserting themselves ahead of a queued ACK, delaying it by an
+     *     unbounded frame prefix and risking a max_ack_delay violation;
+     *     bounding acknowledgement latency takes precedence over reordering
+     *     request data past an ACK.
+     *
+     *   - Every other non-request frame is a barrier.  Unidirectional STREAM
+     *     frames carry HTTP/3 control and QPACK data that must not be
+     *     reordered relative to request data.  Transport control frames --
+     *     flow-control grants (MAX_DATA, MAX_STREAM_DATA, MAX_STREAMS), path
+     *     validation (PATH_CHALLENGE, PATH_RESPONSE), HANDSHAKE_DONE,
+     *     connection-id and stream-state control, CONNECTION_CLOSE -- must not
+     *     be starved behind a growing stream prefix under sustained output.
+     *     Request frames are never moved ahead of any of these.  (CRYPTO lives
+     *     at a different encryption level and never shares this queue.)
+     *
+     *   - Same-stream request STREAM frames must stay in ascending offset
+     *     order for correct reassembly, and this depends ONLY on the offset
+     *     -- never on urgency (both frames share the same stream priority, so
+     *     an urgency comparison here is meaningless and must not be used).
+     *     f stays ahead iff its offset is not greater than ours; a
+     *     higher-offset frame of the same stream is walked past so a
+     *     reprioritized or retransmitted earlier frame is not left stranded
+     *     behind its own later data.
+     *
+     *   - Different-stream request STREAM frames are ordered by RFC 9218
+     *     priority, matching the scheduler's (urgency, then
+     *     non-incremental-before-incremental) ordering.  f stays ahead iff it
+     *     is more urgent, or equally urgent and not less preferred (f
+     *     non-incremental, or our frame incremental).
+     *
+     * The walk stops at the first frame that must stay ahead of the new
+     * frame -- a control frame, a unidirectional STREAM barrier, a same-stream
+     * frame at or before our offset, or a different-stream request frame that
+     * is more urgent or equally urgent and not less preferred -- and the new
+     * frame is inserted right after it.  A request frame therefore only ever
+     * moves ahead of strictly-less-urgent request traffic and reorderable
+     * PING/PADDING frames, and never past an ACK, a control frame, or a
+     * unidirectional STREAM barrier.
+     */
+
+    if (!ngx_quic_stream_frame_prioritized(frame)) {
+        ngx_queue_insert_tail(&ctx->frames, &frame->queue);
+        return;
+    }
+
+    for (q = ngx_queue_last(&ctx->frames);
+         q != ngx_queue_sentinel(&ctx->frames);
+         q = ngx_queue_prev(q))
+    {
+        f = ngx_queue_data(q, ngx_quic_frame_t, queue);
+
+        if (ngx_quic_frame_reorderable(f)) {
+            /*
+             * PING/PADDING: no ordering dependency on STREAM data and no
+             * transport state the peer waits on, so a request frame may be
+             * prioritized past it.
+             */
+            continue;
+        }
+
+        if (f->type != NGX_QUIC_FT_STREAM) {
+            /*
+             * Transport control frame (flow-control grant, path validation,
+             * HANDSHAKE_DONE, connection-id/stream-state control,
+             * CONNECTION_CLOSE): a barrier, so it is never starved behind a
+             * growing stream prefix.
+             */
+            ngx_queue_insert_after(q, &frame->queue);
+            return;
+        }
+
+        if (f->u.stream.stream_id & NGX_QUIC_STREAM_UNIDIRECTIONAL) {
+            /* HTTP/3 control/QPACK: hard barrier, never reordered */
+            ngx_queue_insert_after(q, &frame->queue);
+            return;
+        }
+
+        if (f->u.stream.stream_id == frame->u.stream.stream_id) {
+            /* same stream: ordering is by offset only, priority is equal */
+
+            if (f->u.stream.offset <= frame->u.stream.offset) {
+                ngx_queue_insert_after(q, &frame->queue);
+                return;
+            }
+
+            continue;
+        }
+
+        /* different streams: compare full RFC 9218 priority */
+
+        if (f->urgency < frame->urgency
+            || (f->urgency == frame->urgency
+                && (!f->incremental || frame->incremental)))
+        {
+            ngx_queue_insert_after(q, &frame->queue);
+            return;
+        }
+    }
+
+    ngx_queue_insert_head(&ctx->frames, &frame->queue);
+}
+
+
 void
 ngx_quic_queue_frame(ngx_quic_connection_t *qc, ngx_quic_frame_t *frame)
 {
@@ -302,7 +455,12 @@ ngx_quic_queue_frame(ngx_quic_connection_t *qc, ngx_quic_frame_t *frame)
 
     ctx = ngx_quic_get_send_ctx(qc, frame->level);
 
-    ngx_queue_insert_tail(&ctx->frames, &frame->queue);
+    if (frame->type == NGX_QUIC_FT_STREAM) {
+        ngx_quic_queue_stream_frame(ctx, frame);
+
+    } else {
+        ngx_queue_insert_tail(&ctx->frames, &frame->queue);
+    }
 
     frame->len = ngx_quic_create_frame(NULL, frame);
     /* always succeeds */

--- a/src/event/quic/ngx_event_quic_frames.h
+++ b/src/event/quic/ngx_event_quic_frames.h
@@ -20,6 +20,8 @@ ngx_quic_frame_t *ngx_quic_alloc_frame(ngx_connection_t *c);
 void ngx_quic_free_frame(ngx_connection_t *c, ngx_quic_frame_t *frame);
 void ngx_quic_free_frames(ngx_connection_t *c, ngx_queue_t *frames);
 void ngx_quic_queue_frame(ngx_quic_connection_t *qc, ngx_quic_frame_t *frame);
+void ngx_quic_queue_stream_frame(ngx_quic_send_ctx_t *ctx,
+    ngx_quic_frame_t *frame);
 ngx_int_t ngx_quic_split_frame(ngx_connection_t *c, ngx_quic_frame_t *f,
     size_t len);
 

--- a/src/event/quic/ngx_event_quic_streams.c
+++ b/src/event/quic/ngx_event_quic_streams.c
@@ -32,6 +32,7 @@ static ssize_t ngx_quic_stream_send(ngx_connection_t *c, u_char *buf,
 static ngx_chain_t *ngx_quic_stream_send_chain(ngx_connection_t *c,
     ngx_chain_t *in, off_t limit);
 static ngx_int_t ngx_quic_stream_flush(ngx_quic_stream_t *qs);
+static void ngx_quic_restamp_stream_priority(ngx_quic_stream_t *qs);
 static void ngx_quic_stream_cleanup_handler(void *data);
 static ngx_int_t ngx_quic_close_stream(ngx_quic_stream_t *qs);
 static ngx_int_t ngx_quic_can_shutdown(ngx_connection_t *c);
@@ -167,6 +168,150 @@ ngx_quic_find_stream(ngx_rbtree_t *rbtree, uint64_t id)
     }
 
     return NULL;
+}
+
+
+ngx_connection_t *
+ngx_quic_find_stream_connection(ngx_connection_t *pc, uint64_t id)
+{
+    ngx_quic_stream_t      *qs;
+    ngx_quic_connection_t  *qc;
+
+    qc = ngx_quic_get_connection(pc);
+
+    qs = ngx_quic_find_stream(&qc->streams.tree, id);
+    if (qs == NULL) {
+        return NULL;
+    }
+
+    return qs->connection;
+}
+
+
+ngx_int_t
+ngx_quic_client_bidi_stream_id_allowed(ngx_connection_t *pc, uint64_t id)
+{
+    ngx_quic_connection_t  *qc;
+
+    /*
+     * RFC 9000, 4.6: a client-initiated bidirectional stream id is only
+     * permitted once its stream number is below the limit the server has
+     * advertised via MAX_STREAMS.  An id at or above the current limit
+     * identifies a stream the client is not yet allowed to open.
+     */
+
+    qc = ngx_quic_get_connection(pc);
+
+    return (id >> 2) < qc->streams.client_max_streams_bidi;
+}
+
+
+void
+ngx_quic_set_stream_app_ready(ngx_connection_t *c)
+{
+    ngx_quic_stream_t  *qs;
+
+    /*
+     * The application layer marks a stream ready once it has attached its
+     * per-stream object to c->data.  Kept behind this setter so the HTTP
+     * layer does not reach into the QUIC stream representation directly.
+     */
+
+    qs = c->quic;
+
+    if (qs == NULL) {
+        return;
+    }
+
+    qs->app_ready = 1;
+}
+
+
+ngx_int_t
+ngx_quic_stream_app_ready(ngx_connection_t *c)
+{
+    ngx_quic_stream_t  *qs;
+
+    qs = c->quic;
+
+    return qs != NULL && qs->app_ready;
+}
+
+
+void
+ngx_quic_set_stream_priority(ngx_connection_t *c, ngx_uint_t urgency,
+    ngx_uint_t incremental)
+{
+    ngx_quic_stream_t  *qs;
+
+    qs = c->quic;
+
+    if (qs == NULL) {
+        return;
+    }
+
+    incremental = incremental ? 1 : 0;
+
+    if (qs->urgency == urgency && qs->incremental == incremental) {
+        return;
+    }
+
+    qs->urgency = urgency;
+    qs->incremental = incremental;
+
+    ngx_log_debug3(NGX_LOG_DEBUG_EVENT, c->log, 0,
+                   "quic stream id:0x%xL priority u=%ui i=%ui",
+                   qs->id, qs->urgency, (ngx_uint_t) qs->incremental);
+
+    /*
+     * A PRIORITY_UPDATE (or upstream Priority merge) can change the priority
+     * of a stream whose response is already in flight.  STREAM frames that
+     * were queued under the old urgency are still waiting in the application
+     * send context ordered by that stale value, so re-stamp and re-insert
+     * them to restore the by-urgency wire order for this stream.
+     */
+
+    ngx_quic_restamp_stream_priority(qs);
+}
+
+
+static void
+ngx_quic_restamp_stream_priority(ngx_quic_stream_t *qs)
+{
+    ngx_queue_t            *q;
+    ngx_quic_frame_t       *f;
+    ngx_quic_send_ctx_t    *ctx;
+    ngx_quic_connection_t  *qc;
+
+    qc = ngx_quic_get_connection(qs->parent);
+
+    ctx = ngx_quic_get_send_ctx(qc, NGX_QUIC_ENCRYPTION_APPLICATION);
+
+    q = ngx_queue_head(&ctx->frames);
+
+    while (q != ngx_queue_sentinel(&ctx->frames)) {
+
+        f = ngx_queue_data(q, ngx_quic_frame_t, queue);
+        q = ngx_queue_next(q);
+
+        if (f->type != NGX_QUIC_FT_STREAM
+            || f->u.stream.stream_id != qs->id)
+        {
+            continue;
+        }
+
+        if (f->urgency == qs->urgency
+            && (ngx_uint_t) f->incremental == qs->incremental)
+        {
+            continue;
+        }
+
+        f->urgency = qs->urgency;
+        f->incremental = qs->incremental;
+
+        ngx_queue_remove(&f->queue);
+        ngx_quic_queue_stream_frame(ctx, f);
+    }
 }
 
 
@@ -689,6 +834,7 @@ ngx_quic_create_stream(ngx_connection_t *c, uint64_t id)
     qs->id = id;
     qs->send_final_size = (uint64_t) -1;
     qs->recv_final_size = (uint64_t) -1;
+    qs->urgency = NGX_QUIC_STREAM_DEFAULT_URGENCY;
 
     pool = ngx_create_pool(NGX_DEFAULT_POOL_SIZE, c->log);
     if (pool == NULL) {
@@ -1065,6 +1211,9 @@ ngx_quic_stream_flush(ngx_quic_stream_t *qs)
     frame->level = NGX_QUIC_ENCRYPTION_APPLICATION;
     frame->type = NGX_QUIC_FT_STREAM;
     frame->data = out;
+
+    frame->urgency = qs->urgency;
+    frame->incremental = qs->incremental;
 
     frame->u.stream.off = 1;
     frame->u.stream.len = 1;

--- a/src/event/quic/ngx_event_quic_streams.c
+++ b/src/event/quic/ngx_event_quic_streams.c
@@ -12,6 +12,13 @@
 
 #define NGX_QUIC_STREAM_GONE     (void *) -1
 
+/*
+ * Per-round byte quantum used when interleaving equally-urgent incremental
+ * streams (RFC 9218).  A moderate value keeps interleaving fair without
+ * fragmenting the send stream into excessively small frames.
+ */
+#define NGX_QUIC_INCREMENTAL_QUANTUM  16384
+
 
 static ngx_int_t ngx_quic_do_reset_stream(ngx_quic_stream_t *qs,
     ngx_uint_t err);
@@ -31,7 +38,10 @@ static ssize_t ngx_quic_stream_send(ngx_connection_t *c, u_char *buf,
     size_t size);
 static ngx_chain_t *ngx_quic_stream_send_chain(ngx_connection_t *c,
     ngx_chain_t *in, off_t limit);
-static ngx_int_t ngx_quic_stream_flush(ngx_quic_stream_t *qs);
+static ngx_int_t ngx_quic_stream_flush(ngx_quic_stream_t *qs, off_t quantum);
+static ngx_int_t ngx_quic_flush_streams_by_priority(ngx_connection_t *c);
+static ngx_int_t ngx_quic_stream_priority_cmp(const void *one,
+    const void *two);
 static void ngx_quic_restamp_stream_priority(ngx_quic_stream_t *qs);
 static void ngx_quic_stream_cleanup_handler(void *data);
 static ngx_int_t ngx_quic_close_stream(ngx_quic_stream_t *qs);
@@ -477,7 +487,7 @@ ngx_quic_shutdown_stream_send(ngx_connection_t *c)
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, qs->parent->log, 0,
                    "quic stream id:0x%xL send shutdown", qs->id);
 
-    return ngx_quic_stream_flush(qs);
+    return ngx_quic_stream_flush(qs, 0);
 }
 
 
@@ -1147,7 +1157,14 @@ ngx_quic_stream_send_chain(ngx_connection_t *c, ngx_chain_t *in, off_t limit)
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0,
                    "quic send_chain sent:%uL", n);
 
-    if (ngx_quic_stream_flush(qs) != NGX_OK) {
+    /*
+     * Flush pending stream data in priority order rather than flushing
+     * this stream directly.  This ensures that whenever several streams
+     * compete for the shared connection-level send window, the more
+     * urgent streams are served first (RFC 9218), instead of whichever
+     * stream the HTTP layer happens to write to.
+     */
+    if (ngx_quic_flush_streams_by_priority(pc) != NGX_OK) {
         return NGX_CHAIN_ERROR;
     }
 
@@ -1156,7 +1173,7 @@ ngx_quic_stream_send_chain(ngx_connection_t *c, ngx_chain_t *in, off_t limit)
 
 
 static ngx_int_t
-ngx_quic_stream_flush(ngx_quic_stream_t *qs)
+ngx_quic_stream_flush(ngx_quic_stream_t *qs, off_t quantum)
 {
     off_t                   limit, len;
     ngx_uint_t              last;
@@ -1178,6 +1195,15 @@ ngx_quic_stream_flush(ngx_quic_stream_t *qs)
 
     limit = ngx_min(qc->streams.send_max_data - qc->streams.send_offset,
                     qs->send_max_data - qs->send_offset);
+
+    /*
+     * A non-zero quantum caps how much this stream may send in one flush,
+     * used to interleave equally-urgent incremental streams (RFC 9218)
+     * fairly instead of draining one before starting the next.
+     */
+    if (quantum > 0 && limit > quantum) {
+        limit = quantum;
+    }
 
     ngx_log_debug2(NGX_LOG_DEBUG_EVENT, pc->log, 0,
                    "quic stream id:0x%xL flush limit:%O", qs->id, limit);
@@ -1234,6 +1260,374 @@ ngx_quic_stream_flush(ngx_quic_stream_t *qs)
 
     if (qs->connection == NULL) {
         return ngx_quic_close_stream(qs);
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_quic_stream_priority_cmp(const void *one, const void *two)
+{
+    ngx_quic_stream_t  *qs1 = *(ngx_quic_stream_t **) one;
+    ngx_quic_stream_t  *qs2 = *(ngx_quic_stream_t **) two;
+
+    /* RFC 9218: lower urgency value is served first */
+
+    if (qs1->urgency != qs2->urgency) {
+        return (qs1->urgency < qs2->urgency) ? -1 : 1;
+    }
+
+    /*
+     * Within one urgency, keep non-incremental streams ahead of incremental
+     * ones so each urgency level splits into at most two contiguous runs the
+     * scheduler can apply the correct (sequential vs round-robin) policy to.
+     * Non-incremental resources are served first, matching the sequential-
+     * completion preference of RFC 9218 Section 7.
+     */
+
+    if (qs1->incremental != qs2->incremental) {
+        return qs1->incremental ? 1 : -1;
+    }
+
+    /* tie-break by stream id to keep ordering stable and deterministic */
+
+    if (qs1->id != qs2->id) {
+        return (qs1->id < qs2->id) ? -1 : 1;
+    }
+
+    return 0;
+}
+
+
+/*
+ * A stream in the SEND_SEND state does not necessarily have anything to put
+ * on the wire: its send buffer may be fully drained with no final size yet
+ * known (a streaming response awaiting more upstream data).  A flush of such
+ * a stream is a no-op.  Report whether a flush would actually emit a STREAM
+ * frame, i.e. there are unsent buffered bytes or a known final size has been
+ * reached and the closing (FIN) frame is still pending.  This lets the
+ * scheduler count and sort only the streams that have data to send instead
+ * of every open response.
+ */
+static ngx_inline ngx_uint_t
+ngx_quic_stream_send_ready(ngx_quic_stream_t *qs)
+{
+    if (qs->send_state != NGX_QUIC_STREAM_SEND_SEND) {
+        return 0;
+    }
+
+    if (qs->send.last_offset > qs->send.offset) {
+        return 1;
+    }
+
+    return qs->send_final_size != (uint64_t) -1
+           && qs->send_final_size == qs->send.offset;
+}
+
+
+/*
+ * Flush send-active streams in RFC 9218 urgency order when the connection
+ * is constrained by the shared MAX_DATA budget.  The most urgent stream is
+ * offered the whole remaining budget first and drains its buffered data to
+ * exhaustion before any less urgent stream is served, giving strict
+ * prioritization rather than the round-robin that rbtree (stream id) order
+ * would otherwise produce.
+ */
+static ngx_int_t
+ngx_quic_flush_streams_by_priority(ngx_connection_t *c)
+{
+    uint64_t                sent;
+    ngx_uint_t              i, j, k, n, rr, active, nalloc;
+    ngx_rbtree_t           *tree;
+    ngx_rbtree_node_t      *node;
+    ngx_quic_stream_t      *qs, **streams;
+    ngx_quic_connection_t  *qc;
+
+    qc = ngx_quic_get_connection(c);
+    tree = &qc->streams.tree;
+
+    if (tree->root == tree->sentinel) {
+        return NGX_OK;
+    }
+
+    /*
+     * Unidirectional streams (HTTP/3 control, QPACK encoder/decoder, ...)
+     * carry protocol state, not response bodies, and RFC 9218 prioritization
+     * does not apply to them.  Flush them unconditionally and up front so
+     * they are never starved or delayed by a busy high-priority request
+     * stream, then prioritize only the bidirectional request streams.
+     */
+
+    n = 0;
+
+    for (node = ngx_rbtree_min(tree->root, tree->sentinel);
+         node;
+         node = ngx_rbtree_next(tree, node))
+    {
+        qs = (ngx_quic_stream_t *) node;
+
+        if (qs->send_state != NGX_QUIC_STREAM_SEND_SEND) {
+            continue;
+        }
+
+        if (qs->id & NGX_QUIC_STREAM_UNIDIRECTIONAL) {
+            if (ngx_quic_stream_flush(qs, 0) != NGX_OK) {
+                return NGX_ERROR;
+            }
+
+            continue;
+        }
+
+        if (ngx_quic_stream_send_ready(qs)) {
+            n++;
+        }
+    }
+
+    if (n == 0) {
+        return NGX_OK;
+    }
+
+    if (n == 1) {
+        /* a single request stream; nothing to order */
+
+        for (node = ngx_rbtree_min(tree->root, tree->sentinel);
+             node;
+             node = ngx_rbtree_next(tree, node))
+        {
+            qs = (ngx_quic_stream_t *) node;
+
+            if (!(qs->id & NGX_QUIC_STREAM_UNIDIRECTIONAL)
+                && ngx_quic_stream_send_ready(qs))
+            {
+                return ngx_quic_stream_flush(qs, 0);
+            }
+        }
+
+        return NGX_OK;
+    }
+
+    /*
+     * Use a reusable scratch array kept on the connection, grown on demand,
+     * instead of allocating from the connection pool on every flush (pool
+     * allocations of this size are not reclaimed by ngx_pfree()).  Grow it
+     * geometrically so that, as active streams are added one at a time, the
+     * total memory retained across reallocations stays O(N) rather than the
+     * O(N^2) that growing to exactly n each time would leak into the pool.
+     */
+    if (qc->streams.sched_nalloc < n) {
+        nalloc = qc->streams.sched_nalloc ? qc->streams.sched_nalloc : 4;
+
+        while (nalloc < n) {
+            nalloc *= 2;
+        }
+
+        streams = ngx_palloc(c->pool, nalloc * sizeof(ngx_quic_stream_t *));
+        if (streams == NULL) {
+            return NGX_ERROR;
+        }
+
+        qc->streams.sched = streams;
+        qc->streams.sched_nalloc = nalloc;
+    }
+
+    streams = qc->streams.sched;
+
+    i = 0;
+
+    for (node = ngx_rbtree_min(tree->root, tree->sentinel);
+         node;
+         node = ngx_rbtree_next(tree, node))
+    {
+        qs = (ngx_quic_stream_t *) node;
+
+        if (!(qs->id & NGX_QUIC_STREAM_UNIDIRECTIONAL)
+            && ngx_quic_stream_send_ready(qs))
+        {
+            streams[i++] = qs;
+        }
+    }
+
+    ngx_sort(streams, n, sizeof(ngx_quic_stream_t *),
+             ngx_quic_stream_priority_cmp);
+
+    /*
+     * Walk the urgency-sorted array group by group.  Each group holds all
+     * send-active streams that share one urgency value.
+     *
+     * RFC 9218 semantics within a group:
+     *   - non-incremental: send one stream at a time (drain it fully before
+     *     moving to the next), so flush each with an unlimited quantum;
+     *   - incremental: distribute bandwidth fairly, so round-robin a bounded
+     *     quantum across the group's streams until the shared send window is
+     *     exhausted or every stream in the group has drained.
+     */
+
+    i = 0;
+
+    while (i < n) {
+
+        if (qc->streams.send_offset >= qc->streams.send_max_data) {
+            break;
+        }
+
+        /*
+         * [i, j) is the run of streams sharing streams[i]'s urgency AND
+         * incremental mode.  Because the sort orders by (urgency,
+         * incremental, id), each urgency level yields at most two such runs
+         * (non-incremental first, then incremental), so every stream is
+         * scheduled with the policy matching its own incremental bit.
+         */
+
+        for (j = i + 1; j < n; j++) {
+            if (streams[j]->urgency != streams[i]->urgency
+                || streams[j]->incremental != streams[i]->incremental)
+            {
+                break;
+            }
+        }
+
+        if (!streams[i]->incremental) {
+
+            /*
+             * Non-incremental: prefer sending one stream at a time.  The
+             * streams are already ordered by stream id within the group, so
+             * flushing them in turn lets the earlier stream consume as much
+             * of the currently available send window (and its refilled send
+             * buffer) as it can before the next stream is offered any,
+             * biasing completion towards the earlier stream without ever
+             * withholding the window when the leading stream has nothing
+             * buffered to send (which would otherwise stall the group).
+             */
+
+            for (k = i; k < j; k++) {
+
+                if (qc->streams.send_offset >= qc->streams.send_max_data) {
+                    break;
+                }
+
+                if (ngx_quic_stream_flush(streams[k], 0) != NGX_OK) {
+                    return NGX_ERROR;
+                }
+            }
+
+            i = j;
+            continue;
+        }
+
+        /*
+         * Incremental group: distribute the connection send window fairly
+         * across the group's streams (RFC 9218) instead of letting the first
+         * stream drain it.
+         *
+         * Each round the per-stream quantum is the smaller of a fixed cap and
+         * an equal share of the window currently available.  Dividing the
+         * available window is what actually produces interleaving: when only
+         * a little window has opened, a fixed 16k quantum would let the first
+         * stream visited consume all of it, starving its equally-urgent peers
+         * until the next round; an equal share guarantees every active peer
+         * gets to advance in the same round.
+         *
+         * The first stream visited each round is chosen from a round-robin
+         * cursor (sched_rr_next) preserved across flushes, so that when the
+         * available window is smaller than the group size across successive
+         * MAX_DATA increases the window rotates through the group instead of
+         * repeatedly favouring its lowest id.
+         */
+
+        rr = i;
+
+        for (k = i; k < j; k++) {
+            if (streams[k]->id >= qc->streams.sched_rr_next) {
+                rr = k;
+                break;
+            }
+        }
+
+        for ( ;; ) {
+            off_t       quantum;
+            uint64_t    avail;
+            ngx_uint_t  group_active, m;
+
+            /*
+             * Count the streams in the group that can actually make progress
+             * this round: they must have buffered data AND per-stream flow
+             * control room (send_offset < send_max_data).  A stream that is
+             * blocked by its own MAX_STREAM_DATA limit cannot consume any of
+             * the connection window, so including it would shrink every
+             * writable peer's quantum and force repeated scans (quadratic
+             * work) to drain the window while blocked streams sit idle.
+             */
+
+            group_active = 0;
+
+            for (k = i; k < j; k++) {
+                if (streams[k]->send_state == NGX_QUIC_STREAM_SEND_SEND
+                    && streams[k]->send.last_offset > streams[k]->send.offset
+                    && streams[k]->send_offset < streams[k]->send_max_data)
+                {
+                    group_active++;
+                }
+            }
+
+            if (group_active == 0
+                || qc->streams.send_offset >= qc->streams.send_max_data)
+            {
+                break;
+            }
+
+            avail = qc->streams.send_max_data - qc->streams.send_offset;
+
+            quantum = avail / group_active;
+
+            if (quantum == 0) {
+                quantum = 1;
+            }
+
+            if (quantum > NGX_QUIC_INCREMENTAL_QUANTUM) {
+                quantum = NGX_QUIC_INCREMENTAL_QUANTUM;
+            }
+
+            active = 0;
+
+            for (m = 0; m < j - i; m++) {
+
+                k = i + (rr - i + m) % (j - i);
+
+                if (qc->streams.send_offset >= qc->streams.send_max_data) {
+                    break;
+                }
+
+                if (streams[k]->send_state != NGX_QUIC_STREAM_SEND_SEND) {
+                    continue;
+                }
+
+                sent = streams[k]->send.offset;
+
+                if (ngx_quic_stream_flush(streams[k], quantum) != NGX_OK) {
+                    return NGX_ERROR;
+                }
+
+                if (streams[k]->send_state == NGX_QUIC_STREAM_SEND_SEND
+                    && streams[k]->send.offset > sent)
+                {
+                    active = 1;
+                }
+            }
+
+            if (!active) {
+                break;
+            }
+        }
+
+        /*
+         * Advance the cursor past the stream the next flush should start
+         * from, so the group is entered at a different stream each time.
+         */
+
+        qc->streams.sched_rr_next = streams[rr]->id + 1;
+
+        i = j;
     }
 
     return NGX_OK;
@@ -1473,8 +1867,6 @@ ngx_quic_handle_max_data_frame(ngx_connection_t *c,
     ngx_quic_max_data_frame_t *f)
 {
     ngx_rbtree_t           *tree;
-    ngx_rbtree_node_t      *node;
-    ngx_quic_stream_t      *qs;
     ngx_quic_connection_t  *qc;
 
     qc = ngx_quic_get_connection(c);
@@ -1493,19 +1885,8 @@ ngx_quic_handle_max_data_frame(ngx_connection_t *c,
     }
 
     qc->streams.send_max_data = f->max_data;
-    node = ngx_rbtree_min(tree->root, tree->sentinel);
 
-    while (node && qc->streams.send_offset < qc->streams.send_max_data) {
-
-        qs = (ngx_quic_stream_t *) node;
-        node = ngx_rbtree_next(tree, node);
-
-        if (ngx_quic_stream_flush(qs) != NGX_OK) {
-            return NGX_ERROR;
-        }
-    }
-
-    return NGX_OK;
+    return ngx_quic_flush_streams_by_priority(c);
 }
 
 
@@ -1593,7 +1974,15 @@ ngx_quic_handle_max_stream_data_frame(ngx_connection_t *c,
 
     qs->send_max_data = f->limit;
 
-    return ngx_quic_stream_flush(qs);
+    /*
+     * The stream was blocked on its per-stream limit and has now been
+     * unblocked.  Flush through the connection scheduler rather than
+     * flushing this stream directly: another, more urgent stream may also
+     * have data waiting on the shared connection window, and RFC 9218
+     * requires it to be served first (flushing this stream alone could let a
+     * lower-priority stream consume the remaining MAX_DATA budget).
+     */
+    return ngx_quic_flush_streams_by_priority(c);
 }
 
 

--- a/src/event/quic/ngx_event_quic_transport.h
+++ b/src/event/quic/ngx_event_quic_transport.h
@@ -273,6 +273,14 @@ struct ngx_quic_frame_s {
     unsigned                                    ignore_congestion:1;
     unsigned                                    ignore_loss:1;
 
+    /*
+     * RFC 9218 priority, copied from the owning stream when a STREAM frame
+     * is created, so ngx_quic_queue_frame() can order frames on the wire
+     * without dereferencing the stream.  Only meaningful for STREAM frames.
+     */
+    ngx_uint_t                                  urgency;
+    unsigned                                    incremental:1;
+
     ngx_chain_t                                *data;
     union {
         ngx_quic_ack_frame_t                    ack;

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -36,6 +36,7 @@ typedef u_char *(*ngx_http_log_handler_pt)(ngx_http_request_t *r,
 #include <ngx_http_upstream.h>
 #include <ngx_http_upstream_round_robin.h>
 #include <ngx_http_core_module.h>
+#include <ngx_http_priority.h>
 
 #if (NGX_HTTP_V2)
 #include <ngx_http_v2.h>

--- a/src/http/ngx_http_priority.c
+++ b/src/http/ngx_http_priority.c
@@ -1,0 +1,379 @@
+
+/*
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <ngx_http_priority.h>
+
+
+/*
+ * Parse RFC9218 Priority header value.
+ *
+ * The value is a Structured Fields Dictionary (RFC8941) containing:
+ *   - u: Integer 0-7 (urgency)
+ *   - i: Boolean (incremental)
+ *
+ * This is a simplified parser that handles the common formats:
+ *   "u=5"
+ *   "u=5, i"
+ *   "u=5, i=?1"
+ *   "i, u=3"
+ *
+ * Per RFC9218 Section 4, unknown parameters and out-of-range values
+ * are ignored, and defaults are used instead.
+ */
+
+
+static ngx_int_t
+ngx_http_priority_parse_int(u_char **pos, u_char *end, ngx_int_t *value)
+{
+    u_char      *p;
+    ngx_int_t    n, cutoff, cutlim, d;
+    ngx_uint_t   negative;
+
+    p = *pos;
+    negative = 0;
+
+    if (p >= end) {
+        return NGX_ERROR;
+    }
+
+    if (*p == '-') {
+        negative = 1;
+        p++;
+    }
+
+    if (p >= end || *p < '0' || *p > '9') {
+        return NGX_ERROR;
+    }
+
+    /*
+     * Use pre-check to avoid signed overflow.
+     * cutoff is the largest value before overflow on next digit.
+     */
+    cutoff = NGX_MAX_INT_T_VALUE / 10;
+    cutlim = NGX_MAX_INT_T_VALUE % 10;
+
+    n = 0;
+
+    while (p < end && *p >= '0' && *p <= '9') {
+        d = *p - '0';
+
+        if (n > cutoff || (n == cutoff && d > cutlim)) {
+            return NGX_ERROR;
+        }
+
+        n = n * 10 + d;
+        p++;
+    }
+
+    *pos = p;
+    *value = negative ? -n : n;
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_http_priority_skip_ows(u_char **pos, u_char *end)
+{
+    u_char  *p;
+
+    p = *pos;
+
+    while (p < end && (*p == ' ' || *p == '\t')) {
+        p++;
+    }
+
+    *pos = p;
+}
+
+
+/*
+ * Advance to the next Structured Fields Dictionary member boundary, i.e.
+ * the next top-level ',' or parameter-introducing ';'.
+ *
+ * Per RFC 8941, a member value or parameter value may be a String enclosed
+ * in double quotes, within which ',' and ';' are literal data and a
+ * backslash escapes the following character (only '"' and '\' may be
+ * escaped).  Skipping on a raw ',' / ';' scan (ignoring quoting) would
+ * split a value such as x="a,u=0" at the embedded comma and then misparse
+ * the "u=0" tail as a top-level urgency member, applying a priority the
+ * peer never signaled. Honour quoted strings here so member boundaries are
+ * detected correctly.
+ */
+static void
+ngx_http_priority_skip_member(u_char **pos, u_char *end)
+{
+    u_char      *p, ch;
+    ngx_uint_t   quoted, escaped;
+
+    p = *pos;
+    quoted = 0;
+    escaped = 0;
+
+    while (p < end) {
+        ch = *p;
+
+        if (quoted) {
+
+            if (escaped) {
+                escaped = 0;
+
+            } else if (ch == '\\') {
+                escaped = 1;
+
+            } else if (ch == '"') {
+                quoted = 0;
+            }
+
+            p++;
+            continue;
+        }
+
+        if (ch == '"') {
+            quoted = 1;
+            p++;
+            continue;
+        }
+
+        if (ch == ',' || ch == ';') {
+            break;
+        }
+
+        p++;
+    }
+
+    *pos = p;
+}
+
+
+ngx_int_t
+ngx_http_priority_parse(ngx_str_t *value, ngx_http_priority_t *p)
+{
+    u_char     *pos, *end;
+    ngx_int_t   n;
+
+    /* Initialize with defaults */
+    ngx_http_priority_init(p);
+
+    if (value == NULL || value->len == 0) {
+        return NGX_OK;
+    }
+
+    pos = value->data;
+    end = pos + value->len;
+
+    while (pos < end) {
+        ngx_http_priority_skip_ows(&pos, end);
+
+        if (pos >= end) {
+            break;
+        }
+
+        /* Parse parameter key */
+        if (pos + 1 < end && pos[1] == '=') {
+            /* Key=Value format */
+
+            if (*pos == 'u' || *pos == 'U') {
+                /* urgency parameter: u=<integer> */
+                pos += 2;  /* skip "u=" */
+
+                if (ngx_http_priority_parse_int(&pos, end, &n) == NGX_OK) {
+                    if (n >= NGX_HTTP_PRIORITY_URGENCY_MIN
+                        && n <= NGX_HTTP_PRIORITY_URGENCY_MAX)
+                    {
+                        p->urgency = (ngx_uint_t) n;
+                        p->urgency_set = 1;
+                        p->valid = 1;
+                    }
+                    /* Out of range values are ignored per RFC9218 */
+                }
+
+                /* Skip any trailing junk to next delimiter */
+                ngx_http_priority_skip_member(&pos, end);
+
+            } else if (*pos == 'i' || *pos == 'I') {
+                /* incremental parameter: i=?0 or i=?1 */
+                pos += 2;  /* skip "i=" */
+
+                if (pos < end && *pos == '?') {
+                    pos++;
+
+                    if (pos < end) {
+                        if (*pos == '1') {
+                            p->incremental = 1;
+                            p->incremental_set = 1;
+                            p->valid = 1;
+                            pos++;
+                        } else if (*pos == '0') {
+                            p->incremental = 0;
+                            p->incremental_set = 1;
+                            p->valid = 1;
+                            pos++;
+                        }
+                    }
+                }
+
+                /* Skip any trailing junk to next delimiter */
+                ngx_http_priority_skip_member(&pos, end);
+
+            } else {
+                /* Unknown parameter - skip value */
+                ngx_http_priority_skip_member(&pos, end);
+            }
+
+        } else if (*pos == 'i' || *pos == 'I') {
+            /*
+             * Bare "i" means incremental=true (Structured Fields Boolean)
+             * This is the common shorthand form
+             */
+            pos++;
+
+            /* Check it's not followed by alphanumeric (part of longer key) */
+            if (pos >= end || *pos == ',' || *pos == ' ' || *pos == '\t'
+                || *pos == ';')
+            {
+                p->incremental = 1;
+                p->incremental_set = 1;
+                p->valid = 1;
+            } else {
+                /* Part of a longer key - skip it */
+                ngx_http_priority_skip_member(&pos, end);
+            }
+
+        } else {
+            /* Unknown parameter - skip to next */
+            ngx_http_priority_skip_member(&pos, end);
+        }
+
+        /* Skip to next parameter */
+        ngx_http_priority_skip_ows(&pos, end);
+
+        if (pos < end && (*pos == ',' || *pos == ';')) {
+            pos++;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+void
+ngx_http_priority_merge(ngx_http_priority_t *result,
+    ngx_http_priority_t *client, ngx_http_priority_t *server)
+{
+    /*
+     * Per RFC9218 Section 8:
+     * "The absence of a priority parameter in an HTTP response indicates
+     * the server's disinterest in changing the client-provided value."
+     *
+     * Only override parameters that the server explicitly provided.
+     */
+
+    /* Start with client values */
+    result->urgency = client->urgency;
+    result->incremental = client->incremental;
+    result->valid = client->valid;
+    result->urgency_set = client->urgency_set;
+    result->incremental_set = client->incremental_set;
+
+    /* Override only parameters the server explicitly set */
+    if (server->urgency_set) {
+        result->urgency = server->urgency;
+        result->urgency_set = 1;
+        result->valid = 1;
+    }
+
+    if (server->incremental_set) {
+        result->incremental = server->incremental;
+        result->incremental_set = 1;
+        result->valid = 1;
+    }
+}
+
+
+void
+ngx_http_priority_state_update(ngx_http_priority_state_t *ps)
+{
+    ngx_http_priority_merge(&ps->effective, &ps->client, &ps->server);
+}
+
+
+ngx_int_t
+ngx_http_priority_compare(ngx_http_priority_t *a, ngx_http_priority_t *b)
+{
+    /*
+     * RFC9218 priority comparison for scheduling.
+     *
+     * Returns:
+     *   < 0 if a should be sent before b
+     *   > 0 if b should be sent before a
+     *   = 0 if equal priority (caller handles tie-breaking)
+     *
+     * Ordering rules:
+     *   1. Lower urgency value = higher priority
+     *   2. At same urgency: non-incremental before incremental
+     *      (non-incremental resources should complete quickly)
+     */
+
+    /* Primary: compare urgency (lower = higher priority) */
+    if (a->urgency < b->urgency) {
+        return -1;
+    }
+
+    if (a->urgency > b->urgency) {
+        return 1;
+    }
+
+    /*
+     * Same urgency: non-incremental streams should be sent first
+     * so they complete quickly. Incremental streams can wait and
+     * be interleaved later.
+     */
+    if (!a->incremental && b->incremental) {
+        return -1;  /* a (non-incr) before b (incr) */
+    }
+
+    if (a->incremental && !b->incremental) {
+        return 1;   /* b (non-incr) before a (incr) */
+    }
+
+    return 0;  /* Same urgency and same incremental status */
+}
+
+
+u_char *
+ngx_http_priority_format(u_char *buf, ngx_http_priority_t *p)
+{
+    /*
+     * Format priority as RFC9218/RFC8941 Structured Fields Dictionary.
+     *
+     * Output formats:
+     *   "u=0"     - urgency only (non-default)
+     *   "u=0, i"  - urgency and incremental
+     *   "i"       - incremental only (default urgency)
+     *
+     * If urgency is default (3) and incremental is false, returns empty.
+     */
+
+    u_char  *start = buf;
+
+    if (p->urgency != NGX_HTTP_PRIORITY_DEFAULT_URGENCY) {
+        buf = ngx_sprintf(buf, "u=%ui", p->urgency);
+    }
+
+    if (p->incremental) {
+        if (buf != start) {
+            *buf++ = ',';
+            *buf++ = ' ';
+        }
+        *buf++ = 'i';
+    }
+
+    return buf;
+}

--- a/src/http/ngx_http_priority.h
+++ b/src/http/ngx_http_priority.h
@@ -1,0 +1,132 @@
+
+/*
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#ifndef _NGX_HTTP_PRIORITY_H_INCLUDED_
+#define _NGX_HTTP_PRIORITY_H_INCLUDED_
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+
+
+/*
+ * RFC9218: Extensible Prioritization Scheme for HTTP
+ *
+ * Priority parameters:
+ *   - urgency (u): Integer 0-7, lower is more urgent, default 3
+ *   - incremental (i): Boolean, whether response can be processed
+ *                      incrementally, default false
+ */
+
+
+#define NGX_HTTP_PRIORITY_DEFAULT_URGENCY     3
+#define NGX_HTTP_PRIORITY_URGENCY_MIN         0
+#define NGX_HTTP_PRIORITY_URGENCY_MAX         7
+
+#define NGX_HTTP_PRIORITY_URGENCY_BACKGROUND  7
+
+
+typedef struct {
+    ngx_uint_t   urgency;          /* 0-7, default 3, lower = more urgent */
+    unsigned     incremental:1;    /* default 0 (false) */
+    unsigned     valid:1;          /* 1 if any parameter explicitly set */
+    unsigned     urgency_set:1;    /* 1 if urgency explicitly set */
+    unsigned     incremental_set:1;/* 1 if incremental explicitly set */
+} ngx_http_priority_t;
+
+
+/*
+ * Initialize priority to default values (u=3, i=false)
+ */
+#define ngx_http_priority_init(p)                                             \
+    do {                                                                      \
+        (p)->urgency = NGX_HTTP_PRIORITY_DEFAULT_URGENCY;                     \
+        (p)->incremental = 0;                                                 \
+        (p)->valid = 0;                                                       \
+        (p)->urgency_set = 0;                                                 \
+        (p)->incremental_set = 0;                                             \
+    } while (0)
+
+
+/*
+ * Per-stream priority state.  RFC 9218 priority is derived from two
+ * independent inputs that can each change at any time: the client's request
+ * (its Priority request header and any later PRIORITY_UPDATE frames) and the
+ * server's response hint (an upstream Priority response header, RFC 9218
+ * Section 8).  Keeping them separate lets the effective, scheduled priority
+ * be recomputed by merging the two whenever either input changes -- so a
+ * later client PRIORITY_UPDATE no longer discards a previously merged server
+ * hint, and vice versa.  "effective" is the merged result actually used for
+ * scheduling and pushed to the transport.
+ */
+typedef struct {
+    ngx_http_priority_t   client;
+    ngx_http_priority_t   server;
+    ngx_http_priority_t   effective;
+} ngx_http_priority_state_t;
+
+
+/*
+ * Initialize all three priority slots to defaults.
+ */
+#define ngx_http_priority_state_init(ps)                                      \
+    do {                                                                      \
+        ngx_http_priority_init(&(ps)->client);                               \
+        ngx_http_priority_init(&(ps)->server);                               \
+        ngx_http_priority_init(&(ps)->effective);                            \
+    } while (0)
+
+
+/*
+ * Parse RFC9218 Priority header value (Structured Fields Dictionary).
+ *
+ * Format: "u=<0-7>, i" or "u=<0-7>" or "i" or empty
+ * Examples:
+ *   "u=0"       -> urgency=0, incremental=false
+ *   "u=5, i"    -> urgency=5, incremental=true
+ *   "i"         -> urgency=3 (default), incremental=true
+ *   "u=3, i=?1" -> urgency=3, incremental=true
+ *
+ * Invalid or out-of-range values are ignored (defaults preserved).
+ */
+ngx_int_t ngx_http_priority_parse(ngx_str_t *value, ngx_http_priority_t *p);
+
+
+/*
+ * Merge server-provided priority with client priority per RFC9218 Section 8.
+ * Server values override client values when present.
+ */
+void ngx_http_priority_merge(ngx_http_priority_t *result,
+    ngx_http_priority_t *client, ngx_http_priority_t *server);
+
+
+/*
+ * Recompute ps->effective by merging the current client and server inputs.
+ * Call after updating either ps->client or ps->server.
+ */
+void ngx_http_priority_state_update(ngx_http_priority_state_t *ps);
+
+
+/*
+ * Compare two priorities for scheduling.
+ * Returns:
+ *   < 0 if a has higher priority (lower urgency, should be sent first)
+ *   > 0 if b has higher priority
+ *   = 0 if equal priority
+ */
+ngx_int_t ngx_http_priority_compare(ngx_http_priority_t *a,
+    ngx_http_priority_t *b);
+
+
+/*
+ * Format priority as a header value (RFC8941 Structured Fields Dictionary).
+ * Returns pointer to the character after the last written byte.
+ * Writes at most 6 bytes ("u=7, i"). Caller must NUL-terminate if needed.
+ */
+u_char *ngx_http_priority_format(u_char *buf, ngx_http_priority_t *p);
+
+
+#endif /* _NGX_HTTP_PRIORITY_H_INCLUDED_ */

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -5604,9 +5604,8 @@ static ngx_int_t
 ngx_http_upstream_process_priority(ngx_http_request_t *r,
     ngx_table_elt_t *h, ngx_uint_t offset)
 {
-#if (NGX_HTTP_V2)
-    ngx_http_priority_t    server_priority;
-    ngx_http_v2_stream_t  *stream;
+    ngx_http_priority_state_t  *ps;
+    ngx_http_priority_t         server_priority;
 
     /*
      * RFC9218 Section 8: Intermediaries can combine server priority hints
@@ -5618,36 +5617,63 @@ ngx_http_upstream_process_priority(ngx_http_request_t *r,
      * PRIORITY_UPDATE does not discard this server hint.
      */
 
-    stream = r->stream;
+    ps = NULL;
 
-    if (stream != NULL) {
-        if (ngx_http_priority_parse(&h->value, &server_priority) == NGX_OK
-            && server_priority.valid)
-        {
-            stream->priority.server = server_priority;
-            ngx_http_priority_state_update(&stream->priority);
-
-            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                           "http2 upstream priority merged: u=%ui i=%ui",
-                           stream->priority.effective.urgency,
-                           stream->priority.effective.incremental);
-
-            /*
-             * Update header value to reflect merged priority.
-             * Buffer needs space for "u=N, i" (max 6 bytes) plus NUL.
-             */
-            h->value.data = ngx_pnalloc(r->pool, 7);
-            if (h->value.data == NULL) {
-                return NGX_ERROR;
-            }
-
-            h->value.len = ngx_http_priority_format(h->value.data,
-                                                    &stream->priority.effective)
-                           - h->value.data;
-            h->value.data[h->value.len] = '\0';
-        }
+#if (NGX_HTTP_V2)
+    if (r->stream != NULL) {
+        ps = &r->stream->priority;
     }
 #endif
+
+#if (NGX_HTTP_V3)
+    /*
+     * Subrequests are zero-initialized and do not carry their own v3_parse;
+     * the HTTP/2 path inherits r->stream via ngx_http_subrequest() but there
+     * is no equivalent copy for v3_parse.  Use the main request's parse
+     * context so upstream responses produced through subrequests merge the
+     * upstream priority hint exactly as the HTTP/2 path does.
+     */
+    if (r->connection->quic != NULL && r->main->v3_parse != NULL) {
+        ps = &r->main->v3_parse->priority;
+    }
+#endif
+
+    if (ps == NULL) {
+        return NGX_OK;
+    }
+
+    if (ngx_http_priority_parse(&h->value, &server_priority) != NGX_OK
+        || !server_priority.valid)
+    {
+        return NGX_OK;
+    }
+
+    ps->server = server_priority;
+    ngx_http_priority_state_update(ps);
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "upstream priority merged: u=%ui i=%ui",
+                   ps->effective.urgency, ps->effective.incremental);
+
+#if (NGX_HTTP_V3)
+    if (r->connection->quic != NULL) {
+        ngx_quic_set_stream_priority(r->connection, ps->effective.urgency,
+                                     ps->effective.incremental);
+    }
+#endif
+
+    /*
+     * Update header value to reflect merged priority.
+     * Buffer needs space for "u=N, i" (max 6 bytes) plus NUL.
+     */
+    h->value.data = ngx_pnalloc(r->pool, 7);
+    if (h->value.data == NULL) {
+        return NGX_ERROR;
+    }
+
+    h->value.len = ngx_http_priority_format(h->value.data, &ps->effective)
+                   - h->value.data;
+    h->value.data[h->value.len] = '\0';
 
     return NGX_OK;
 }

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -139,6 +139,8 @@ static ngx_int_t
     ngx_table_elt_t *h, ngx_uint_t offset);
 static ngx_int_t ngx_http_upstream_process_vary(ngx_http_request_t *r,
     ngx_table_elt_t *h, ngx_uint_t offset);
+static ngx_int_t ngx_http_upstream_process_priority(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset);
 static ngx_int_t ngx_http_upstream_copy_header_line(ngx_http_request_t *r,
     ngx_table_elt_t *h, ngx_uint_t offset);
 static ngx_int_t
@@ -335,6 +337,10 @@ static ngx_http_upstream_header_t  ngx_http_upstream_headers_in[] = {
                  ngx_http_upstream_ignore_header_line, 0,
                  ngx_http_upstream_copy_header_line,
                  offsetof(ngx_http_headers_out_t, content_encoding), 0 },
+
+    { ngx_string("Priority"),
+                 ngx_http_upstream_process_priority, 0,
+                 ngx_http_upstream_copy_header_line, 0, 0 },
 
     { ngx_null_string, NULL, 0, NULL, 0, 0 }
 };
@@ -5587,6 +5593,59 @@ ngx_http_upstream_process_vary(ngx_http_request_t *r,
     }
 
     r->cache->vary = vary;
+    }
+#endif
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_upstream_process_priority(ngx_http_request_t *r,
+    ngx_table_elt_t *h, ngx_uint_t offset)
+{
+#if (NGX_HTTP_V2)
+    ngx_http_priority_t    server_priority;
+    ngx_http_v2_stream_t  *stream;
+
+    /*
+     * RFC9218 Section 8: Intermediaries can combine server priority hints
+     * with client priority.  When the upstream sends a Priority header,
+     * record it as the stream's server priority and recompute the effective
+     * priority by merging it with the client's requested value, then update
+     * the header to reflect the merged value per RFC9218 Section 5.4.  The
+     * client and server inputs are kept separately so a later client
+     * PRIORITY_UPDATE does not discard this server hint.
+     */
+
+    stream = r->stream;
+
+    if (stream != NULL) {
+        if (ngx_http_priority_parse(&h->value, &server_priority) == NGX_OK
+            && server_priority.valid)
+        {
+            stream->priority.server = server_priority;
+            ngx_http_priority_state_update(&stream->priority);
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http2 upstream priority merged: u=%ui i=%ui",
+                           stream->priority.effective.urgency,
+                           stream->priority.effective.incremental);
+
+            /*
+             * Update header value to reflect merged priority.
+             * Buffer needs space for "u=N, i" (max 6 bytes) plus NUL.
+             */
+            h->value.data = ngx_pnalloc(r->pool, 7);
+            if (h->value.data == NULL) {
+                return NGX_ERROR;
+            }
+
+            h->value.len = ngx_http_priority_format(h->value.data,
+                                                    &stream->priority.effective)
+                           - h->value.data;
+            h->value.data[h->value.len] = '\0';
+        }
     }
 #endif
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1721,6 +1721,7 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
     ngx_http_core_main_conf_t  *cmcf;
 
     static ngx_str_t cookie = ngx_string("cookie");
+    static ngx_str_t priority_name = ngx_string("priority");
 
     header = &h2c->state.header;
 
@@ -1816,6 +1817,38 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
                           "client sent invalid header: \"%V\"", &header->name);
 
             return ngx_http_v2_state_header_complete(h2c, pos, end);
+        }
+    }
+
+    /*
+     * RFC9218: Handle Priority request header for extensible priorities.
+     * Parse and store the priority parameters in the stream, but continue
+     * normal header processing so the header is visible to variables and
+     * forwarding.
+     *
+     * Parse the Priority header for RFC9218 extensible priorities.
+     */
+    if (header->name.len == priority_name.len
+        && ngx_memcmp(header->name.data, priority_name.data,
+                      priority_name.len) == 0)
+    {
+        ngx_http_priority_t  tmp;
+
+        ngx_http_priority_parse(&header->value, &tmp);
+
+        /*
+         * Only apply if the value is empty (an explicit reset) or at least
+         * one parameter was recognized.  This prevents a malformed value from
+         * clobbering a priority already set for this stream.
+         */
+        if (header->value.len == 0 || tmp.valid) {
+            h2c->state.stream->priority.client = tmp;
+            ngx_http_priority_state_update(&h2c->state.stream->priority);
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http2 priority header: u=%ui, i=%ui",
+                           h2c->state.stream->priority.effective.urgency,
+                           h2c->state.stream->priority.effective.incremental);
         }
     }
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -47,8 +47,6 @@
 
 #define NGX_HTTP_V2_FRAME_BUFFER_SIZE            24
 
-#define NGX_HTTP_V2_ROOT                         (void *) -1
-
 
 static void ngx_http_v2_read_handler(ngx_event_t *rev);
 static void ngx_http_v2_write_handler(ngx_event_t *wev);
@@ -288,7 +286,6 @@ ngx_http_v2_init(ngx_event_t *rev)
     h2c->state.handler = ngx_http_v2_state_preface;
 
     ngx_queue_init(&h2c->waiting);
-    ngx_queue_init(&h2c->dependencies);
     ngx_queue_init(&h2c->closed);
 
     c->data = h2c;
@@ -1298,11 +1295,6 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     if (node == NULL) {
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
-    }
-
-    if (node->parent) {
-        ngx_queue_remove(&node->reuse);
-        h2c->closed_nodes--;
     }
 
     stream = ngx_http_v2_create_stream(h2c);
@@ -3365,8 +3357,6 @@ ngx_http_v2_get_node_by_id(ngx_http_v2_connection_t *h2c, ngx_uint_t sid,
 
     node->id = sid;
 
-    ngx_queue_init(&node->children);
-
     node->index = h2c->streams_index[index];
     h2c->streams_index[index] = node;
 
@@ -3377,12 +3367,8 @@ ngx_http_v2_get_node_by_id(ngx_http_v2_connection_t *h2c, ngx_uint_t sid,
 static ngx_http_v2_node_t *
 ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
 {
-    ngx_queue_t             *q;
-    ngx_http_v2_node_t      *node, **next, *n;
-    ngx_http_v2_srv_conf_t  *h2scf;
-
-    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
-                                         ngx_http_v2_module);
+    ngx_queue_t         *q;
+    ngx_http_v2_node_t  *node;
 
     h2c->closed_nodes--;
 
@@ -3391,19 +3377,6 @@ ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
     ngx_queue_remove(q);
 
     node = ngx_queue_data(q, ngx_http_v2_node_t, reuse);
-
-    next = &h2c->streams_index[ngx_http_v2_index(h2scf, node->id)];
-
-    for ( ;; ) {
-        n = *next;
-
-        if (n == node) {
-            *next = n->index;
-            break;
-        }
-
-        next = &n->index;
-    }
 
     ngx_memzero(node, sizeof(ngx_http_v2_node_t));
 
@@ -4728,7 +4701,8 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
     ngx_pool_t                *pool;
     ngx_event_t               *ev;
     ngx_connection_t          *fc;
-    ngx_http_v2_node_t        *node;
+    ngx_http_v2_node_t        *node, **next, *n;
+    ngx_http_v2_srv_conf_t    *h2scf;
     ngx_http_v2_connection_t  *h2c;
 
     h2c = stream->connection;
@@ -4772,6 +4746,23 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
     }
 
     node->stream = NULL;
+
+    /* Remove node from streams_index before adding to closed queue */
+    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                         ngx_http_v2_module);
+
+    next = &h2c->streams_index[ngx_http_v2_index(h2scf, node->id)];
+
+    for ( ;; ) {
+        n = *next;
+
+        if (n == node) {
+            *next = n->index;
+            break;
+        }
+
+        next = &n->index;
+    }
 
     ngx_queue_insert_tail(&h2c->closed, &node->reuse);
     h2c->closed_nodes++;

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -179,9 +179,6 @@ static void ngx_http_v2_finalize_connection(ngx_http_v2_connection_t *h2c,
 
 static ngx_int_t ngx_http_v2_adjust_windows(ngx_http_v2_connection_t *h2c,
     ssize_t delta);
-static void ngx_http_v2_set_dependency(ngx_http_v2_connection_t *h2c,
-    ngx_http_v2_node_t *node, ngx_uint_t depend, ngx_uint_t exclusive);
-static void ngx_http_v2_node_children_update(ngx_http_v2_node_t *node);
 
 static void ngx_http_v2_pool_cleanup(void *data);
 
@@ -1172,8 +1169,7 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
     u_char *end)
 {
     size_t                     size;
-    ngx_uint_t                 padded, priority, depend, dependency, excl,
-                               weight;
+    ngx_uint_t                 padded, priority;
     ngx_uint_t                 status;
     ngx_http_v2_node_t        *node;
     ngx_http_v2_stream_t      *stream;
@@ -1238,37 +1234,18 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
         h2c->state.length -= h2c->state.padding;
     }
 
-    depend = 0;
-    excl = 0;
-    weight = NGX_HTTP_V2_DEFAULT_WEIGHT;
-
     if (priority) {
-        dependency = ngx_http_v2_parse_uint32(pos);
-
-        depend = dependency & 0x7fffffff;
-        excl = dependency >> 31;
-        weight = pos[4] + 1;
-
+        /* Skip RFC7540 priority data; RFC9218 uses Priority header instead */
         pos += sizeof(uint32_t) + 1;
     }
 
-    ngx_log_debug4(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
-                   "http2 HEADERS frame sid:%ui "
-                   "depends on %ui excl:%ui weight:%ui",
-                   h2c->state.sid, depend, excl, weight);
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 HEADERS frame sid:%ui", h2c->state.sid);
 
     if (h2c->state.sid % 2 == 0 || h2c->state.sid <= h2c->last_sid) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
                       "client sent HEADERS frame with incorrect identifier "
                       "%ui, the last was %ui", h2c->state.sid, h2c->last_sid);
-
-        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
-    }
-
-    if (depend == h2c->state.sid) {
-        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
-                      "client sent HEADERS frame for stream %ui "
-                      "with incorrect dependency", h2c->state.sid);
 
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
     }
@@ -1375,17 +1352,6 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
                 break;
             }
         }
-    }
-
-    /*
-     * RFC9218: Even when RFC9218 is enabled, we still need to set up the
-     * node tree structure for proper node lifecycle management (the closed
-     * queue uses the node's queue member). We just don't use the dependency
-     * tree for scheduling.
-     */
-    if (priority || node->parent == NULL) {
-        node->weight = weight;
-        ngx_http_v2_set_dependency(h2c, node, depend, excl);
     }
 
     clcf = ngx_http_get_module_loc_conf(h2c->http_connection->conf_ctx,
@@ -3411,9 +3377,8 @@ ngx_http_v2_get_node_by_id(ngx_http_v2_connection_t *h2c, ngx_uint_t sid,
 static ngx_http_v2_node_t *
 ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
 {
-    ngx_uint_t               weight;
-    ngx_queue_t             *q, *children;
-    ngx_http_v2_node_t      *node, **next, *n, *parent, *child;
+    ngx_queue_t             *q;
+    ngx_http_v2_node_t      *node, **next, *n;
     ngx_http_v2_srv_conf_t  *h2scf;
 
     h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
@@ -3439,49 +3404,6 @@ ngx_http_v2_get_closed_node(ngx_http_v2_connection_t *h2c)
 
         next = &n->index;
     }
-
-    ngx_queue_remove(&node->queue);
-
-    weight = 0;
-
-    for (q = ngx_queue_head(&node->children);
-         q != ngx_queue_sentinel(&node->children);
-         q = ngx_queue_next(q))
-    {
-        child = ngx_queue_data(q, ngx_http_v2_node_t, queue);
-        weight += child->weight;
-    }
-
-    parent = node->parent;
-
-    for (q = ngx_queue_head(&node->children);
-         q != ngx_queue_sentinel(&node->children);
-         q = ngx_queue_next(q))
-    {
-        child = ngx_queue_data(q, ngx_http_v2_node_t, queue);
-        child->parent = parent;
-        child->weight = node->weight * child->weight / weight;
-
-        if (child->weight == 0) {
-            child->weight = 1;
-        }
-    }
-
-    if (parent == NGX_HTTP_V2_ROOT) {
-        node->rank = 0;
-        node->rel_weight = 1.0;
-
-        children = &h2c->dependencies;
-
-    } else {
-        node->rank = parent->rank;
-        node->rel_weight = parent->rel_weight;
-
-        children = &parent->children;
-    }
-
-    ngx_http_v2_node_children_update(node);
-    ngx_queue_add(children, &node->children);
 
     ngx_memzero(node, sizeof(ngx_http_v2_node_t));
 
@@ -5199,117 +5121,6 @@ ngx_http_v2_adjust_windows(ngx_http_v2_connection_t *h2c, ssize_t delta)
     }
 
     return NGX_OK;
-}
-
-
-static void
-ngx_http_v2_set_dependency(ngx_http_v2_connection_t *h2c,
-    ngx_http_v2_node_t *node, ngx_uint_t depend, ngx_uint_t exclusive)
-{
-    ngx_queue_t         *children, *q;
-    ngx_http_v2_node_t  *parent, *child, *next;
-
-    parent = depend ? ngx_http_v2_get_node_by_id(h2c, depend, 0) : NULL;
-
-    if (parent == NULL) {
-        parent = NGX_HTTP_V2_ROOT;
-
-        if (depend != 0) {
-            exclusive = 0;
-        }
-
-        node->rank = 1;
-        node->rel_weight = (1.0 / 256) * node->weight;
-
-        children = &h2c->dependencies;
-
-    } else {
-        if (node->parent != NULL) {
-
-            for (next = parent->parent;
-                 next != NGX_HTTP_V2_ROOT && next->rank >= node->rank;
-                 next = next->parent)
-            {
-                if (next != node) {
-                    continue;
-                }
-
-                ngx_queue_remove(&parent->queue);
-                ngx_queue_insert_after(&node->queue, &parent->queue);
-
-                parent->parent = node->parent;
-
-                if (node->parent == NGX_HTTP_V2_ROOT) {
-                    parent->rank = 1;
-                    parent->rel_weight = (1.0 / 256) * parent->weight;
-
-                } else {
-                    parent->rank = node->parent->rank + 1;
-                    parent->rel_weight = (node->parent->rel_weight / 256)
-                                         * parent->weight;
-                }
-
-                if (!exclusive) {
-                    ngx_http_v2_node_children_update(parent);
-                }
-
-                break;
-            }
-        }
-
-        node->rank = parent->rank + 1;
-        node->rel_weight = (parent->rel_weight / 256) * node->weight;
-
-        if (parent->stream == NULL) {
-            ngx_queue_remove(&parent->reuse);
-            ngx_queue_insert_tail(&h2c->closed, &parent->reuse);
-        }
-
-        children = &parent->children;
-    }
-
-    if (exclusive) {
-        for (q = ngx_queue_head(children);
-             q != ngx_queue_sentinel(children);
-             q = ngx_queue_next(q))
-        {
-            child = ngx_queue_data(q, ngx_http_v2_node_t, queue);
-            child->parent = node;
-        }
-
-        ngx_queue_add(&node->children, children);
-        ngx_queue_init(children);
-    }
-
-    if (node->parent != NULL) {
-        ngx_queue_remove(&node->queue);
-    }
-
-    ngx_queue_insert_tail(children, &node->queue);
-
-    node->parent = parent;
-
-    ngx_http_v2_node_children_update(node);
-}
-
-
-static void
-ngx_http_v2_node_children_update(ngx_http_v2_node_t *node)
-{
-    ngx_queue_t         *q;
-    ngx_http_v2_node_t  *child;
-
-    for (q = ngx_queue_head(&node->children);
-         q != ngx_queue_sentinel(&node->children);
-         q = ngx_queue_next(q))
-    {
-        child = ngx_queue_data(q, ngx_http_v2_node_t, queue);
-
-        child->rank = node->rank + 1;
-        child->rel_weight = (node->rel_weight / 256) * child->weight;
-
-        ngx_http_v2_node_children_update(child);
-    }
 }
 
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -2069,8 +2069,7 @@ static u_char *
 ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
     u_char *end)
 {
-    ngx_uint_t           depend, dependency, excl, weight;
-    ngx_http_v2_node_t  *node;
+    ngx_uint_t  depend;
 
     if (h2c->state.length != NGX_HTTP_V2_PRIORITY_SIZE) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
@@ -2080,30 +2079,18 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
     }
 
-    if (--h2c->priority_limit == 0) {
-        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
-                      "client sent too many PRIORITY frames");
-
-        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
-    }
-
     if (end - pos < NGX_HTTP_V2_PRIORITY_SIZE) {
         return ngx_http_v2_state_save(h2c, pos, end,
                                       ngx_http_v2_state_priority);
     }
 
-    dependency = ngx_http_v2_parse_uint32(pos);
-
-    depend = dependency & 0x7fffffff;
-    excl = dependency >> 31;
-    weight = pos[4] + 1;
+    depend = ngx_http_v2_parse_uint32(pos) & 0x7fffffff;
 
     pos += NGX_HTTP_V2_PRIORITY_SIZE;
 
-    ngx_log_debug4(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
-                   "http2 PRIORITY frame sid:%ui "
-                   "depends on %ui excl:%ui weight:%ui",
-                   h2c->state.sid, depend, excl, weight);
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 PRIORITY frame sid:%ui ignored",
+                   h2c->state.sid);
 
     if (h2c->state.sid == 0) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
@@ -2120,26 +2107,11 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
     }
 
-    node = ngx_http_v2_get_node_by_id(h2c, h2c->state.sid, 1);
-
-    if (node == NULL) {
-        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
+    if (--h2c->priority_limit == 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent too many PRIORITY frames");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
     }
-
-    node->weight = weight;
-
-    if (node->stream == NULL) {
-        if (node->parent == NULL) {
-            h2c->closed_nodes++;
-
-        } else {
-            ngx_queue_remove(&node->reuse);
-        }
-
-        ngx_queue_insert_tail(&h2c->closed, &node->reuse);
-    }
-
-    ngx_http_v2_set_dependency(h2c, node, depend, excl);
 
     return ngx_http_v2_state_complete(h2c, pos, end);
 }

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -38,11 +38,12 @@
 #define NGX_HTTP_V2_SETTINGS_PARAM_SIZE          6
 
 /* settings fields */
-#define NGX_HTTP_V2_HEADER_TABLE_SIZE_SETTING    0x1
-#define NGX_HTTP_V2_ENABLE_PUSH_SETTING          0x2
-#define NGX_HTTP_V2_MAX_STREAMS_SETTING          0x3
-#define NGX_HTTP_V2_INIT_WINDOW_SIZE_SETTING     0x4
-#define NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING       0x5
+#define NGX_HTTP_V2_HEADER_TABLE_SIZE_SETTING      0x1
+#define NGX_HTTP_V2_ENABLE_PUSH_SETTING            0x2
+#define NGX_HTTP_V2_MAX_STREAMS_SETTING            0x3
+#define NGX_HTTP_V2_INIT_WINDOW_SIZE_SETTING       0x4
+#define NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING         0x5
+#define NGX_HTTP_V2_NO_RFC7540_PRIORITIES_SETTING  0x9
 
 #define NGX_HTTP_V2_FRAME_BUFFER_SIZE            24
 
@@ -2735,7 +2736,14 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
         return NGX_ERROR;
     }
 
-    len = NGX_HTTP_V2_SETTINGS_PARAM_SIZE * 3;
+    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                         ngx_http_v2_module);
+
+    /*
+     * Settings: MAX_STREAMS, INIT_WINDOW_SIZE, MAX_FRAME_SIZE,
+     * NO_RFC7540_PRIORITIES
+     */
+    len = NGX_HTTP_V2_SETTINGS_PARAM_SIZE * 4;
 
     buf = ngx_create_temp_buf(h2c->pool, NGX_HTTP_V2_FRAME_HEADER_SIZE + len);
     if (buf == NULL) {
@@ -2763,9 +2771,6 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
 
     buf->last = ngx_http_v2_write_sid(buf->last, 0);
 
-    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
-                                         ngx_http_v2_module);
-
     buf->last = ngx_http_v2_write_uint16(buf->last,
                                          NGX_HTTP_V2_MAX_STREAMS_SETTING);
     buf->last = ngx_http_v2_write_uint32(buf->last,
@@ -2779,6 +2784,14 @@ ngx_http_v2_send_settings(ngx_http_v2_connection_t *h2c)
                                          NGX_HTTP_V2_MAX_FRAME_SIZE_SETTING);
     buf->last = ngx_http_v2_write_uint32(buf->last,
                                          NGX_HTTP_V2_MAX_FRAME_SIZE);
+
+    /* RFC9218: Signal that we use extensible priorities */
+    buf->last = ngx_http_v2_write_uint16(buf->last,
+                                NGX_HTTP_V2_NO_RFC7540_PRIORITIES_SETTING);
+    buf->last = ngx_http_v2_write_uint32(buf->last, 1);
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 RFC9218 extensible priorities enabled");
 
     ngx_http_v2_queue_blocked_frame(h2c, frame);
 
@@ -3105,6 +3118,9 @@ ngx_http_v2_create_stream(ngx_http_v2_connection_t *h2c)
 
     stream->request = r;
     stream->connection = h2c;
+
+    /* RFC9218: Initialize with default priority */
+    ngx_http_priority_state_init(&stream->priority);
 
     h2scf = ngx_http_get_module_srv_conf(r, ngx_http_v2_module);
 

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -86,6 +86,8 @@ static u_char *ngx_http_v2_handle_continuation(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end, ngx_http_v2_handler_pt handler);
 static u_char *ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
+static u_char *ngx_http_v2_state_priority_update(ngx_http_v2_connection_t *h2c,
+    u_char *pos, u_char *end);
 static u_char *ngx_http_v2_state_rst_stream(ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
 static u_char *ngx_http_v2_state_settings(ngx_http_v2_connection_t *h2c,
@@ -907,6 +909,11 @@ ngx_http_v2_state_head(ngx_http_v2_connection_t *h2c, u_char *pos, u_char *end)
                    "http2 frame type:%ui f:%Xd l:%uz sid:%ui",
                    type, h2c->state.flags, h2c->state.length, h2c->state.sid);
 
+    /* RFC9218: Handle PRIORITY_UPDATE frame (type 0x10) */
+    if (type == NGX_HTTP_V2_PRIORITY_UPDATE_FRAME) {
+        return ngx_http_v2_state_priority_update(h2c, pos, end);
+    }
+
     if (type >= NGX_HTTP_V2_FRAME_STATES) {
         ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
                       "client sent frame with unknown type %ui", type);
@@ -1338,6 +1345,44 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     node->stream = stream;
 
+    /*
+     * RFC9218: Apply any pending priority updates for this stream.
+     * PRIORITY_UPDATE frames may arrive before HEADERS.
+     */
+    if (h2c->pending_priorities) {
+        ngx_uint_t                       i, n;
+        ngx_http_v2_pending_priority_t  *pp;
+
+        pp = h2c->pending_priorities->elts;
+        n = h2c->pending_priorities->nelts;
+
+        for (i = 0; i < n; i++) {
+            if (pp[i].sid == node->id) {
+                stream->priority.client = pp[i].priority;
+                ngx_http_priority_state_update(&stream->priority);
+
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                               "http2 applied pending priority for stream %ui: "
+                               "u=%ui", node->id,
+                               stream->priority.effective.urgency);
+
+                /* Remove entry: swap with last and decrement count */
+                n--;
+                if (i < n) {
+                    pp[i] = pp[n];
+                }
+                h2c->pending_priorities->nelts = n;
+                break;
+            }
+        }
+    }
+
+    /*
+     * RFC9218: Even when RFC9218 is enabled, we still need to set up the
+     * node tree structure for proper node lifecycle management (the closed
+     * queue uses the node's queue member). We just don't use the dependency
+     * tree for scheduling.
+     */
     if (priority || node->parent == NULL) {
         node->weight = weight;
         ngx_http_v2_set_dependency(h2c, node, depend, excl);
@@ -2096,6 +2141,180 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
 
     ngx_http_v2_set_dependency(h2c, node, depend, excl);
 
+    return ngx_http_v2_state_complete(h2c, pos, end);
+}
+
+
+static u_char *
+ngx_http_v2_state_priority_update(ngx_http_v2_connection_t *h2c, u_char *pos,
+    u_char *end)
+{
+    size_t                           len;
+    ngx_str_t                        value;
+    ngx_uint_t                       i, sid;
+    ngx_http_v2_node_t              *node;
+    ngx_http_priority_t              priority;
+    ngx_http_v2_stream_t            *stream;
+    ngx_http_v2_srv_conf_t          *h2scf;
+    ngx_http_v2_pending_priority_t  *pp;
+
+    /*
+     * RFC9218: PRIORITY_UPDATE frame format:
+     *   - Prioritized Stream ID (31 bits)
+     *   - Priority Field Value (variable length)
+     *
+     * Must be sent on stream 0, for client-initiated streams only.
+     */
+
+    if (h2c->state.sid != 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent PRIORITY_UPDATE frame on non-zero stream");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
+    }
+
+    if (h2c->state.length < 4) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent PRIORITY_UPDATE frame too short");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
+    }
+
+    len = h2c->state.length;
+
+    if ((size_t) (end - pos) < len) {
+        /*
+         * Frame is fragmented.  Only buffer if it fits in state buffer,
+         * otherwise skip to avoid overflow.
+         */
+        if (len > NGX_HTTP_V2_STATE_BUFFER_SIZE) {
+            if (--h2c->priority_limit == 0) {
+                ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                              "client sent too many PRIORITY_UPDATE frames");
+                return ngx_http_v2_connection_error(h2c,
+                                                NGX_HTTP_V2_ENHANCE_YOUR_CALM);
+            }
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                           "http2 PRIORITY_UPDATE frame too large to buffer: "
+                           "%uz", len);
+            return ngx_http_v2_state_skip(h2c, pos, end);
+        }
+
+        return ngx_http_v2_state_save(h2c, pos, end,
+                                      ngx_http_v2_state_priority_update);
+    }
+
+    if (--h2c->priority_limit == 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent too many PRIORITY_UPDATE frames");
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
+    }
+
+    /* Parse Prioritized Stream ID (first 4 bytes, top bit reserved) */
+    sid = ngx_http_v2_parse_uint32(pos) & 0x7fffffff;
+    pos += 4;
+    len -= 4;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                   "http2 PRIORITY_UPDATE frame for stream %ui, len=%uz",
+                   sid, len);
+
+    /* Must be odd (client-initiated) */
+    if (sid == 0 || (sid & 1) == 0) {
+        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
+                      "client sent PRIORITY_UPDATE for invalid stream %ui",
+                      sid);
+        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_PROTOCOL_ERROR);
+    }
+
+    /* Parse Priority Field Value */
+    value.data = pos;
+    value.len = len;
+
+    ngx_http_priority_parse(&value, &priority);
+
+    /*
+     * A PRIORITY_UPDATE frame communicates a complete set of priority
+     * parameters (RFC 9218 Section 7): an omitted parameter is a signal to
+     * use its default, and an empty value is an explicit reset to the
+     * defaults.  ngx_http_priority_parse() has already seeded priority with
+     * those defaults, so it is applied as-is -- a value whose only members
+     * are unknown extensions still resets the recognized parameters to their
+     * defaults rather than retaining a stale prior signal.
+     */
+
+    node = ngx_http_v2_get_node_by_id(h2c, sid, 0);
+
+    if (node && node->stream) {
+        /* Stream exists, apply priority immediately */
+        stream = node->stream;
+        stream->priority.client = priority;
+        ngx_http_priority_state_update(&stream->priority);
+
+        ngx_log_debug3(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                       "http2 PRIORITY_UPDATE applied to stream %ui: "
+                       "u=%ui, i=%ui",
+                       sid, stream->priority.effective.urgency,
+                       stream->priority.effective.incremental);
+
+    } else if (sid > h2c->last_sid) {
+        /*
+         * Stream doesn't exist yet (sid > last_sid), buffer the priority.
+         * If sid <= last_sid, the stream already existed and is now closed,
+         * so there's no point buffering since it will never be created again.
+         */
+        h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                             ngx_http_v2_module);
+
+        if (h2c->pending_priorities == NULL) {
+            h2c->pending_priorities = ngx_array_create(h2c->pool, 4,
+                                        sizeof(ngx_http_v2_pending_priority_t));
+            if (h2c->pending_priorities == NULL) {
+                return ngx_http_v2_connection_error(h2c,
+                                                    NGX_HTTP_V2_INTERNAL_ERROR);
+            }
+        }
+
+        /* Check if we already have a pending priority for this stream */
+        pp = h2c->pending_priorities->elts;
+        for (i = 0; i < h2c->pending_priorities->nelts; i++) {
+            if (pp[i].sid == sid) {
+                /* Update existing entry */
+                pp[i].priority = priority;
+
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                               "http2 PRIORITY_UPDATE updated pending for "
+                               "stream %ui: u=%ui",
+                               sid, pp[i].priority.urgency);
+                goto done;
+            }
+        }
+
+        /* Cap pending priorities at max_concurrent_streams */
+        if (h2c->pending_priorities->nelts >= h2scf->concurrent_streams) {
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                           "http2 PRIORITY_UPDATE ignored, pending limit "
+                           "reached for stream %ui", sid);
+            goto done;
+        }
+
+        /* Add new pending entry */
+        pp = ngx_array_push(h2c->pending_priorities);
+        if (pp == NULL) {
+            return ngx_http_v2_connection_error(h2c,
+                                                NGX_HTTP_V2_INTERNAL_ERROR);
+        }
+
+        pp->sid = sid;
+        pp->priority = priority;
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
+                       "http2 PRIORITY_UPDATE buffered for stream "
+                       "%ui: u=%ui", sid, pp->priority.urgency);
+    }
+
+done:
+
+    pos += h2c->state.length - 4;
     return ngx_http_v2_state_complete(h2c, pos, end);
 }
 

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -27,16 +27,17 @@
 #define NGX_HTTP_V2_FRAME_HEADER_SIZE    9
 
 /* frame types */
-#define NGX_HTTP_V2_DATA_FRAME           0x0
-#define NGX_HTTP_V2_HEADERS_FRAME        0x1
-#define NGX_HTTP_V2_PRIORITY_FRAME       0x2
-#define NGX_HTTP_V2_RST_STREAM_FRAME     0x3
-#define NGX_HTTP_V2_SETTINGS_FRAME       0x4
-#define NGX_HTTP_V2_PUSH_PROMISE_FRAME   0x5
-#define NGX_HTTP_V2_PING_FRAME           0x6
-#define NGX_HTTP_V2_GOAWAY_FRAME         0x7
-#define NGX_HTTP_V2_WINDOW_UPDATE_FRAME  0x8
-#define NGX_HTTP_V2_CONTINUATION_FRAME   0x9
+#define NGX_HTTP_V2_DATA_FRAME             0x00
+#define NGX_HTTP_V2_HEADERS_FRAME          0x01
+#define NGX_HTTP_V2_PRIORITY_FRAME         0x02
+#define NGX_HTTP_V2_RST_STREAM_FRAME       0x03
+#define NGX_HTTP_V2_SETTINGS_FRAME         0x04
+#define NGX_HTTP_V2_PUSH_PROMISE_FRAME     0x05
+#define NGX_HTTP_V2_PING_FRAME             0x06
+#define NGX_HTTP_V2_GOAWAY_FRAME           0x07
+#define NGX_HTTP_V2_WINDOW_UPDATE_FRAME    0x08
+#define NGX_HTTP_V2_CONTINUATION_FRAME     0x09
+#define NGX_HTTP_V2_PRIORITY_UPDATE_FRAME  0x10
 
 /* frame flags */
 #define NGX_HTTP_V2_NO_FLAG              0x00

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -50,8 +50,6 @@
 #define NGX_HTTP_V2_MAX_WINDOW           ((1U << 31) - 1)
 #define NGX_HTTP_V2_DEFAULT_WINDOW       65535
 
-#define NGX_HTTP_V2_DEFAULT_WEIGHT       16
-
 
 typedef struct ngx_http_v2_connection_s   ngx_http_v2_connection_t;
 typedef struct ngx_http_v2_node_s         ngx_http_v2_node_t;
@@ -168,7 +166,6 @@ struct ngx_http_v2_connection_s {
 
     ngx_http_v2_out_frame_t         *last_out;
 
-    ngx_queue_t                      dependencies;
     ngx_queue_t                      closed;
 
     ngx_uint_t                       closed_nodes;
@@ -189,13 +186,7 @@ struct ngx_http_v2_connection_s {
 struct ngx_http_v2_node_s {
     ngx_uint_t                       id;
     ngx_http_v2_node_t              *index;
-    ngx_http_v2_node_t              *parent;
-    ngx_queue_t                      queue;
-    ngx_queue_t                      children;
     ngx_queue_t                      reuse;
-    ngx_uint_t                       rank;
-    ngx_uint_t                       weight;
-    double                           rel_weight;
     ngx_http_v2_stream_t            *stream;
 };
 

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -61,6 +61,16 @@ typedef u_char *(*ngx_http_v2_handler_pt) (ngx_http_v2_connection_t *h2c,
     u_char *pos, u_char *end);
 
 
+/*
+ * RFC9218: Pending priority update for streams not yet created.
+ * PRIORITY_UPDATE frames may arrive before the HEADERS frame.
+ */
+typedef struct {
+    ngx_uint_t                       sid;
+    ngx_http_priority_t              priority;
+} ngx_http_v2_pending_priority_t;
+
+
 typedef struct {
     ngx_flag_t                       enable;
     size_t                           pool_size;
@@ -169,6 +179,9 @@ struct ngx_http_v2_connection_s {
     unsigned                         table_update:1;
     unsigned                         blocked:1;
     unsigned                         goaway:1;
+
+    /* RFC9218 Extensible Priorities */
+    ngx_array_t                     *pending_priorities;
 };
 
 
@@ -223,6 +236,9 @@ struct ngx_http_v2_stream_s {
     unsigned                         rst_sent:1;
     unsigned                         no_flow_control:1;
     unsigned                         skip_data:1;
+
+    /* RFC9218 Extensible Priorities */
+    ngx_http_priority_state_t        priority;
 };
 
 

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -258,11 +258,50 @@ struct ngx_http_v2_out_frame_s {
 };
 
 
+/*
+ * Compare two streams for scheduling order.
+ *
+ * Returns 1 if existing stream 's' should come before 'stream' (break),
+ * returns 0 if search should continue.
+ *
+ * Uses RFC9218 urgency-based scheduling.
+ * Lower urgency value (0-7) = higher priority.
+ * At same urgency, non-incremental before incremental.
+ * At same urgency and incremental, lower stream ID wins (FIFO order).
+ */
+static ngx_inline ngx_uint_t
+ngx_http_v2_stream_comes_before(ngx_http_v2_connection_t *h2c,
+    ngx_http_v2_stream_t *s, ngx_http_v2_stream_t *stream)
+{
+    ngx_int_t  cmp;
+
+    /* RFC9218 urgency-based scheduling */
+    cmp = ngx_http_priority_compare(&s->priority.effective,
+                                    &stream->priority.effective);
+
+    if (cmp < 0) {
+        return 1;
+    }
+
+    if (cmp == 0) {
+        /* Same priority: lower stream ID wins */
+        if (s->node->id <= stream->node->id) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
 static ngx_inline void
 ngx_http_v2_queue_frame(ngx_http_v2_connection_t *h2c,
     ngx_http_v2_out_frame_t *frame)
 {
+    ngx_http_v2_stream_t      *s, *fs;
     ngx_http_v2_out_frame_t  **out;
+
+    fs = frame->stream;
 
     for (out = &h2c->last_out; *out; out = &(*out)->next) {
 
@@ -270,11 +309,9 @@ ngx_http_v2_queue_frame(ngx_http_v2_connection_t *h2c,
             break;
         }
 
-        if ((*out)->stream->node->rank < frame->stream->node->rank
-            || ((*out)->stream->node->rank == frame->stream->node->rank
-                && (*out)->stream->node->rel_weight
-                   >= frame->stream->node->rel_weight))
-        {
+        s = (*out)->stream;
+
+        if (ngx_http_v2_stream_comes_before(h2c, s, fs)) {
             break;
         }
     }

--- a/src/http/v2/ngx_http_v2_filter_module.c
+++ b/src/http/v2/ngx_http_v2_filter_module.c
@@ -1446,10 +1446,7 @@ ngx_http_v2_waiting_queue(ngx_http_v2_connection_t *h2c,
     {
         s = ngx_queue_data(q, ngx_http_v2_stream_t, queue);
 
-        if (s->node->rank < stream->node->rank
-            || (s->node->rank == stream->node->rank
-                && s->node->rel_weight >= stream->node->rel_weight))
-        {
+        if (ngx_http_v2_stream_comes_before(h2c, s, stream)) {
             break;
         }
     }

--- a/src/http/v3/ngx_http_v3.c
+++ b/src/http/v3/ngx_http_v3.c
@@ -17,9 +17,10 @@ static void ngx_http_v3_cleanup_session(void *data);
 ngx_int_t
 ngx_http_v3_init_session(ngx_connection_t *c)
 {
-    ngx_pool_cleanup_t     *cln;
-    ngx_http_connection_t  *hc;
-    ngx_http_v3_session_t  *h3c;
+    ngx_pool_cleanup_t      *cln;
+    ngx_http_connection_t   *hc;
+    ngx_http_v3_session_t   *h3c;
+    ngx_http_v3_srv_conf_t  *h3scf;
 
     hc = c->data;
 
@@ -31,6 +32,10 @@ ngx_http_v3_init_session(ngx_connection_t *c)
     }
 
     h3c->http_connection = hc;
+
+    h3scf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_v3_module);
+
+    h3c->priority_limit = ngx_max(h3scf->max_concurrent_streams, 100);
 
     ngx_queue_init(&h3c->blocked);
 

--- a/src/http/v3/ngx_http_v3.h
+++ b/src/http/v3/ngx_http_v3.h
@@ -38,6 +38,8 @@
 #define NGX_HTTP_V3_FRAME_PUSH_PROMISE             0x05
 #define NGX_HTTP_V3_FRAME_GOAWAY                   0x07
 #define NGX_HTTP_V3_FRAME_MAX_PUSH_ID              0x0d
+#define NGX_HTTP_V3_FRAME_PRIORITY_UPDATE_REQUEST  0xf0700
+#define NGX_HTTP_V3_FRAME_PRIORITY_UPDATE_PUSH     0xf0701
 
 #define NGX_HTTP_V3_PARAM_MAX_TABLE_CAPACITY       0x01
 #define NGX_HTTP_V3_PARAM_MAX_FIELD_SECTION_SIZE   0x06
@@ -117,7 +119,20 @@ struct ngx_http_v3_parse_s {
     ngx_http_v3_parse_headers_t   headers;
     ngx_http_v3_parse_data_t      body;
     ngx_array_t                  *cookies;
+
+    /* RFC9218 extensible priority for this request stream */
+    ngx_http_priority_state_t     priority;
 };
+
+
+/*
+ * RFC9218: Pending priority update for streams not yet created.
+ * PRIORITY_UPDATE frames may arrive before the HEADERS frame.
+ */
+typedef struct {
+    uint64_t                      id;
+    ngx_http_priority_t           priority;
+} ngx_http_v3_pending_priority_t;
 
 
 struct ngx_http_v3_session_s {
@@ -141,6 +156,18 @@ struct ngx_http_v3_session_s {
     unsigned                      created_streams:NGX_HTTP_V3_MAX_KNOWN_STREAM;
 
     ngx_connection_t             *known_streams[NGX_HTTP_V3_MAX_KNOWN_STREAM];
+
+    /* RFC9218 Extensible Priorities */
+    ngx_array_t                  *pending_priorities;
+
+    /*
+     * Replenished budget for PRIORITY_UPDATE frames, mirroring the HTTP/2
+     * priority_limit: it caps how many updates a peer may send relative to
+     * the number of requests it opens, so a flood of updates (each of which
+     * reprioritizes and re-sorts queued STREAM frames) cannot be used for
+     * CPU exhaustion.
+     */
+    ngx_uint_t                    priority_limit;
 };
 
 
@@ -150,6 +177,9 @@ ngx_int_t ngx_http_v3_init_session(ngx_connection_t *c);
 ngx_int_t ngx_http_v3_check_flood(ngx_connection_t *c);
 ngx_int_t ngx_http_v3_init(ngx_connection_t *c);
 void ngx_http_v3_shutdown(ngx_connection_t *c);
+
+ngx_int_t ngx_http_v3_set_priority(ngx_connection_t *c, uint64_t id,
+    ngx_http_priority_t *value);
 
 ngx_int_t ngx_http_v3_read_request_body(ngx_http_request_t *r);
 ngx_int_t ngx_http_v3_read_unbuffered_request_body(ngx_http_request_t *r);

--- a/src/http/v3/ngx_http_v3_parse.c
+++ b/src/http/v3/ngx_http_v3_parse.c
@@ -46,6 +46,8 @@ static ngx_int_t ngx_http_v3_parse_control(ngx_connection_t *c,
     ngx_http_v3_parse_control_t *st, ngx_buf_t *b);
 static ngx_int_t ngx_http_v3_parse_settings(ngx_connection_t *c,
     ngx_http_v3_parse_settings_t *st, ngx_buf_t *b);
+static ngx_int_t ngx_http_v3_parse_priority_update(ngx_connection_t *c,
+    ngx_http_v3_parse_priority_t *st, ngx_buf_t *b);
 
 static ngx_int_t ngx_http_v3_parse_encoder(ngx_connection_t *c,
     ngx_http_v3_parse_encoder_t *st, ngx_buf_t *b);
@@ -289,7 +291,9 @@ ngx_http_v3_parse_headers(ngx_connection_t *c, ngx_http_v3_parse_headers_t *st,
                 || st->type == NGX_HTTP_V3_FRAME_SETTINGS
                 || st->type == NGX_HTTP_V3_FRAME_MAX_PUSH_ID
                 || st->type == NGX_HTTP_V3_FRAME_CANCEL_PUSH
-                || st->type == NGX_HTTP_V3_FRAME_PUSH_PROMISE)
+                || st->type == NGX_HTTP_V3_FRAME_PUSH_PROMISE
+                || st->type == NGX_HTTP_V3_FRAME_PRIORITY_UPDATE_REQUEST
+                || st->type == NGX_HTTP_V3_FRAME_PRIORITY_UPDATE_PUSH)
             {
                 return NGX_HTTP_V3_ERR_FRAME_UNEXPECTED;
             }
@@ -1177,14 +1181,18 @@ static ngx_int_t
 ngx_http_v3_parse_control(ngx_connection_t *c, ngx_http_v3_parse_control_t *st,
     ngx_buf_t *b)
 {
-    ngx_buf_t  loc;
-    ngx_int_t  rc;
+    ngx_str_t            value;
+    ngx_buf_t            loc;
+    ngx_int_t            rc;
+    ngx_http_priority_t  priority;
     enum {
         sw_start = 0,
         sw_first_type,
         sw_type,
         sw_length,
         sw_settings,
+        sw_priority_update,
+        sw_priority_update_push,
         sw_skip
     };
 
@@ -1252,6 +1260,21 @@ ngx_http_v3_parse_control(ngx_connection_t *c, ngx_http_v3_parse_control_t *st,
                            "http3 parse frame len:%uL", st->vlint.value);
 
             st->length = st->vlint.value;
+
+            /*
+             * RFC 9218: a PRIORITY_UPDATE frame carries a mandatory
+             * Prioritized Element ID and so cannot have an empty payload.
+             * An empty payload is a malformed frame (H3_FRAME_ERROR),
+             * regardless of variant; the id-range check (H3_ID_ERROR) only
+             * applies once an id has actually been decoded.
+             */
+            if ((st->type == NGX_HTTP_V3_FRAME_PRIORITY_UPDATE_REQUEST
+                 || st->type == NGX_HTTP_V3_FRAME_PRIORITY_UPDATE_PUSH)
+                && st->length == 0)
+            {
+                return NGX_HTTP_V3_ERR_FRAME_ERROR;
+            }
+
             if (st->length == 0) {
                 st->state = sw_type;
                 break;
@@ -1261,6 +1284,25 @@ ngx_http_v3_parse_control(ngx_connection_t *c, ngx_http_v3_parse_control_t *st,
 
             case NGX_HTTP_V3_FRAME_SETTINGS:
                 st->state = sw_settings;
+                break;
+
+            case NGX_HTTP_V3_FRAME_PRIORITY_UPDATE_REQUEST:
+                st->priority.state = 0;
+                st->priority.vlint.state = 0;
+                st->priority.value_len = 0;
+                st->priority.value_overflow = 0;
+                st->state = sw_priority_update;
+                break;
+
+            case NGX_HTTP_V3_FRAME_PRIORITY_UPDATE_PUSH:
+                /*
+                 * nginx advertises no push capability, so it never grants a
+                 * push id and any decodable push id is out of range.  Decode
+                 * the id first (a truncated varint is H3_FRAME_ERROR) and
+                 * only then report the out-of-range id as H3_ID_ERROR.
+                 */
+                st->priority.vlint.state = 0;
+                st->state = sw_priority_update_push;
                 break;
 
             default:
@@ -1292,6 +1334,96 @@ ngx_http_v3_parse_control(ngx_connection_t *c, ngx_http_v3_parse_control_t *st,
             }
 
             break;
+
+        case sw_priority_update:
+
+            ngx_http_v3_parse_start_local(b, &loc, st->length);
+
+            rc = ngx_http_v3_parse_priority_update(c, &st->priority, &loc);
+
+            ngx_http_v3_parse_end_local(b, &loc, &st->length);
+
+            if (st->length == 0 && rc == NGX_AGAIN) {
+                /*
+                 * The frame is fully consumed but the parser is still waiting
+                 * for value bytes.  If the element id has been parsed, this is
+                 * a valid Priority Field Value of length zero (an explicit
+                 * reset), so complete it; otherwise the id itself was
+                 * truncated and the frame is malformed.
+                 */
+                if (st->priority.state == 0) {
+                    return NGX_HTTP_V3_ERR_FRAME_ERROR;
+                }
+
+                rc = NGX_DONE;
+            }
+
+            if (rc != NGX_DONE) {
+                return rc;
+            }
+
+            if (st->length == 0) {
+
+                /*
+                 * A value that overflowed the buffer would parse to something
+                 * other than what the peer sent; reject it as excessive load
+                 * rather than silently truncating and misapplying it.
+                 */
+                if (st->priority.value_overflow) {
+                    ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                                  "client sent too long PRIORITY_UPDATE value");
+                    return NGX_HTTP_V3_ERR_EXCESSIVE_LOAD;
+                }
+
+                /*
+                 * Parse the whole Priority Field Value in one pass with the
+                 * shared parser, so commas inside quoted strings, structured
+                 * field parameters, and unknown extension members are all
+                 * handled without dropping the recognized "u"/"i" members.
+                 */
+                value.data = st->priority.value;
+                value.len = st->priority.value_len;
+
+                ngx_http_priority_parse(&value, &priority);
+
+                rc = ngx_http_v3_set_priority(c, st->priority.element_id,
+                                              &priority);
+                if (rc != NGX_OK) {
+                    return rc;
+                }
+
+                st->state = sw_type;
+            }
+
+            break;
+
+        case sw_priority_update_push:
+
+            ngx_http_v3_parse_start_local(b, &loc, st->length);
+
+            rc = ngx_http_v3_parse_varlen_int(c, &st->priority.vlint, &loc);
+
+            ngx_http_v3_parse_end_local(b, &loc, &st->length);
+
+            /*
+             * A truncated Prioritized Element ID (the frame is fully consumed
+             * but the varint is incomplete) is a malformed frame.  Once the
+             * id decodes, it necessarily references a push that was never
+             * promised, which RFC 9218 treats as H3_ID_ERROR.
+             */
+            if (rc == NGX_AGAIN) {
+                if (st->length == 0) {
+                    return NGX_HTTP_V3_ERR_FRAME_ERROR;
+                }
+
+                return NGX_AGAIN;
+            }
+
+            if (rc != NGX_DONE) {
+                return rc;
+            }
+
+            return NGX_HTTP_V3_ERR_ID_ERROR;
 
         case sw_skip:
 
@@ -1362,6 +1494,61 @@ done:
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0, "http3 parse settings done");
 
     st->state = sw_start;
+    return NGX_DONE;
+}
+
+
+static ngx_int_t
+ngx_http_v3_parse_priority_update(ngx_connection_t *c,
+    ngx_http_v3_parse_priority_t *st, ngx_buf_t *b)
+{
+    u_char     ch;
+    ngx_int_t  rc;
+
+    enum {
+        sw_id = 0,
+        sw_value
+    };
+
+    if (st->state == sw_id) {
+        rc = ngx_http_v3_parse_varlen_int(c, &st->vlint, b);
+        if (rc != NGX_DONE) {
+            return rc;
+        }
+
+        st->element_id = st->vlint.value;
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "http3 priority update element id:%uL", st->element_id);
+
+        st->state = sw_value;
+    }
+
+    if (st->state == sw_value) {
+
+        if (b->pos == b->last) {
+            return NGX_AGAIN;
+        }
+
+        /*
+         * Buffer the whole Priority Field Value so it can be handed to the
+         * shared ngx_http_priority_parse() in one pass once the frame ends.
+         * A legitimate value is tiny; anything that does not fit the buffer
+         * is flagged and later rejected as excessive load rather than being
+         * silently truncated (which could change the parsed priority).
+         */
+        while (b->pos < b->last) {
+            ch = *b->pos++;
+
+            if (st->value_len < sizeof(st->value)) {
+                st->value[st->value_len++] = ch;
+
+            } else {
+                st->value_overflow = 1;
+            }
+        }
+    }
+
     return NGX_DONE;
 }
 
@@ -1839,7 +2026,9 @@ ngx_http_v3_parse_data(ngx_connection_t *c, ngx_http_v3_parse_data_t *st,
                 || st->type == NGX_HTTP_V3_FRAME_SETTINGS
                 || st->type == NGX_HTTP_V3_FRAME_MAX_PUSH_ID
                 || st->type == NGX_HTTP_V3_FRAME_CANCEL_PUSH
-                || st->type == NGX_HTTP_V3_FRAME_PUSH_PROMISE)
+                || st->type == NGX_HTTP_V3_FRAME_PUSH_PROMISE
+                || st->type == NGX_HTTP_V3_FRAME_PRIORITY_UPDATE_REQUEST
+                || st->type == NGX_HTTP_V3_FRAME_PRIORITY_UPDATE_PUSH)
             {
                 return NGX_HTTP_V3_ERR_FRAME_UNEXPECTED;
             }

--- a/src/http/v3/ngx_http_v3_parse.h
+++ b/src/http/v3/ngx_http_v3_parse.h
@@ -14,6 +14,15 @@
 #include <ngx_http.h>
 
 
+/*
+ * Maximum buffered length of a PRIORITY_UPDATE Priority Field Value.  The
+ * recognized RFC 9218 members ("u"/"i") need only ~10 bytes; the remainder
+ * is headroom for unknown extension members a peer may legitimately send,
+ * while keeping the per-stream buffer bounded.
+ */
+#define NGX_HTTP_V3_PRIORITY_VALUE_LEN  256
+
+
 typedef struct {
     ngx_uint_t                      state;
     uint64_t                        value;
@@ -32,6 +41,41 @@ typedef struct {
     uint64_t                        id;
     ngx_http_v3_parse_varlen_int_t  vlint;
 } ngx_http_v3_parse_settings_t;
+
+
+typedef struct {
+    ngx_uint_t                      state;
+    uint64_t                        element_id;
+    ngx_http_v3_parse_varlen_int_t  vlint;
+
+    /*
+     * The Priority Field Value is a structured-field dictionary that is
+     * parsed as a whole by the shared ngx_http_priority_parse(), exactly as
+     * the HTTP/2 and upstream code paths do.  Parsing it in one pass (rather
+     * than splitting on ',' ourselves) is what lets commas inside quoted
+     * strings, structured-field parameters (e.g. u=0;ext="..."), and unknown
+     * extension members all be handled correctly without dropping the
+     * recognized "u"/"i" members.  Because the frame may be delivered across
+     * several reads, the value bytes are buffered here until the frame
+     * completes.
+     *
+     * A legitimate priority value is tiny: the only members RFC 9218 defines
+     * are "u" (urgency, "u=0".."u=7") and "i" (incremental, "i" or "i=?1"),
+     * so a fully-populated recognized value is at most "u=7, i=?1" (10 bytes
+     * including optional whitespace).  RFC 9218 does, however, permit unknown
+     * dictionary members, which a peer may legitimately include; the buffer
+     * is therefore sized well beyond the recognized members
+     * (NGX_HTTP_V3_PRIORITY_VALUE_LEN bytes) so that values carrying
+     * reasonable unknown extensions are still accepted, while the amount of
+     * unparsed data held per stream stays bounded.  A value that does not fit
+     * the buffer is treated as excessive load rather than silently truncated
+     * -- silent truncation could turn a well-formed value into a different,
+     * valid-looking one and apply a priority the peer never signalled.
+     */
+    u_char                          value[NGX_HTTP_V3_PRIORITY_VALUE_LEN];
+    ngx_uint_t                      value_len;
+    unsigned                        value_overflow:1;
+} ngx_http_v3_parse_priority_t;
 
 
 typedef struct {
@@ -104,6 +148,7 @@ typedef struct {
     ngx_uint_t                      length;
     ngx_http_v3_parse_varlen_int_t  vlint;
     ngx_http_v3_parse_settings_t    settings;
+    ngx_http_v3_parse_priority_t    priority;
 } ngx_http_v3_parse_control_t;
 
 

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -17,6 +17,8 @@ static void ngx_http_v3_cleanup_request(void *data);
 static void ngx_http_v3_process_request(ngx_event_t *rev);
 static ngx_int_t ngx_http_v3_process_header(ngx_http_request_t *r,
     ngx_str_t *name, ngx_str_t *value);
+static void ngx_http_v3_apply_pending_priority(ngx_connection_t *c,
+    ngx_http_request_t *r);
 static ngx_int_t ngx_http_v3_validate_header(ngx_http_request_t *r,
     ngx_str_t *name, ngx_str_t *value);
 static ngx_int_t ngx_http_v3_process_pseudo_header(ngx_http_request_t *r,
@@ -184,6 +186,7 @@ ngx_http_v3_init_request_stream(ngx_connection_t *c)
     ngx_pool_cleanup_t        *cln;
     ngx_http_connection_t     *hc;
     ngx_http_v3_session_t     *h3c;
+    ngx_http_v3_srv_conf_t    *h3scf;
     ngx_http_core_loc_conf_t  *clcf;
     ngx_http_core_srv_conf_t  *cscf;
 
@@ -242,6 +245,15 @@ ngx_http_v3_init_request_stream(ngx_connection_t *c)
     cln->data = c;
 
     h3c->nrequests++;
+
+    /*
+     * Replenish the PRIORITY_UPDATE budget as each request stream opens, so
+     * a client that legitimately opens many streams may send proportionally
+     * more updates while a peer that opens few streams cannot flood updates
+     * (mirrors the HTTP/2 priority_limit accounting).
+     */
+    h3scf = ngx_http_v3_get_module_srv_conf(c, ngx_http_v3_module);
+    h3c->priority_limit += h3scf->max_concurrent_streams;
 
     if (h3c->keepalive.timer_set) {
         ngx_del_timer(&h3c->keepalive);
@@ -388,7 +400,12 @@ ngx_http_v3_wait_request_handler(ngx_event_t *rev)
     r->v3_parse->header_limit = cscf->large_client_header_buffers.size
                                 * cscf->large_client_header_buffers.num;
 
+    ngx_http_priority_state_init(&r->v3_parse->priority);
+
+    ngx_http_v3_apply_pending_priority(c, r);
+
     c->data = r;
+    ngx_quic_set_stream_app_ready(c);
     c->requests = (c->quic->id >> 2) + 1;
 
     cln = ngx_pool_cleanup_add(r->pool, 0);
@@ -654,6 +671,34 @@ ngx_http_v3_process_header(ngx_http_request_t *r, ngx_str_t *name,
 
     if (ngx_http_v3_init_pseudo_headers(r) != NGX_OK) {
         return NGX_ERROR;
+    }
+
+    if (name->len == 8
+        && ngx_strncmp(name->data, "priority", 8) == 0)
+    {
+        ngx_http_priority_t  tmp;
+
+        ngx_http_priority_parse(value, &tmp);
+
+        /*
+         * Only apply if the value is empty (explicit reset) or at least one
+         * parameter was recognized.  This prevents a malformed value from
+         * clobbering a priority previously set via PRIORITY_UPDATE.
+         */
+        if (value->len == 0 || tmp.valid) {
+            r->v3_parse->priority.client = tmp;
+            ngx_http_priority_state_update(&r->v3_parse->priority);
+
+            ngx_quic_set_stream_priority(
+                                    r->connection,
+                                    r->v3_parse->priority.effective.urgency,
+                                    r->v3_parse->priority.effective.incremental);
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "http3 priority header: u=%ui, i=%ui",
+                           r->v3_parse->priority.effective.urgency,
+                           r->v3_parse->priority.effective.incremental);
+        }
     }
 
     if (name->len == cookie.len
@@ -1273,6 +1318,243 @@ ngx_http_v3_construct_cookie_header(ngx_http_request_t *r)
     }
 
     return NGX_OK;
+}
+
+
+static ngx_inline ngx_uint_t
+ngx_http_v3_request_ready(ngx_connection_t *sc)
+{
+    /*
+     * True once ngx_http_v3_init_request_stream() has attached the
+     * ngx_http_request_t to the stream connection (c->data = r) and
+     * allocated r->v3_parse.  Before that, sc->data points at the
+     * ngx_http_connection_t and must not be dereferenced as a request.
+     */
+    return ngx_quic_stream_app_ready(sc) && sc->data != NULL;
+}
+
+
+ngx_int_t
+ngx_http_v3_set_priority(ngx_connection_t *c, uint64_t id,
+    ngx_http_priority_t *value)
+{
+    ngx_uint_t                      i;
+    ngx_connection_t               *pc, *sc;
+    ngx_http_request_t             *r;
+    ngx_http_priority_t             priority;
+    ngx_http_v3_session_t          *h3c;
+    ngx_http_v3_srv_conf_t         *h3scf;
+    ngx_http_v3_pending_priority_t *pp;
+
+    h3c = ngx_http_v3_get_session(c);
+
+    /*
+     * Charge the frame against the replenished PRIORITY_UPDATE budget before
+     * doing any per-frame work.  Exhausting it means the peer sent far more
+     * updates than the streams it opened justifies, which is treated as a
+     * connection-level excessive-load error (the HTTP/3 analogue of the
+     * HTTP/2 priority_limit / ENHANCE_YOUR_CALM handling).
+     */
+    if (h3c->priority_limit == 0) {
+        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                      "client sent too many PRIORITY_UPDATE frames");
+        return NGX_HTTP_V3_ERR_EXCESSIVE_LOAD;
+    }
+
+    h3c->priority_limit--;
+
+    /*
+     * The Prioritized Element ID must identify a client-initiated
+     * bidirectional (request) stream.  A server-initiated or unidirectional
+     * id is a validly encoded but invalid identifier, which RFC 9218
+     * requires to be treated as a connection error of type H3_ID_ERROR
+     * (not H3_FRAME_ERROR, which is for malformed frame payloads).
+     */
+    if (id & NGX_QUIC_STREAM_SERVER_INITIATED) {
+        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                      "client sent PRIORITY_UPDATE for "
+                      "server-initiated stream %uL", id);
+        return NGX_HTTP_V3_ERR_ID_ERROR;
+    }
+
+    if (id & NGX_QUIC_STREAM_UNIDIRECTIONAL) {
+        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                      "client sent PRIORITY_UPDATE for "
+                      "unidirectional stream %uL", id);
+        return NGX_HTTP_V3_ERR_ID_ERROR;
+    }
+
+    pc = c->quic->parent;
+
+    /*
+     * The id must also be within the range the client is currently permitted
+     * to open: an id at or above the advertised MAX_STREAMS limit identifies
+     * a stream that cannot yet exist.  RFC 9218 requires such an id to be
+     * rejected as H3_ID_ERROR rather than buffered, so it cannot occupy the
+     * pending-priority table.
+     */
+    if (!ngx_quic_client_bidi_stream_id_allowed(pc, id)) {
+        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                      "client sent PRIORITY_UPDATE for stream %uL "
+                      "beyond the current stream limit", id);
+        return NGX_HTTP_V3_ERR_ID_ERROR;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http3 PRIORITY_UPDATE for stream %uL", id);
+
+    /*
+     * A PRIORITY_UPDATE frame communicates a complete set of priority
+     * parameters (RFC 9218 Section 7): an omitted parameter is a signal to
+     * use its default, and an empty value is an explicit reset to the
+     * defaults.  ngx_http_priority_parse() has already seeded *value with
+     * those defaults, so it is applied as-is -- a value whose only members
+     * are unknown extensions still resets the recognized parameters to their
+     * defaults rather than retaining a stale prior signal.  (An over-long
+     * value has already been rejected as excessive load by the frame parser,
+     * bounding what reaches here.)
+     */
+    priority = *value;
+
+    /*
+     * If the target request stream already exists and its request has been
+     * fully initialized, apply the priority to it immediately.  This also
+     * covers re-prioritization of an in-flight response.
+     *
+     * A QUIC stream connection may exist before its ngx_http_request_t is
+     * created: until ngx_http_v3_init_request_stream() assigns c->data = r
+     * (and allocates r->v3_parse), sc->data still points at the
+     * ngx_http_connection_t, so it must not be treated as a request.
+     * ngx_http_v3_request_ready() performs that check safely; when the
+     * stream exists but is not yet a request, fall through and buffer the
+     * update so ngx_http_v3_apply_pending_priority() applies it at init.
+     */
+    sc = ngx_quic_find_stream_connection(pc, id);
+
+    if (sc != NULL && ngx_http_v3_request_ready(sc)) {
+        r = sc->data;
+
+        r->v3_parse->priority.client = priority;
+        ngx_http_priority_state_update(&r->v3_parse->priority);
+
+        ngx_quic_set_stream_priority(
+                                    sc,
+                                    r->v3_parse->priority.effective.urgency,
+                                    r->v3_parse->priority.effective.incremental);
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "http3 PRIORITY_UPDATE applied to stream "
+                       "%uL: u=%ui", id,
+                       r->v3_parse->priority.effective.urgency);
+
+        return NGX_OK;
+    }
+
+    /*
+     * Request stream ids are opened by the client in increasing order.
+     * next_request_id tracks the id of the most recently initialized
+     * request stream plus one.  An id below it that is not an existing,
+     * not-yet-initialized stream belongs to a stream that has already been
+     * created (and by now closed); there is nothing left to buffer for it.
+     */
+    if (sc == NULL && id < h3c->next_request_id) {
+        return NGX_OK;
+    }
+
+    /* buffer priority for a stream not yet created or not yet initialized */
+
+    h3scf = ngx_http_v3_get_module_srv_conf(c, ngx_http_v3_module);
+
+    if (h3c->pending_priorities == NULL) {
+        h3c->pending_priorities = ngx_array_create(pc->pool, 4,
+                                      sizeof(ngx_http_v3_pending_priority_t));
+        if (h3c->pending_priorities == NULL) {
+            return NGX_ERROR;
+        }
+    }
+
+    pp = h3c->pending_priorities->elts;
+
+    for (i = 0; i < h3c->pending_priorities->nelts; i++) {
+        if (pp[i].id == id) {
+            pp[i].priority = priority;
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                           "http3 PRIORITY_UPDATE updated pending for "
+                           "stream %uL: u=%ui", id, priority.urgency);
+            return NGX_OK;
+        }
+    }
+
+    if (h3c->pending_priorities->nelts >= h3scf->max_concurrent_streams) {
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "http3 PRIORITY_UPDATE ignored, pending limit "
+                       "reached for stream %uL", id);
+        return NGX_OK;
+    }
+
+    pp = ngx_array_push(h3c->pending_priorities);
+    if (pp == NULL) {
+        return NGX_ERROR;
+    }
+
+    pp->id = id;
+    pp->priority = priority;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                   "http3 PRIORITY_UPDATE buffered for stream "
+                   "%uL: u=%ui", id, priority.urgency);
+
+    return NGX_OK;
+}
+
+
+static void
+ngx_http_v3_apply_pending_priority(ngx_connection_t *c, ngx_http_request_t *r)
+{
+    uint64_t                         id;
+    ngx_uint_t                       i, n;
+    ngx_http_v3_session_t           *h3c;
+    ngx_http_v3_pending_priority_t  *pp;
+
+    h3c = ngx_http_v3_get_session(c);
+
+    if (h3c->pending_priorities == NULL) {
+        return;
+    }
+
+    id = c->quic->id;
+
+    pp = h3c->pending_priorities->elts;
+    n = h3c->pending_priorities->nelts;
+
+    for (i = 0; i < n; i++) {
+        if (pp[i].id != id) {
+            continue;
+        }
+
+        r->v3_parse->priority.client = pp[i].priority;
+        ngx_http_priority_state_update(&r->v3_parse->priority);
+
+        ngx_quic_set_stream_priority(
+                                    c,
+                                    r->v3_parse->priority.effective.urgency,
+                                    r->v3_parse->priority.effective.incremental);
+
+        ngx_log_debug3(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                       "http3 applied pending priority for stream "
+                       "%uL: u=%ui, i=%ui",
+                       id, r->v3_parse->priority.effective.urgency,
+                       r->v3_parse->priority.effective.incremental);
+
+        n--;
+        if (i < n) {
+            pp[i] = pp[n];
+        }
+        h3c->pending_priorities->nelts = n;
+
+        break;
+    }
 }
 
 


### PR DESCRIPTION

```
First, the same elephant in the room as the HTTP/2 series. This patchset
was produced with AI. Specifically Claude Opus 4.8 via F5AI.

As well as calling it out here, each commit has a tag of

  Assisted-by: F5AI:claude-opus-4.8

as inspired by the Linux Kernel.
<https://docs.kernel.org/process/coding-assistants.html#attribution>

I believe this is important for several reasons, including outright
rejection due to use of AI and for future archaeology.

While the code was mostly written by AI, it was done so with a certain
amount of prodding and guidance from myself. It has been through several
rounds of copilot review as can be viewed here
<https://github.com/ac000/nginx/pull/3>


NOTE: It is my intention that the HTTP/2 implementation will be reviewed
first and I will update this PR as and when the other is updated to
address review feedback.


Overview
--------

This series extends nginx's RFC 9218 support to HTTP/3, adding priority
signaling over QUIC and, crucially, a QUIC-layer scheduler that acts on
the negotiated priorities when sending response data.

As a recap, RFC 9218 replaces the complex tree-based priority scheme
from RFC 7540 with a simpler system using two parameters:

  - urgency (u): Integer 0-7, lower values are more urgent (default: 3)
  - incremental (i): Boolean indicating progressive rendering (default:
    false)

Over HTTP/3 clients signal priority via the "Priority" request header or
PRIORITY_UPDATE frames (0xF0700 / 0xF0701) on the control stream, using
RFC 8941 Structured Fields syntax:

  Priority: u=1
  Priority: u=3, i
  Priority: u=5, i=?0


Relationship to the HTTP/2 prioritisation work
-----------------------------------------------

This builds on the HTTP/2 RFC 9218 support (PR #1520) and reuses the
shared, protocol-agnostic priority helpers (ngx_http_priority_*). The
client-facing signalling is equivalent: the Priority request header and
PRIORITY_UPDATE frames are parsed, stored, and merged with any upstream
Priority response header (RFC 9218 Section 8).

Unlike the HTTP/2 implementation, this patch also acts on the priority
when scheduling response bytes. QUIC exposes an explicit connection-level
send step (gated by the shared MAX_DATA window) with server-owned
per-stream send buffers, which gives a natural single point at which to
order output. The new ngx_quic_flush_streams_by_priority() therefore:

  - serves send-active bidirectional request streams in ascending urgency
    order (unidirectional control/QPACK streams are flushed up front and
    are never subject to prioritisation);

  - for a non-incremental urgency group, drains one stream before
    offering the window to the next, approximating the sequential
    completion recommended by RFC 9218 Section 7;

  - for an incremental urgency group, round-robins a fair-share quantum
    across the group so equally-urgent streams advance together.

This goes further than the HTTP/2 series -- whose cover letter notes it
provides urgency-based ordering via queue placement but not strict
sequential or incremental delivery -- because it is achievable cleanly in
the QUIC layer. HTTP/2 multiplexes over a single ordered TCP byte stream,
where reordering is both harder to express in nginx's event-driven output
path and ultimately limited by TCP head-of-line blocking: a single lost
segment stalls every multiplexed stream regardless of urgency. HTTP/3's
independent streams remove that constraint, so the prioritisation scheme
delivers its full intended benefit here.

The priority is pushed down to the transport through a small,
HTTP-agnostic QUIC API (ngx_quic_set_stream_priority(),
ngx_quic_find_stream_connection()); the QUIC layer stores only bare
urgency/incremental values and has no dependency on HTTP types.


The series is structured for bisectability:

  1. QUIC: add per-stream priority and urgency-ordered STREAM frame
     queuing
  2. QUIC: schedule response data by RFC 9218 priority
  3. HTTP/3: implement RFC 9218 priority signaling
  4. HTTP/3: merge upstream Priority response header for proxied requests

Commits 1-2 are pure QUIC-layer changes with no HTTP dependency: commit 1
adds the per-stream priority primitives and orders STREAM frames within
the output queue; commit 2 adds the connection-level scheduler that acts
on them. Commits 3-4 are the HTTP/3 layer: commit 3 parses the client's
signals (Priority header + PRIORITY_UPDATE, including buffering an update
that arrives before its stream) and pushes them to QUIC; commit 4 extends
the shared upstream Priority merge to HTTP/3.


Relationship to the HTTP/2 commits
----------------------------------

The HTTP/3 commits build directly on the HTTP/2 RFC 9218 commits earlier
in this PR (the series that is also under separate review as PR #1520);
they do not stand alone. The coupling is deliberately confined to one
shared, protocol-agnostic interface -- the ngx_http_priority_* API
introduced earlier in src/http/ngx_http_priority.{c,h}. HTTP/3 reuses it
verbatim rather than reimplementing header parsing or the upstream merge:

  - ngx_http_priority_t                (stored on the v3 parse context)
  - ngx_http_priority_init()
  - ngx_int_t ngx_http_priority_parse(ngx_str_t *value,
                                      ngx_http_priority_t *p)
  - void      ngx_http_priority_merge(ngx_http_priority_t *result,
                                      ngx_http_priority_t *client,
                                      ngx_http_priority_t *server)
  - u_char   *ngx_http_priority_format(u_char *buf,
                                       ngx_http_priority_t *p)

The only file the HTTP/3 commits share with the HTTP/2 commits is
src/http/ngx_http_upstream.c: the HTTP/2 commits add
ngx_http_upstream_process_priority(); the HTTP/3 commits extend that same
function to source the client priority from either the HTTP/2 stream or
the HTTP/3 parse context and, for HTTP/3, to push the merged result down
to QUIC. Every other file the HTTP/3 commits touch is new to HTTP/3
(src/event/quic/*, src/http/v3/*).

Reviewers reshaping the ngx_http_priority_* API in the HTTP/2 commits
(struct layout, signatures, or the header's location) should note that it
will require a matching, mechanical update to the HTTP/3 call sites, even
though it produces no textual merge conflict.


Layering
--------

The dependency direction is one-way (HTTP/3 -> QUIC):

  - QUIC (src/event/quic/): priority is stored on ngx_quic_stream_t as
    bare primitives (ngx_uint_t urgency + an incremental bit), never as
    HTTP types. The scheduler, the stream comparator, and the on-the-wire
    STREAM-frame ordering operate purely on stream id / urgency /
    send-state / offsets. A STREAM frame carries a copy of the priority so
    queue ordering never dereferences the owning stream.

  - HTTP/3 (src/http/v3/): talks to QUIC only through the two new public
    functions above, plus the pre-existing convention of reading
    c->quic->id / c->quic->parent. No HTTP-layer code touches QUIC stream
    internals.


Testing
-------

nginx-tests: A new h3_rfc9218.t test file has been created at
<https://github.com/nginx/nginx-tests/pull/105> that exercises Priority
header parsing (u=1; u=3,i; u=5,i=?0; malformed -> defaults),
PRIORITY_UPDATE for an existing stream, PRIORITY_UPDATE buffered before
HEADERS, PRIORITY_UPDATE for a push id (rejected with H3_ID_ERROR, as
nginx grants no push ids), an empty PRIORITY_UPDATE payload
(H3_FRAME_ERROR), upstream Priority passthrough, and a partial upstream
merge that preserves the client's incremental flag.  The existing
h2_rfc9218.t and the full H2/H3 suites continue to pass.

Manual, end-to-end behaviour was verified with a small ngtcp2 + nghttp3
QUIC client that issues several concurrent prioritized requests and reports
per-stream progress milestones, confirming strict urgency ordering for
non-incremental streams and lockstep interleaving for incremental streams
of equal urgency.

  Example nginx configuration:

    http {
        server {
            listen 8443 quic reuseport;
            listen 8443 ssl;
            http2 on;
            ...

            # Advertise HTTP/3 availability to HTTP/1.1 and HTTP/2 clients
            add_header Alt-Svc 'h3=":8443"; ma=86400';

            # Server-side priority hints (RFC 9218 Section 8) for
            # intermediaries
            location /critical.css {
                add_header Priority "u=0";
                ...
            }
        }
    }

  Priorities only take effect when the connection is actually
  send-constrained: with a large window every stream's data is flushed
  in full on each pass, so there is no scarce budget for the scheduler to
  allocate and streams simply run in parallel.  Unlike HTTP/2 -- where
  creating that contention on loopback requires shaping the link with
  tc(1) so the kernel socket buffer backs data up inside nginx -- HTTP/3
  exposes the constraint directly in-protocol: the client's
  initial_max_data (the connection-level flow-control window) bounds how
  much unacknowledged data the server may have outstanding across the
  whole connection, and that limit is exactly what
  ngx_quic_flush_streams_by_priority() arbitrates.  Shrinking the window
  therefore forces several streams to compete for one budget
  deterministically, with no root, no kernel qdisc, and no reliance on
  link timing.

  The demo repository below ships a small ngtcp2/nghttp3 client (j3ster)
  whose -w option sets that window.  Two 50MB downloads on one
  connection, u=7 (low) vs u=1 (high), with a small window so the streams
  contend:

    $ j3ster -w 65536 \
        -r "u=7:/big.bin" \
        -r "u=1:/big.bin" \
        127.0.0.1 8443

  The high-priority (u=1) stream completes well before the low-priority
  (u=7) one, even though it was requested second; equally-urgent
  incremental streams instead advance in lockstep.  Re-running with a
  large window (e.g. -w 67108864, larger than a single response) removes
  the contention and the two streams finish together -- a useful control
  confirming the ordering comes from window arbitration rather than
  anything incidental.

  curl(1) built against ngtcp2/nghttp3 speaks HTTP/3 and can set the
  Priority header, but issues one request per connection, so it does not
  reproduce the multi-stream contention that exercises the scheduler:

    $ curl --http3-only -H 'Priority: u=1' https://localhost:8443/large.bin

  The tc(1) approach used for the HTTP/2 series also works here (it
  simulates genuine network congestion rather than a conservative
  client), but is no longer necessary and needs root:

    # Limit loopback to 50mbit/s
    $ sudo tc qdisc add dev lo root handle 1: htb default 12
    $ sudo tc class add dev lo parent 1: classid 1:12 htb rate 50mbit

    # Remove the limit afterwards
    $ sudo tc qdisc del dev lo root

  A self-contained demo (config, test resources, the j3ster client, and a
  browser demo) covering both HTTP/2 and HTTP/3 is available at:

    <https://github.com/ac000/nginx-rfc9218-demo>


Known limitations
-----------------

The incremental fair-share quantum is a heuristic (an equal share of the
currently-available connection window, capped at 16 KB per round). It
keeps equally-urgent incremental streams advancing together without
fragmenting output into excessively small frames, but it is not a formal
bandwidth guarantee.


References
----------

  - RFC 9218: <https://www.rfc-editor.org/rfc/rfc9218>
  - RFC 8941: <https://www.rfc-editor.org/rfc/rfc8941> (Structured Fields)
  - HTTP/2 series: <https://github.com/nginx/nginx/pull/1520>
  - Review PR:     <https://github.com/ac000/nginx/pull/3>
  - Demo:          <https://github.com/ac000/nginx-rfc9218-demo>

 src/event/quic/ngx_event_quic.h            |  30 ++
 src/event/quic/ngx_event_quic_ack.c        |  13 +-
 src/event/quic/ngx_event_quic_connection.h |  15 +
 src/event/quic/ngx_event_quic_frames.c     | 160 ++++++++-
 src/event/quic/ngx_event_quic_frames.h     |   2 +
 src/event/quic/ngx_event_quic_streams.c    | 548 ++++++++++++++++++++++++++++-
 src/event/quic/ngx_event_quic_transport.h  |   8 +
 src/http/ngx_http_upstream.c               |  86 +++--
 src/http/v3/ngx_http_v3.c                  |  11 +-
 src/http/v3/ngx_http_v3.h                  |  30 ++
 src/http/v3/ngx_http_v3_parse.c            | 197 ++++++++++-
 src/http/v3/ngx_http_v3_parse.h            |  45 +++
 src/http/v3/ngx_http_v3_request.c          | 282 +++++++++++++++
 13 files changed, 1369 insertions(+), 58 deletions(-)

--
```