### PR TITLE
Core: avoided unaligned reads in the MD5 implementation

### DIFF
--- a/src/core/ngx_md5.c
+++ b/src/core/ngx_md5.c
@@ -137,15 +137,14 @@ ngx_md5_final(u_char result[16], ngx_md5_t *ctx)
  * SET() reads 4 input bytes in little-endian byte order and stores them
  * in a properly aligned word in host byte order.
  *
- * The check for little-endian architectures that tolerate unaligned
- * memory accesses is just an optimization.  Nothing will break if it
- * does not work.
+ * The check for little-endian architectures is just an optimization.
+ * Nothing will break if it does not work.
  */
 
-#if (NGX_HAVE_LITTLE_ENDIAN && NGX_HAVE_NONALIGNED)
+#if (NGX_HAVE_LITTLE_ENDIAN)
 
-#define SET(n)      (*(uint32_t *) &p[n * 4])
-#define GET(n)      (*(uint32_t *) &p[n * 4])
+#define SET(n)      (ngx_memcpy(&block[n], &p[n * 4], 4), block[n])
+#define GET(n)      block[n]
 
 #else
 
@@ -172,9 +171,7 @@ ngx_md5_body(ngx_md5_t *ctx, const u_char *data, size_t size)
     uint32_t       a, b, c, d;
     uint32_t       saved_a, saved_b, saved_c, saved_d;
     const u_char  *p;
-#if !(NGX_HAVE_LITTLE_ENDIAN && NGX_HAVE_NONALIGNED)
     uint32_t       block[16];
-#endif
 
     p = data;
 


### PR DESCRIPTION
As asked in #1632.

`SET()` and `GET()` in `src/core/ngx_md5.c` load a `uint32_t` through a
pointer aimed at an arbitrary offset of the input. Nothing computes a wrong
digest, but it is undefined behaviour, and UndefinedBehaviorSanitizer stops
on it. Reading through `memcpy()` says the same thing without the
assumption, so the alignment half of the `#if` is no longer needed; the byte
order half stays.

### The optimization is kept

The comment this patch edits says the condition "is just an optimization".
That is what made it worth checking rather than assuming: compilers fold a
four byte `memcpy()` into a single load.

Comparing `-S` output for `ngx_md5.c` before and after, with
`NGX_HAVE_NONALIGNED` forced on. At `-O`, which is what `auto/cc/gcc` and
`auto/cc/clang` set:

| target | before | after | |
| --- | --- | --- | --- |
| x86_64 | 817 instructions | 817 | identical |
| arm64 | 797 instructions | 797 | identical |

At `-O2` the same holds, 817 and 791.

### Checked

Against master at 8d96667 (this branch is rebased on it; `ngx_md5.c` has not
been touched since the issue was filed).

- the seven RFC 1321 test vectors, and a 100 byte input taken from each of
  the four alignments in turn: **all eleven digests are identical before and
  after**, and the RFC ones match the published values
- UBSan with `-fno-sanitize-recover=undefined`: reports
  `load of misaligned address ... for type 'uint32_t'` on master, silent
  with this patch
- `nginx-tests`, the files that reach MD5 through the cache key and the
  upstream hash: `proxy_cache`, `proxy_cache_path`, `proxy_cache_variables`,
  `proxy_cache_vary`, `proxy_cache_valid`, `proxy_cache_revalidate`,
  `proxy_cache_range`, `upstream_hash` — 154 assertions, all pass

### How it is reached

`ngx_md5_body()` needs a whole block from an unaligned address, so short
inputs never show it — they go through `ctx->buffer`, which is aligned.
`ngx_http_upstream_init_round_robin_sid()` hashes the name of every upstream
server while the configuration is read, so a `server unix:` path longer than
64 bytes gets there. That is how it turned up, in the CI of a third-party
module built with `-fno-sanitize-recover=undefined`.

### Not included

`src/http/ngx_http_parse.c`, `src/http/v2/ngx_http_v2.h` and
`src/event/quic/ngx_event_quic_transport.c` have the same construct. They
are left out to keep this to one thing; glad to follow up if this approach
is the one you want.

