### PR TITLE
Core: avoided passing NULL to memcpy in ngx_pstrdup().

### DIFF
--- a/src/core/ngx_string.c
+++ b/src/core/ngx_string.c
@@ -81,7 +81,9 @@ ngx_pstrdup(ngx_pool_t *pool, ngx_str_t *src)
         return NULL;
     }
 
-    ngx_memcpy(dst, src->data, src->len);
+    if (src->len) {
+        ngx_memcpy(dst, src->data, src->len);
+    }
 
     return dst;
 }


### PR DESCRIPTION
Hello!

While fuzzing nginx with UBSan enabled, I encountered the following report:
```bash
src/core/ngx_string.c:84:5: runtime error:
null pointer passed as argument 2, which is declared to never be null /usr/include/string.h:44:28:
note: nonnull attribute specified here SUMMARY:UndefinedBehaviorSanitizer:
undefined-behavior src/core/ngx_string.c:84:5
```

`memcpy` can not recive null: 
```cpp
/* Copy N bytes of SRC to DEST.*/
extern void *memcpy (void *_restrict __dest, const void *_restrict __src, size_t __n) __THROW __nonnull ((1, 2)); 
```

For an empty string, src->data may be NULL. Passing it to memcpy() violates its nonnull contract even when the requested length is zero.

The issue currently requires fuzzing nginx with
`-fno-sanitize=nonnull-attribute`. OSS-Fuzz does not currently enable UBSan for nginx.

This change skips memcpy() when src->len is zero.