### PR TITLE
Event pipe: do not free buffers still used by the downstream

### DIFF
--- a/src/event/ngx_event_pipe.c
+++ b/src/event/ngx_event_pipe.c
@@ -253,6 +253,7 @@ ngx_event_pipe_read_upstream(ngx_event_pipe_t *p)
                 chain->next = NULL;
 
             } else if (!p->cacheable
+                       && !p->downstream_error
                        && p->downstream->data == p->output_ctx
                        && p->downstream->write->ready
                        && !p->downstream->write->delayed)
@@ -1111,11 +1112,7 @@ ngx_event_pipe_drain_chains(ngx_event_pipe_t *p)
     ngx_chain_t  *cl, *tl;
 
     for ( ;; ) {
-        if (p->busy) {
-            cl = p->busy;
-            p->busy = NULL;
-
-        } else if (p->out) {
+        if (p->out) {
             cl = p->out;
             p->out = NULL;
 


### PR DESCRIPTION
## Problem

When `proxy_buffering` is enabled, the response body is placed into proxying buffers and passed along the filter chain. Notably, when using HTTP/2, no data copying occurs and instead, the `ngx_http_v2_send_chain()` function encapsulates these buffers into DATA frames and places them into the `h2c->last_out` queue.

The pipe tracks buffer ownership via the `p->busy` field, a buffer moves from `p->busy` to the free buffer list only after `ngx_chain_update_chains()` confirms its complete consumption,  i.e. once the downstream has really sent it.

The `ngx_event_pipe_drain_chains()` ignores that. If a downstream error occurs (for example, because the body filter returns `NGX_ERROR`), it iterates through the `p->busy`, `p->out`, and `p->in` lists and returns every raw buffer to `p->free_raw_bufs`, clearing `buf->shadow` on the way.. Consequently, buffers that are still referenced by output filters are marked as free.

If the upstream EOF is then discovered on the same `ngx_event_pipe()` pass, `ngx_event_pipe_read_upstream()` releases everything on that list:

```c
if (p->free_bufs && p->buf_to_file == NULL) {
    for (cl = p->free_raw_bufs; cl; cl = cl->next) {
        if (cl->buf->shadow == NULL) {
            ngx_pfree(p->pool, cl->buf->start);
        }
    }
}
```

It is worth noting that in the HTTP/1.1 protocol, this goes invisible and `ngx_http_output_filter()` sets `c->error` for the connection to which the response is actually being written, so `ngx_http_write_filter()` refuses to write anything else and the request is finalized right away.

In the case of HTTP/2, the `r->connection` field represents a fake connection, so a filter error sets only `fc->error`. The `ngx_http_v2_send_output_queue()` function checks `h2c->connection->error` (which remains zero), and upon the next write event, `ngx_http_v2_write_handler()` proceeds to send (flush) the DATA frames accumulated in the queue, reading data from buffers that have already been freed. The `ngx_http_v2_filter_cleanup()` function, which should have removed these frames from the queue, is never called because `ngx_http_v2_close_stream()` refuses to free the request as long as `stream->queued != 0`.

This results in a use-after-free bug: freed heap contents get encrypted and sent to the client, and the read can just as well hit an unmapped page causing worker process to crash.

## Solution

In the `ngx_event_pipe_drain_chains()`, the `p->busy` chain should be left unchanged. These are the specific buffers still under the control of the downstream connection, so they must not be returned to `p->free_raw_bufs` and the other chains are drained as before, and the buffers are freed along with the request pool.

This also resolves the issue of buffer reuse, in addition to the use-after-free problem. Because the busy buffers are no longer recycled, the pipe cannot overwrite request body data awaiting transmission to the client, thereby eliminating the risk of data corruption.

Because the pipe no longer receives these buffers back, the `ngx_event_pipe_read_upstream()` function must not assume that a downstream connection experiencing an error is merely temporarily blocked and will soon unblock. Otherwise, it might continue setting the `p->upstream_blocked` flag and passing control to `ngx_event_pipe_write_to_downstream()`, a function responsible solely for draining queues. Checking the pipe's own flag, the same one relied upon by `write_to_downstream()`, provides an explicit loop exit condition.

## Testing

To repro, needs, all at once:

- `proxy_buffering on`, `proxy_max_temp_file_size 0`;
- a response body filter that returns `NGX_ERROR` during response transmission (`body_filter_by_lua` with
`return ngx.ERROR` or a few lines of C code);
- an HTTP/2 client that stops reading, causing DATA frames to accumulate in `h2c->last_out`. 
- a response from the upstream without a `Content-Length` and without chunked encoding. 
- a FIN packet from the upstream is already in nginx's receive buffer when the proxy buffers overflow.

**Closes:** #1468
