### PR TITLE
Mp4: fix possible integer overflow in ngx_http_mp4_crop_stts_data()

### DIFF
--- a/src/http/modules/ngx_http_mp4_module.c
+++ b/src/http/modules/ngx_http_mp4_module.c
@@ -2469,7 +2469,7 @@ found:
         start_sample -= key_prefix;
 
         while (rest < key_prefix) {
-            trak->prefix += rest * duration;
+            trak->prefix += (uint64_t) rest * duration;
             key_prefix -= rest;
 
             entry--;
@@ -2480,7 +2480,7 @@ found:
             rest = count;
         }
 
-        trak->prefix += key_prefix * duration;
+        trak->prefix += (uint64_t) key_prefix * duration;
         trak->duration += trak->prefix;
         rest -= key_prefix;
 


### PR DESCRIPTION
```
Mp4: fix possible integer overflow in ngx_http_mp4_crop_stts_data()

Variables "rest", "key_prefix" and "duration" are all 32-bit, so their
products might potentially overflow. They are added into 64-bit
trak->prefix, which becomes the media_time value written into the output
elst atom, and with very large values this can result in incorrect
seeking.

Reported-by: TimofeyGritsun
Closes: https://github.com/nginx/nginx/issues/621
```