### PR TITLE
Avoided unaligned reads and writes outside the MD5 code

### DIFF
--- a/src/event/quic/ngx_event_quic_transport.c
+++ b/src/event/quic/ngx_event_quic_transport.c
@@ -19,33 +19,37 @@
 #define NGX_QUIC_STREAM_FRAME_OFF      0x04
 
 
-#if (NGX_HAVE_NONALIGNED)
+static ngx_inline uint32_t
+ngx_quic_parse_uint32(const u_char *p)
+{
+    uint32_t  v;
 
-#define ngx_quic_parse_uint16(p)  ntohs(*(uint16_t *) (p))
-#define ngx_quic_parse_uint32(p)  ntohl(*(uint32_t *) (p))
+    ngx_memcpy(&v, p, sizeof(uint32_t));
 
-#define ngx_quic_write_uint16  ngx_quic_write_uint16_aligned
-#define ngx_quic_write_uint32  ngx_quic_write_uint32_aligned
+    return ntohl(v);
+}
 
-#else
 
-#define ngx_quic_parse_uint16(p)  ((p)[0] << 8 | (p)[1])
-#define ngx_quic_parse_uint32(p)                                              \
-    ((uint32_t) (p)[0] << 24 | (p)[1] << 16 | (p)[2] << 8 | (p)[3])
+static ngx_inline u_char *
+ngx_quic_write_uint16(u_char *p, ngx_uint_t s)
+{
+    uint16_t  v = htons((uint16_t) s);
 
-#define ngx_quic_write_uint16(p, s)                                           \
-    ((p)[0] = (u_char) ((s) >> 8),                                            \
-     (p)[1] = (u_char)  (s),                                                  \
-     (p) + sizeof(uint16_t))
+    ngx_memcpy(p, &v, sizeof(uint16_t));
 
-#define ngx_quic_write_uint32(p, s)                                           \
-    ((p)[0] = (u_char) ((s) >> 24),                                           \
-     (p)[1] = (u_char) ((s) >> 16),                                           \
-     (p)[2] = (u_char) ((s) >> 8),                                            \
-     (p)[3] = (u_char)  (s),                                                  \
-     (p) + sizeof(uint32_t))
+    return p + sizeof(uint16_t);
+}
 
-#endif
+
+static ngx_inline u_char *
+ngx_quic_write_uint32(u_char *p, ngx_uint_t s)
+{
+    uint32_t  v = htonl((uint32_t) s);
+
+    ngx_memcpy(p, &v, sizeof(uint32_t));
+
+    return p + sizeof(uint32_t);
+}
 
 #define ngx_quic_write_uint64(p, s)                                           \
     ((p)[0] = (u_char) ((s) >> 56),                                           \

--- a/src/http/ngx_http_huff_encode.c
+++ b/src/http/ngx_http_huff_encode.c
@@ -156,36 +156,44 @@ static ngx_http_huff_encode_code_t  ngx_http_huff_encode_table_lc[256] =
 };
 
 
+static ngx_inline void
+ngx_http_huff_encode_buf(u_char *dst, ngx_uint_t buf)
+{
 #if (NGX_PTR_SIZE == 8)
 
-#if (NGX_HAVE_LITTLE_ENDIAN)
+#if (NGX_HAVE_LITTLE_ENDIAN && NGX_HAVE_GCC_BSWAP64)
 
-#if (NGX_HAVE_GCC_BSWAP64)
-#define ngx_http_huff_encode_buf(dst, buf)                                    \
-    (*(uint64_t *) (dst) = __builtin_bswap64(buf))
+    uint64_t  v = __builtin_bswap64(buf);
+
+    ngx_memcpy(dst, &v, sizeof(uint64_t));
+
+#elif (NGX_HAVE_LITTLE_ENDIAN)
+
+    dst[0] = (u_char) (buf >> 56);
+    dst[1] = (u_char) (buf >> 48);
+    dst[2] = (u_char) (buf >> 40);
+    dst[3] = (u_char) (buf >> 32);
+    dst[4] = (u_char) (buf >> 24);
+    dst[5] = (u_char) (buf >> 16);
+    dst[6] = (u_char) (buf >> 8);
+    dst[7] = (u_char)  buf;
+
 #else
-#define ngx_http_huff_encode_buf(dst, buf)                                    \
-    ((dst)[0] = (u_char) ((buf) >> 56),                                       \
-     (dst)[1] = (u_char) ((buf) >> 48),                                       \
-     (dst)[2] = (u_char) ((buf) >> 40),                                       \
-     (dst)[3] = (u_char) ((buf) >> 32),                                       \
-     (dst)[4] = (u_char) ((buf) >> 24),                                       \
-     (dst)[5] = (u_char) ((buf) >> 16),                                       \
-     (dst)[6] = (u_char) ((buf) >> 8),                                        \
-     (dst)[7] = (u_char)  (buf))
-#endif
 
-#else /* !NGX_HAVE_LITTLE_ENDIAN */
-#define ngx_http_huff_encode_buf(dst, buf)                                    \
-    (*(uint64_t *) (dst) = (buf))
+    uint64_t  v = buf;
+
+    ngx_memcpy(dst, &v, sizeof(uint64_t));
+
 #endif
 
 #else /* NGX_PTR_SIZE == 4 */
 
-#define ngx_http_huff_encode_buf(dst, buf)                                    \
-    (*(uint32_t *) (dst) = htonl(buf))
+    uint32_t  v = htonl((uint32_t) buf);
+
+    ngx_memcpy(dst, &v, sizeof(uint32_t));
 
 #endif
+}
 
 
 size_t

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -37,39 +37,51 @@ static uint32_t  usual[] = {
 };
 
 
-#if (NGX_HAVE_LITTLE_ENDIAN && NGX_HAVE_NONALIGNED)
+#if (NGX_HAVE_LITTLE_ENDIAN)
+
+static ngx_inline uint32_t
+ngx_str_uint32(const u_char *m)
+{
+    uint32_t  v;
+
+    ngx_memcpy(&v, m, sizeof(uint32_t));
+
+    return v;
+}
+
 
 #define ngx_str3_cmp(m, c0, c1, c2, c3)                                       \
-    *(uint32_t *) m == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)
+    ngx_str_uint32(m) == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)
 
 #define ngx_str3Ocmp(m, c0, c1, c2, c3)                                       \
-    *(uint32_t *) m == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)
+    ngx_str_uint32(m) == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)
 
 #define ngx_str4cmp(m, c0, c1, c2, c3)                                        \
-    *(uint32_t *) m == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)
+    ngx_str_uint32(m) == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)
 
 #define ngx_str5cmp(m, c0, c1, c2, c3, c4)                                    \
-    *(uint32_t *) m == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)             \
+    ngx_str_uint32(m) == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)           \
         && m[4] == c4
 
 #define ngx_str6cmp(m, c0, c1, c2, c3, c4, c5)                                \
-    *(uint32_t *) m == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)             \
-        && (((uint32_t *) m)[1] & 0xffff) == ((c5 << 8) | c4)
+    ngx_str_uint32(m) == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)           \
+        && (ngx_str_uint32(m + 4) & 0xffff) == ((c5 << 8) | c4)
 
 #define ngx_str7_cmp(m, c0, c1, c2, c3, c4, c5, c6, c7)                       \
-    *(uint32_t *) m == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)             \
-        && ((uint32_t *) m)[1] == ((c7 << 24) | (c6 << 16) | (c5 << 8) | c4)
+    ngx_str_uint32(m) == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)           \
+        && ngx_str_uint32(m + 4) == ((c7 << 24) | (c6 << 16) | (c5 << 8) | c4)
 
 #define ngx_str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7)                        \
-    *(uint32_t *) m == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)             \
-        && ((uint32_t *) m)[1] == ((c7 << 24) | (c6 << 16) | (c5 << 8) | c4)
+    ngx_str_uint32(m) == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)           \
+        && ngx_str_uint32(m + 4) == ((c7 << 24) | (c6 << 16) | (c5 << 8) | c4)
 
 #define ngx_str9cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8)                    \
-    *(uint32_t *) m == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)             \
-        && ((uint32_t *) m)[1] == ((c7 << 24) | (c6 << 16) | (c5 << 8) | c4)  \
+    ngx_str_uint32(m) == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)           \
+        && ngx_str_uint32(m + 4)                                              \
+               == ((c7 << 24) | (c6 << 16) | (c5 << 8) | c4)                  \
         && m[8] == c8
 
-#else /* !(NGX_HAVE_LITTLE_ENDIAN && NGX_HAVE_NONALIGNED) */
+#else /* !NGX_HAVE_LITTLE_ENDIAN */
 
 #define ngx_str3_cmp(m, c0, c1, c2, c3)                                       \
     m[0] == c0 && m[1] == c1 && m[2] == c2

--- a/src/http/v2/ngx_http_v2.h
+++ b/src/http/v2/ngx_http_v2.h
@@ -317,18 +317,26 @@ ngx_int_t ngx_http_v2_table_size(ngx_http_v2_connection_t *h2c, size_t size);
 #define ngx_http_v2_prefix(bits)  ((1 << (bits)) - 1)
 
 
-#if (NGX_HAVE_NONALIGNED)
+static ngx_inline uint16_t
+ngx_http_v2_parse_uint16(const u_char *p)
+{
+    uint16_t  v;
 
-#define ngx_http_v2_parse_uint16(p)  ntohs(*(uint16_t *) (p))
-#define ngx_http_v2_parse_uint32(p)  ntohl(*(uint32_t *) (p))
+    ngx_memcpy(&v, p, sizeof(uint16_t));
 
-#else
+    return ntohs(v);
+}
 
-#define ngx_http_v2_parse_uint16(p)  ((p)[0] << 8 | (p)[1])
-#define ngx_http_v2_parse_uint32(p)                                           \
-    ((uint32_t) (p)[0] << 24 | (p)[1] << 16 | (p)[2] << 8 | (p)[3])
 
-#endif
+static ngx_inline uint32_t
+ngx_http_v2_parse_uint32(const u_char *p)
+{
+    uint32_t  v;
+
+    ngx_memcpy(&v, p, sizeof(uint32_t));
+
+    return ntohl(v);
+}
 
 #define ngx_http_v2_parse_length(p)  ((p) >> 8)
 #define ngx_http_v2_parse_type(p)    ((p) & 0xff)
@@ -341,26 +349,26 @@ ngx_int_t ngx_http_v2_table_size(ngx_http_v2_connection_t *h2c, size_t size);
 #define ngx_http_v2_write_uint32_aligned(p, s)                                \
     (*(uint32_t *) (p) = htonl((uint32_t) (s)), (p) + sizeof(uint32_t))
 
-#if (NGX_HAVE_NONALIGNED)
+static ngx_inline u_char *
+ngx_http_v2_write_uint16(u_char *p, ngx_uint_t s)
+{
+    uint16_t  v = htons((uint16_t) s);
 
-#define ngx_http_v2_write_uint16  ngx_http_v2_write_uint16_aligned
-#define ngx_http_v2_write_uint32  ngx_http_v2_write_uint32_aligned
+    ngx_memcpy(p, &v, sizeof(uint16_t));
 
-#else
+    return p + sizeof(uint16_t);
+}
 
-#define ngx_http_v2_write_uint16(p, s)                                        \
-    ((p)[0] = (u_char) ((s) >> 8),                                            \
-     (p)[1] = (u_char)  (s),                                                  \
-     (p) + sizeof(uint16_t))
 
-#define ngx_http_v2_write_uint32(p, s)                                        \
-    ((p)[0] = (u_char) ((s) >> 24),                                           \
-     (p)[1] = (u_char) ((s) >> 16),                                           \
-     (p)[2] = (u_char) ((s) >> 8),                                            \
-     (p)[3] = (u_char)  (s),                                                  \
-     (p) + sizeof(uint32_t))
+static ngx_inline u_char *
+ngx_http_v2_write_uint32(u_char *p, ngx_uint_t s)
+{
+    uint32_t  v = htonl((uint32_t) s);
 
-#endif
+    ngx_memcpy(p, &v, sizeof(uint32_t));
+
+    return p + sizeof(uint32_t);
+}
 
 #define ngx_http_v2_write_len_and_type(p, l, t)                               \
     ngx_http_v2_write_uint32_aligned(p, (l) << 8 | (t))


### PR DESCRIPTION
Follows #1660, which does the same thing to `ngx_md5.c`. Four more places
read or write a wider type through a pointer aimed at an arbitrary offset,
which is undefined behaviour, and each of them goes through `memcpy()`
instead. Four commits, one per file.

| commit | | reports removed |
| --- | --- | --- |
| `HTTP:` | `ngx_http_parse.c`, the `ngx_strNcmp()` method comparisons | 9 |
| `HTTP/2:` | `ngx_http_v2.h`, the frame field helpers | 821 |
| `QUIC:` | `ngx_event_quic_transport.c`, the packet field helpers | 81 |
| `HTTP/2:` | `ngx_http_huff_encode.c`, the encoder output store | 25 |

`ngx_http_huff_encode.c` does not test `NGX_HAVE_NONALIGNED` at all, so it
is not found by looking for that macro. UndefinedBehaviorSanitizer named it.

This is a standards-compliance cleanup rather than a fix for anything that
misbehaves. No value changes, and I could not produce a case where the
generated code goes wrong — see "the optimization is kept" below.

### UBSan, over the whole of nginx-tests

Built with `-DNGX_HAVE_NONALIGNED=1` forced on, since `auto/os/conf` sets it
only for i386 and amd64 and the host here is arm64. 493 files, ~4600
assertions.

| | reports | sites |
| --- | --- | --- |
| before | 1205 | 93 |
| after | 269 | 64 |

**Everything still reported afterwards is `src/core/ngx_md5.c`**, which
#1660 covers and this branch does not touch. For the four files here it is
936 to 0.

The pipeline detects: reverting only `ngx_http_huff_encode.c` brings its two
reports back.

### Behaviour

The whole of nginx-tests, 493 files, gives the same verdict for every file
before and after — 276 ok, 206 skipped, 22 otherwise, the last being SSL
files that fail the same way on both because of the OpenSSL on this host.

Run them serially. With `prove -j4` nine SSL certificate files come and go
between runs on either build.

### The optimization is kept

Compiled with `-S` and `NGX_HAVE_NONALIGNED` forced on, comparing the
instruction stream with directives and comments removed. **At `-O`, which is
what `auto/cc/gcc` and `auto/cc/clang` set** — not `-O2`:

| | x86_64 | arm64 | |
| --- | --- | --- | --- |
| `ngx_event_quic_transport.c` | 4371 → 4371 | 3916 → 3916 | identical |
| `ngx_http_huff_encode.c` | 95 → 95 | 72 → 72 | identical |
| `ngx_http_parse.c` | 2082 → **2079** | 2063 → **2060** | 3 shorter |
| `ngx_http_v2.c` (through the header) | 7401 → **7276** | 7210 → **7110** | shorter |

Nothing gets longer. At `-O2` the picture is the same: quic and huffman
identical (4498 and 231 on x86_64), parse unchanged in count with some
branches reordered, v2 118 instructions shorter.

Where `NGX_HAVE_NONALIGNED` is *not* set, the QUIC file at `-O` is 21
instructions shorter on x86_64 and 28 on arm64: the byte by byte assembly it
used to fall back to is four loads and three shifts where `memcpy()` plus
`ntohl()` is one load and a swap. Nothing is left to call — the functions
inline.

### Two things worth flagging

`ngx_quic_parse_uint16()` is **removed** rather than converted. Nothing calls
it; an unused macro costs nothing, an unused static function does not build
with `-Werror`.

The QUIC write macros evaluated their first argument three times and the
functions evaluate it once. No caller passes an expression with a side
effect today, so nothing moves.

### Not included

The `_aligned` variants are untouched. Their name is a contract with the
caller and `ngx_http_v2_write_len_and_type()` relies on it. No report comes
from that path in the run above, but whether the contract holds everywhere
is not something I checked.
