### PR TITLE
Core: Use explicit loop termination in `ngx_rtbtree_next`

### DIFF
--- a/src/core/ngx_rbtree.c
+++ b/src/core/ngx_rbtree.c
@@ -388,12 +388,8 @@ ngx_rbtree_next(ngx_rbtree_t *tree, ngx_rbtree_node_t *node)
 
     root = tree->root;
 
-    for ( ;; ) {
+    while (node != root) {
         parent = node->parent;
-
-        if (node == root) {
-            return NULL;
-        }
 
         if (node == parent->left) {
             return parent;
@@ -401,4 +397,5 @@ ngx_rbtree_next(ngx_rbtree_t *tree, ngx_rbtree_node_t *node)
 
         node = parent;
     }
+    return NULL;
 }


### PR DESCRIPTION
Refactored `ngx_rbtree_next` to use a `while (node != root)` loop instead of an infinite `for` loop with an internal `if (node == root)` check. This refactoring makes the exit condition explicit and potentially reduces branching overhead within the loop body, while maintaining identical logic.
