### PR TITLE
Core: avoid calling memcpy() with NULL in ngx_sprintf_str()

### DIFF
--- a/src/core/ngx_string.c
+++ b/src/core/ngx_string.c
@@ -574,6 +574,10 @@ ngx_sprintf_str(u_char *buf, u_char *last, u_char *src, size_t len,
     static u_char   hex[] = "0123456789abcdef";
     static u_char   HEX[] = "0123456789ABCDEF";
 
+    if (len == 0) {
+        return buf;
+    }
+
     if (hexadecimal == 0) {
 
         if (len == (size_t) -1) {


### PR DESCRIPTION
## Problem

`%V` on an empty `ngx_str_t` (`{ 0, NULL }`) passes NULL into `ngx_sprintf_str()`'s `ngx_cpymem()`, which glibc's `nonnull` attribute traps under `-fsanitize=undefined`; with `-fno-sanitize-recover=undefined` the worker dies at the first such line.

Two paths reach it. The debug path formats `r->args`/`r->exten` on any query-less URI, so a `--with-debug` UBSan build dies on the first request and the nginx-tests harness (which logs at debug level unconditionally) cannot run. The **non-debug** path, found by @ac000 (comment below), is `ngx_http_log_error_handler()`: it formats `u->uri` for every upstream error logged at ERR level, and only the proxy module ever assigns `u->uri`, so a fastcgi, uwsgi, scgi or grpc upstream failure (a reset connection, say) passes `{ 0, NULL }` on a production build at the default `error_log` level. Full analysis, reproducer, and traces in #1671 and in the comment thread.

## Solution

Skip the copy when the clamped length is zero. `ngx_cpymem()` with zero length already returns `buf` unchanged, so the guard is exactly behaviour-preserving. The hexadecimal branches are unaffected (their loops never dereference `src` at length zero), and `%s`'s length-`-1` path requires a NUL-terminated string by contract. The guard is unconditional: the non-debug path above is why it cannot sit under `NGX_DEBUG`, and its cost was measured in the thread at within 0.12 ns of a ~4.2 ns call on non-empty inputs.

## Testing

- Manual: the reproducer from #1671 --- unpatched, the first request kills the worker with the UBSan report; patched, requests are served indefinitely with no reports. @ac000's non-debug reproduction (fastcgi upstream, RST after one byte, `error_log ... info`) is in the thread.
- Functional: full nginx-tests suite against a plain `--with-debug` build of the patched tree: 493 files, 2519 tests, PASS (no behaviour change). Against the patched `--with-debug` UBSan build the suite then runs to completion; the remaining failures are unrelated UB instances detailed in #1671, reported separately.
- A dedicated regression test isn't practical in nginx-tests: the change is behaviour-identical and only observable under a sanitizer build.


- [X] Manual Testing
- [X] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

Closes #1671

## Checklist

Before submitting this PR, please confirm:

- [X] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [X] I have added tests (if applicable) to validate my changes
- [X] All existing tests pass
- [X] I have updated documentation where necessary
- [X] My branch is rebased on the latest master
- [X] This PR targets the master branch from my fork
- [X] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

Builds instrumented with UndefinedBehaviorSanitizer no longer abort when an empty string is formatted into a log line, including the upstream error lines of the fastcgi, uwsgi, scgi and grpc modules. No change for regular builds.
