### PR TITLE
Fix heap-buffer-overflow in fastcgi/scgi/uwsgi request creation

### DIFF
--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -1978,7 +1978,11 @@ ngx_http_script_var_code(ngx_http_script_engine_t *e)
 
     e->ip += sizeof(ngx_http_script_var_code_t);
 
-    value = ngx_http_get_flushed_variable(e->request, code->index);
+    if (e->flushed) {
+        value = ngx_http_get_indexed_variable(e->request, code->index);
+    } else {
+        value = ngx_http_get_flushed_variable(e->request, code->index);
+    }
 
     if (value && !value->not_found) {
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, e->request->connection->log, 0,


### PR DESCRIPTION
Fixes #1194

When fastcgi_param (or scgi_param/uwsgi_param) references NGX_HTTP_VAR_NOCACHEABLE variables (e.g. $tcpinfo_rtt), the length pass and fill pass can observe different values for the same variable. The length pass uses ngx_http_get_indexed_variable (cached), but ngx_http_script_var_code() in the fill pass always used ngx_http_get_flushed_variable(), which re-evaluates NOCACHEABLE variables. If the re-evaluated value is longer than the cached length used to size the buffer, the fill pass writes past the buffer boundary (heap-buffer-overflow).

Fix: ngx_http_script_var_code() now checks e->flushed and uses ngx_http_get_indexed_variable() when the engine is in flushed mode, consistent with ngx_http_script_copy_var_code().

This is a production crash affecting nginx with $tcpinfo_* variables in fastcgi_param.