### PR TITLE
Upstream: clamp the least_time decay shift

### DIFF
--- a/src/http/modules/ngx_http_upstream_least_time_module.c
+++ b/src/http/modules/ngx_http_upstream_least_time_module.c
@@ -411,7 +411,7 @@ static ngx_uint_t
 ngx_http_upstream_least_time_eta(ngx_http_upstream_lt_peer_data_t *ltp,
     ngx_http_upstream_rr_peer_t *peer)
 {
-    time_t      now;
+    time_t      now, shift;
     ngx_msec_t  rt;
 
     switch (ltp->conf->mode) {
@@ -429,9 +429,17 @@ ngx_http_upstream_least_time_eta(ngx_http_upstream_lt_peer_data_t *ltp,
     if (now - peer->checked > peer->fail_timeout) {
         /*
          * once in fail_timeout make response time of a peer 2 times
-         * lower to give chances to slow peers
+         * lower to give chances to slow peers; shifting by the type
+         * width or more is undefined, so long-idle peers saturate to 0
          */
-        rt >>= (now - peer->checked) / (peer->fail_timeout + 1);
+        shift = (now - peer->checked) / (peer->fail_timeout + 1);
+
+        if (shift < (time_t) (8 * sizeof(ngx_msec_t))) {
+            rt >>= shift;
+
+        } else {
+            rt = 0;
+        }
     }
 
     if (peer->inflight_reqs > 0) {

--- a/src/stream/ngx_stream_upstream_least_time_module.c
+++ b/src/stream/ngx_stream_upstream_least_time_module.c
@@ -397,7 +397,7 @@ static ngx_uint_t
 ngx_stream_upstream_least_time_eta(ngx_stream_upstream_lt_peer_data_t *ltp,
     ngx_stream_upstream_rr_peer_t *peer)
 {
-    time_t      now;
+    time_t      now, shift;
     ngx_msec_t  rt;
 
     switch (ltp->conf->mode) {
@@ -419,9 +419,17 @@ ngx_stream_upstream_least_time_eta(ngx_stream_upstream_lt_peer_data_t *ltp,
     if (now - peer->checked > peer->fail_timeout) {
         /*
          * once in fail_timeout make response time of a peer 2 times
-         * lower to give chances to slow peers
+         * lower to give chances to slow peers; shifting by the type
+         * width or more is undefined, so long-idle peers saturate to 0
          */
-        rt >>= (now - peer->checked) / (peer->fail_timeout + 1);
+        shift = (now - peer->checked) / (peer->fail_timeout + 1);
+
+        if (shift < (time_t) (8 * sizeof(ngx_msec_t))) {
+            rt >>= shift;
+
+        } else {
+            rt = 0;
+        }
     }
 
     if (peer->inflight_reqs > 0) {


### PR DESCRIPTION
## Problem

The least_time decay shift is unclamped: for a peer with `checked == 0` or one idle long enough, the shift amount reaches or exceeds the width of `ngx_msec_t`. That is undefined behaviour, and on x86 the count is masked mod 64 — so a long-idle peer gets an arbitrary intermediate ETA instead of the comment's intended decay toward zero, and the balancer misranks it. This shows on regular (non-sanitised) builds; under UBSan it is also a fatal per-request trap. Analysis and trace in #1675.

## Solution

Compute the shift once and saturate to zero when it reaches the type width, matching the existing comment's intent. Site-local, no behaviour change for shifts below the width.

The stream `least_time` balancer (`src/stream/ngx_stream_upstream_least_time_module.c`) carries the same shift; the same hunk is applied there, in this one commit (as pointed out in #1719).

## Testing

- Functional, on a `--with-stream` UBSan build (`-fno-sanitize-recover=undefined`, no `--with-debug`): `nginx-tests/upstream_least_time.t` fails 5/14 before and passes 14/14 after; `nginx-tests/stream_upstream_least_time.t` fails 5/15 before and passes 15/15 after. Both modules build under `-W -Wall -Werror`.
- Manual: verified the trap (shift exponent 1787288950) reproduces before and is gone after.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

Closes #1675

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

least_time balancing (http and stream) now decays long-idle peers' response times toward zero as documented, instead of computing an undefined (and on x86, arbitrary) value.

