### PR TITLE
Resolver: avoid signed overflow assembling values from DNS responses

### DIFF
--- a/src/core/ngx_resolver.c
+++ b/src/core/ngx_resolver.c
@@ -2194,7 +2194,7 @@ ngx_resolver_process_a(ngx_resolver_t *r, u_char *buf, size_t n,
         type = (an->type_hi << 8) + an->type_lo;
         class = (an->class_hi << 8) + an->class_lo;
         len = (an->len_hi << 8) + an->len_lo;
-        ttl = (an->ttl[0] << 24) + (an->ttl[1] << 16)
+        ttl = ((uint32_t) an->ttl[0] << 24) + (an->ttl[1] << 16)
             + (an->ttl[2] << 8) + (an->ttl[3]);
 
         if (class != 1) {
@@ -2356,7 +2356,7 @@ ngx_resolver_process_a(ngx_resolver_t *r, u_char *buf, size_t n,
 
             if (type == NGX_RESOLVE_A) {
 
-                addr[j] = htonl((buf[i] << 24) + (buf[i + 1] << 16)
+                addr[j] = htonl(((uint32_t) buf[i] << 24) + (buf[i + 1] << 16)
                                 + (buf[i + 2] << 8) + (buf[i + 3]));
 
                 if (++j == naddrs) {
@@ -2736,7 +2736,7 @@ ngx_resolver_process_srv(ngx_resolver_t *r, u_char *buf, size_t n,
         type = (an->type_hi << 8) + an->type_lo;
         class = (an->class_hi << 8) + an->class_lo;
         len = (an->len_hi << 8) + an->len_lo;
-        ttl = (an->ttl[0] << 24) + (an->ttl[1] << 16)
+        ttl = ((uint32_t) an->ttl[0] << 24) + (an->ttl[1] << 16)
             + (an->ttl[2] << 8) + (an->ttl[3]);
 
         if (class != 1) {
@@ -3301,7 +3301,7 @@ valid:
         type = (an->type_hi << 8) + an->type_lo;
         class = (an->class_hi << 8) + an->class_lo;
         len = (an->len_hi << 8) + an->len_lo;
-        ttl = (an->ttl[0] << 24) + (an->ttl[1] << 16)
+        ttl = ((uint32_t) an->ttl[0] << 24) + (an->ttl[1] << 16)
             + (an->ttl[2] << 8) + (an->ttl[3]);
 
         if (class != 1) {


### PR DESCRIPTION
## Problem

A-record address and TTL bytes are `u_char`, promoted to (signed) `int` in the shift expressions; for any first octet >= 128 the `<< 24` overflows `int` — undefined behaviour on bytes arriving in a DNS response (well-formed TTLs keep the top bit clear per RFC 2181, but a hostile response need not). Analysis and trace in #1676.

Two consequences:

- UBSan's shift check makes every such resolution a fatal trap in `-fno-sanitize-recover` builds.
- The `ttl < 0` guard after each TTL assembly is reachable only through the overflow, so a compiler doing value-range propagation may conclude `ttl >= 0` and delete it. Without the guard, a top-bit TTL flows through `ngx_min(rn->ttl, (uint32_t) ttl)` into `rn->valid = ngx_time() + (time_t) rn->ttl` — an entry cached for roughly 68 years. (Analysis from #1702, closed as a duplicate of this PR.)

On current gcc and clang the wrapped value produces the intended bit pattern and the guard fires, so observable behaviour is unchanged today.

## Solution

Widen the first term explicitly (`(uint32_t)`) at all four assembly sites in the file — the address at the reported line and the three identical TTL assemblies. This follows the existing idiom of casting only the leading `<< 24` term (`ngx_inet.c`, `ngx_stream_geo_module.c`, `ngx_stream_access_module.c`); the `<< 16` and `<< 8` shifts of a `u_char` cannot overflow `int`.

## Testing

- Functional: `nginx-tests/tunnel_next_upstream.t` under an UBSan build fails 3/10 before, passes 10/10 with this fix.
- Manual: verified the trap (`left shift of 240 by 24 places`) reproduces before and is gone after.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

Closes #1676

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

No user-visible change for regular builds.
