### PR TITLE
Proxy: avoid calling memcpy() with NULL for a URI-less proxy_pass

### DIFF
--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -1153,7 +1153,7 @@ ngx_http_proxy_create_key(ngx_http_request_t *r)
 
     key->data = p;
 
-    if (r->valid_location) {
+    if (r->valid_location && ctx->vars.uri.len) {
         p = ngx_copy(p, ctx->vars.uri.data, ctx->vars.uri.len);
     }
 
@@ -1394,7 +1394,7 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
         b->last = ngx_copy(b->last, r->unparsed_uri.data, r->unparsed_uri.len);
 
     } else {
-        if (r->valid_location) {
+        if (r->valid_location && ctx->vars.uri.len) {
             b->last = ngx_copy(b->last, ctx->vars.uri.data, ctx->vars.uri.len);
         }
 


### PR DESCRIPTION
## Problem

With `proxy_pass http://backend;` — no URI part — `ctx->vars.uri` is `{ 0, NULL }`, so **two** assembly sites pass NULL to `memcpy()` through `ngx_copy()`: `ngx_http_proxy_create_request()` building the upstream request, and `ngx_http_proxy_create_key()` building the cache key (the identical `if (r->valid_location)` copy pattern; the latter surfaces with `proxy_cache`). glibc declares `memcpy()`'s pointers nonnull, so UBSan's nonnull-attribute check (the #1671 mechanism, at sites `ngx_sprintf_str()`/#1672 does not cover) makes each proxied request a fatal trap in `-fno-sanitize-recover` builds. Analysis and trace in #1677.

## Solution

Guard both copies on `uri.len`, exactly as the `proxy_lengths` branch in `create_request` already does.

## Testing

- Functional: under an UBSan build, `nginx-tests/subrequest_output_buffer_size.t` fails 2/6 before and passes 6/6 after (create_request site), and `nginx-tests/proxy_cache_lock_ssi.t` fails before and passes after (create_key site).
- Manual: any `location { proxy_pass http://host; }` plus one request reproduces before; gone after.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

Closes #1677

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

No user-visible change for regular builds.

