### PR TITLE
Upstream: avoid calling memcpy() with NULL for a path-less sticky cookie

### DIFF
--- a/src/http/modules/ngx_http_upstream_sticky_module.c
+++ b/src/http/modules/ngx_http_upstream_sticky_module.c
@@ -681,7 +681,9 @@ ngx_http_upstream_sticky_cookie_insert(ngx_peer_connection_t *pc,
         p = ngx_copy(p, samesite.data, samesite.len);
     }
 
-    p = ngx_cpymem(p, stcf->cookie_path.data, stcf->cookie_path.len);
+    if (stcf->cookie_path.len) {
+        p = ngx_cpymem(p, stcf->cookie_path.data, stcf->cookie_path.len);
+    }
 
     cookie = stp->cookie;
 


### PR DESCRIPTION
## Problem

With `sticky cookie` configured without a `path=` attribute, `cookie_path` is `{ 0, NULL }`, so assembling every Set-Cookie header passes NULL to `memcpy()` through `ngx_cpymem()` — the #1671 mechanism at a site #1672 does not cover; UBSan makes each such response a fatal trap in `-fno-sanitize-recover` builds. Analysis and trace in #1678.

## Solution

Guard on `cookie_path.len`, as the function's `domain` and `samesite` attributes already are — this was the one unguarded copy in the assembly.

## Testing

- Functional: `nginx-tests/upstream_sticky_next.t` under an UBSan build fails 3/5 before, passes 5/5 with this fix.
- Manual: an upstream with `sticky cookie sid;` behind a proxied location reproduces before; gone after.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

Closes #1678

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

No user-visible change for regular builds.
