### PR TITLE
QUIC: directives for UDP payload size and initial max data

### DIFF
--- a/src/event/quic/ngx_event_quic.h
+++ b/src/event/quic/ngx_event_quic.h
@@ -90,6 +90,8 @@ typedef struct {
     ngx_uint_t                     max_concurrent_streams_bidi;
     ngx_uint_t                     max_concurrent_streams_uni;
     ngx_uint_t                     active_connection_id_limit;
+    size_t                         max_udp_payload_size;
+    size_t                         initial_max_data;
     size_t                         max_egress_udp_payload_size;
     ngx_int_t                      stream_close_code;
     ngx_int_t                      stream_reject_code_uni;

--- a/src/event/quic/ngx_event_quic.h
+++ b/src/event/quic/ngx_event_quic.h
@@ -90,6 +90,7 @@ typedef struct {
     ngx_uint_t                     max_concurrent_streams_bidi;
     ngx_uint_t                     max_concurrent_streams_uni;
     ngx_uint_t                     active_connection_id_limit;
+    size_t                         max_egress_udp_payload_size;
     ngx_int_t                      stream_close_code;
     ngx_int_t                      stream_reject_code_uni;
     ngx_int_t                      stream_reject_code_bidi;

--- a/src/event/quic/ngx_event_quic_migration.c
+++ b/src/event/quic/ngx_event_quic_migration.c
@@ -618,6 +618,7 @@ ngx_quic_send_path_challenge(ngx_connection_t *c, ngx_quic_path_t *path)
 void
 ngx_quic_discover_path_mtu(ngx_connection_t *c, ngx_quic_path_t *path)
 {
+    size_t                  max;
     ngx_quic_connection_t  *qc;
 
     qc = ngx_quic_get_connection(c);
@@ -634,9 +635,12 @@ ngx_quic_discover_path_mtu(ngx_connection_t *c, ngx_quic_path_t *path)
     } else {
         path->mtud = path->mtu * 2;
 
-        if (path->mtud >= qc->ctp.max_udp_payload_size) {
-            path->mtud = qc->ctp.max_udp_payload_size;
-            path->max_mtu = qc->ctp.max_udp_payload_size;
+        max = ngx_min(qc->ctp.max_udp_payload_size,
+                      qc->conf->max_egress_udp_payload_size);
+
+        if (path->mtud >= max) {
+            path->mtud = max;
+            path->max_mtu = max;
         }
     }
 

--- a/src/event/quic/ngx_event_quic_transport.c
+++ b/src/event/quic/ngx_event_quic_transport.c
@@ -2003,12 +2003,17 @@ ngx_quic_init_transport_params(ngx_quic_tp_t *tp, ngx_quic_conf_t *qcf)
 
     tp->max_idle_timeout = qcf->idle_timeout;
 
-    tp->max_udp_payload_size = NGX_QUIC_MAX_UDP_PAYLOAD_SIZE;
+    tp->max_udp_payload_size = qcf->max_udp_payload_size;
 
     nstreams = qcf->max_concurrent_streams_bidi
                + qcf->max_concurrent_streams_uni;
 
     tp->initial_max_data = nstreams * qcf->stream_buffer_size;
+
+    if (qcf->initial_max_data) {
+        tp->initial_max_data = ngx_min(tp->initial_max_data,
+                                       qcf->initial_max_data);
+    }
     tp->initial_max_stream_data_bidi_local = qcf->stream_buffer_size;
     tp->initial_max_stream_data_bidi_remote = qcf->stream_buffer_size;
     tp->initial_max_stream_data_uni = qcf->stream_buffer_size;

--- a/src/http/v3/ngx_http_v3_module.c
+++ b/src/http/v3/ngx_http_v3_module.c
@@ -78,6 +78,13 @@ static ngx_command_t  ngx_http_v3_commands[] = {
       offsetof(ngx_http_v3_srv_conf_t, quic.active_connection_id_limit),
       NULL },
 
+    { ngx_string("quic_max_egress_udp_payload_size"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_v3_srv_conf_t, quic.max_egress_udp_payload_size),
+      NULL },
+
       ngx_null_command
 };
 
@@ -209,6 +216,7 @@ ngx_http_v3_create_srv_conf(ngx_conf_t *cf)
     h3scf->quic.stream_close_code = NGX_HTTP_V3_ERR_NO_ERROR;
     h3scf->quic.stream_reject_code_bidi = NGX_HTTP_V3_ERR_REQUEST_REJECTED;
     h3scf->quic.active_connection_id_limit = NGX_CONF_UNSET_UINT;
+    h3scf->quic.max_egress_udp_payload_size = NGX_CONF_UNSET_SIZE;
 
     h3scf->quic.init = ngx_http_v3_init;
     h3scf->quic.shutdown = ngx_http_v3_shutdown;
@@ -249,6 +257,22 @@ ngx_http_v3_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_uint_value(conf->quic.active_connection_id_limit,
                               prev->quic.active_connection_id_limit,
                               2);
+
+    ngx_conf_merge_size_value(conf->quic.max_egress_udp_payload_size,
+                              prev->quic.max_egress_udp_payload_size,
+                              NGX_QUIC_MAX_UDP_PAYLOAD_SIZE);
+
+    if (conf->quic.max_egress_udp_payload_size < NGX_QUIC_MIN_INITIAL_SIZE
+        || conf->quic.max_egress_udp_payload_size
+           > NGX_QUIC_MAX_UDP_PAYLOAD_SIZE)
+    {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "\"quic_max_egress_udp_payload_size\" must be "
+                           "between %d and %d",
+                           NGX_QUIC_MIN_INITIAL_SIZE,
+                           NGX_QUIC_MAX_UDP_PAYLOAD_SIZE);
+        return NGX_CONF_ERROR;
+    }
 
     if (conf->quic.host_key.len == 0) {
 

--- a/src/http/v3/ngx_http_v3_module.c
+++ b/src/http/v3/ngx_http_v3_module.c
@@ -78,6 +78,20 @@ static ngx_command_t  ngx_http_v3_commands[] = {
       offsetof(ngx_http_v3_srv_conf_t, quic.active_connection_id_limit),
       NULL },
 
+    { ngx_string("quic_max_udp_payload_size"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_v3_srv_conf_t, quic.max_udp_payload_size),
+      NULL },
+
+    { ngx_string("quic_initial_max_data"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_v3_srv_conf_t, quic.initial_max_data),
+      NULL },
+
     { ngx_string("quic_max_egress_udp_payload_size"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_size_slot,
@@ -216,6 +230,8 @@ ngx_http_v3_create_srv_conf(ngx_conf_t *cf)
     h3scf->quic.stream_close_code = NGX_HTTP_V3_ERR_NO_ERROR;
     h3scf->quic.stream_reject_code_bidi = NGX_HTTP_V3_ERR_REQUEST_REJECTED;
     h3scf->quic.active_connection_id_limit = NGX_CONF_UNSET_UINT;
+    h3scf->quic.max_udp_payload_size = NGX_CONF_UNSET_SIZE;
+    h3scf->quic.initial_max_data = NGX_CONF_UNSET_SIZE;
     h3scf->quic.max_egress_udp_payload_size = NGX_CONF_UNSET_SIZE;
 
     h3scf->quic.init = ngx_http_v3_init;
@@ -257,6 +273,34 @@ ngx_http_v3_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_uint_value(conf->quic.active_connection_id_limit,
                               prev->quic.active_connection_id_limit,
                               2);
+
+    ngx_conf_merge_size_value(conf->quic.max_udp_payload_size,
+                              prev->quic.max_udp_payload_size,
+                              NGX_QUIC_MAX_UDP_PAYLOAD_SIZE);
+
+    if (conf->quic.max_udp_payload_size < NGX_QUIC_MIN_INITIAL_SIZE
+        || conf->quic.max_udp_payload_size > NGX_QUIC_MAX_UDP_PAYLOAD_SIZE)
+    {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "\"quic_max_udp_payload_size\" must be between "
+                           "%d and %d",
+                           NGX_QUIC_MIN_INITIAL_SIZE,
+                           NGX_QUIC_MAX_UDP_PAYLOAD_SIZE);
+        return NGX_CONF_ERROR;
+    }
+
+    ngx_conf_merge_size_value(conf->quic.initial_max_data,
+                              prev->quic.initial_max_data, 0);
+
+    if (conf->quic.initial_max_data
+        && conf->quic.initial_max_data < conf->quic.stream_buffer_size)
+    {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "\"quic_initial_max_data\" is too small, "
+                           "raised to \"http3_stream_buffer_size\" (%uz)",
+                           conf->quic.stream_buffer_size);
+        conf->quic.initial_max_data = conf->quic.stream_buffer_size;
+    }
 
     ngx_conf_merge_size_value(conf->quic.max_egress_udp_payload_size,
                               prev->quic.max_egress_udp_payload_size,


### PR DESCRIPTION
Split of #1219 as requested in review: the new directives can be judged separately from the reuseport work.

Original work by @climagabriel; authorship is preserved in the commits.

Builds clean and a full nginx-tests run matches master.
