### PR TITLE
[codex] HTTP: enforce client_max_body_size while discarding chunked bodies

### DIFF
--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -849,6 +849,7 @@ ngx_http_discard_request_body_filter(ngx_http_request_t *r, ngx_buf_t *b)
     size_t                     size;
     ngx_int_t                  rc;
     ngx_http_request_body_t   *rb;
+    ngx_http_core_loc_conf_t  *clcf;
     ngx_http_core_srv_conf_t  *cscf;
 
     if (r->headers_in.chunked) {
@@ -870,6 +871,8 @@ ngx_http_discard_request_body_filter(ngx_http_request_t *r, ngx_buf_t *b)
             r->request_body = rb;
         }
 
+        clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
         for ( ;; ) {
 
             rc = ngx_http_parse_chunked(r, b, rb->chunked, 0);
@@ -881,13 +884,27 @@ ngx_http_discard_request_body_filter(ngx_http_request_t *r, ngx_buf_t *b)
                 size = b->last - b->pos;
 
                 if ((off_t) size > rb->chunked->size) {
-                    b->pos += (size_t) rb->chunked->size;
-                    rb->chunked->size = 0;
-
-                } else {
-                    rb->chunked->size -= size;
-                    b->pos = b->last;
+                    size = (size_t) rb->chunked->size;
                 }
+
+                if (clcf->client_max_body_size
+                    && (rb->received > clcf->client_max_body_size
+                        || (off_t) size > clcf->client_max_body_size
+                                          - rb->received))
+                {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "client intended to send too large chunked "
+                                  "body: %O+%uz bytes",
+                                  rb->received, size);
+
+                    r->lingering_close = 1;
+
+                    return NGX_HTTP_REQUEST_ENTITY_TOO_LARGE;
+                }
+
+                rb->received += size;
+                rb->chunked->size -= size;
+                b->pos += size;
 
                 continue;
             }


### PR DESCRIPTION
# HTTP: enforce client_max_body_size while discarding chunked bodies

## Summary

The HTTP/1.x discard path parsed and drained chunked request bodies without
measuring their decoded size. As a result, `client_max_body_size` was applied
to requests with `Content-Length` and to normally consumed chunked bodies, but
not to chunked bodies handled by `ngx_http_discard_request_body_filter()`.

Track decoded bytes in `rb->received` while discarding chunked data and stop
processing once the configured limit is exceeded. Only payload bytes are
counted; chunk framing is excluded. The zero value continues to disable the
limit, and a body exactly equal to the limit remains accepted.

Add regression coverage for:

- a multi-chunk body exactly at the configured limit;
- a single chunk exceeding the limit;
- cumulative overflow across multiple individually valid chunks.

Companion regression-test PR:
https://github.com/nginx/nginx-tests/pull/108

Closes: https://github.com/nginx/nginx/issues/1522

## Testing

Baseline `3f6f7824d4e2eb1ac37dec76683d525ac0ff521c`:

- `body_chunked.t`: tests 12 and 13 fail because nginx returns 200.

With this patch:

- `body_chunked.t`: 23/23 pass;
- `body.t`, `body_chunked.t`, and `http_keepalive.t`: 63/63 pass
  (two existing TODO assertions remain TODO and do not fail the suite);
- ASan+UBSan build: `body.t` and `body_chunked.t`: 40/40 pass;
- `git diff --check`: clean in both repositories.
