### PR TITLE
Variables: avoid passing NULL to memcpy in the $request_body assembly

### DIFF
--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -2212,7 +2212,10 @@ ngx_http_variable_request_body(ngx_http_request_t *r,
 
     for ( /* void */ ; cl; cl = cl->next) {
         buf = cl->buf;
-        p = ngx_cpymem(p, buf->pos, buf->last - buf->pos);
+
+        if (buf->pos != buf->last) {
+            p = ngx_cpymem(p, buf->pos, buf->last - buf->pos);
+        }
     }
 
     v->len = len;


### PR DESCRIPTION
## Problem

Evaluating `$request_body` for a multi-buffer body traps under UBSan (`ngx_http_variables.c:2215`): the assembly loop `ngx_cpymem(p, buf->pos, buf->last - buf->pos)` hits a data-less buffer (`pos == last == NULL`), i.e. `memcpy(p, NULL, 0)`, which glibc's nonnull attribute makes a fatal trap in `-fno-sanitize-recover` builds. The empty buffer in the request-body chain is new on master — the same test files pass under UBSan on 1.31.4 and trap on current master, introduced by `client_body_early_read` (3f6f7824d). Analysis and trace in #1689.

## Solution

Guard the copy on a non-empty buffer. The length loop just above already sums `last - pos`, so a skipped empty buffer contributes zero to both the allocation and the copy — the assembled result is unchanged.

## Testing

- Functional: under an UBSan `--with-debug` build, `nginx-tests/body_chunked.t` (7/20), `binary_upgrade.t` and `proxy_request_buffering_chunked.t` (8/24) trap before and pass after.
- With this and the remaining UBSan nonnull fixes applied (plus the `ngx_http_parse.c` unaligned-read change from #1668, which is a separate class), the **full nginx-tests suite runs clean under `-fsanitize=undefined -fno-sanitize-recover` + `--with-debug` — 493 files, all passing**, which as far as I can tell is the first time the suite has been runnable under UBSan at all.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

Closes: #1689

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

No user-visible change for regular builds.
