### PR TITLE
Core: avoid passing NULL to memcpy at three further callsites

### DIFF
--- a/src/core/ngx_resolver.c
+++ b/src/core/ngx_resolver.c
@@ -4210,7 +4210,9 @@ ngx_resolver_dup(ngx_resolver_t *r, void *src, size_t size)
         return dst;
     }
 
-    ngx_memcpy(dst, src, size);
+    if (size) {
+        ngx_memcpy(dst, src, size);
+    }
 
     return dst;
 }

--- a/src/http/modules/ngx_http_upstream_zone_module.c
+++ b/src/http/modules/ngx_http_upstream_zone_module.c
@@ -413,7 +413,9 @@ ngx_http_upstream_zone_copy_peer(ngx_http_upstream_rr_peers_t *peers,
         ngx_memcpy(dst->sockaddr, src->sockaddr, src->socklen);
         ngx_memcpy(dst->name.data, src->name.data, src->name.len);
 #if (NGX_HTTP_UPSTREAM_SID)
-        ngx_memcpy(dst->sid.data, src->sid.data, src->sid.len);
+        if (src->sid.len) {
+            ngx_memcpy(dst->sid.data, src->sid.data, src->sid.len);
+        }
 #endif
 
         dst->server.data = ngx_slab_alloc_locked(pool, src->server.len);

--- a/src/http/ngx_http_file_cache.c
+++ b/src/http/ngx_http_file_cache.c
@@ -1329,7 +1329,9 @@ ngx_http_file_cache_set_header(ngx_http_request_t *r, u_char *buf)
 
     if (c->etag.len <= NGX_HTTP_CACHE_ETAG_LEN) {
         h->etag_len = (u_char) c->etag.len;
-        ngx_memcpy(h->etag, c->etag.data, c->etag.len);
+        if (c->etag.len) {
+            ngx_memcpy(h->etag, c->etag.data, c->etag.len);
+        }
     }
 
     if (c->vary.len) {


### PR DESCRIPTION
## Problem

Three further nonnull-attribute traps from the UBSan inventory in https://github.com/nginx/nginx/issues/1671#issuecomment-5375419951, each a `memcpy()`/`ngx_cpymem()` call reached with a NULL source and zero length — fatal in `-fno-sanitize-recover` builds, none a miscomputation on regular builds:

- **`ngx_resolver_dup()`** (`src/core/ngx_resolver.c`) fed `(NULL, 0)` for an empty CNAME name (`http_resolver_cname.t`).
- **`ngx_http_upstream_zone_module.c`** peer copy `ngx_memcpy(dst->sid.data, src->sid.data, src->sid.len)` with an empty SID on the re-resolve path (six `upstream_*.t` files).
- **`ngx_http_file_cache.c`** cache-header writer `ngx_memcpy(h->etag, c->etag.data, c->etag.len)` for a response with no ETag (the `proxy_cache*` and `range_clearing` tests).

## Solution

Guard each copy on a non-zero length. The resolver one is a callee guard in the (private, static) `ngx_resolver_dup()`: `ngx_resolver_alloc()` already returns a valid pointer for size zero, and unlike a call-site guard it needs no change to any of the four callers (which all treat a NULL return as an allocation error). The SID and ETag guards are at the call site, matching the per-callsite precedent in `2ee94bab7` and the guards already present beside them.

## Testing

- Functional: under an UBSan `--with-debug` build, each named test file traps before and passes after.
- With these three plus the earlier UBSan nonnull fixes (#1672/#1679–#1682, #1689) and the `ngx_http_parse.c` unaligned-read change from #1668 (a separate class), the **full nginx-tests suite runs clean under `-fsanitize=undefined -fno-sanitize-recover` + `--with-debug` — 493 files, all passing.** The clean run depends on #1668 being applied; without it, the request-line method-matching macros still trap in five files.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** No paired issue — the three sites are documented in the #1671 inventory (https://github.com/nginx/nginx/issues/1671#issuecomment-5375419951).

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

No user-visible change for regular builds.
