### PR TITLE
Upstream: keepalive support for upstreams created at runtime

### DIFF
--- a/src/http/modules/ngx_http_upstream_keepalive_module.c
+++ b/src/http/modules/ngx_http_upstream_keepalive_module.c
@@ -22,6 +22,7 @@ typedef struct {
     ngx_http_upstream_init_peer_pt     original_init_peer;
 
     ngx_uint_t                         local; /* unsigned  local:1; */
+    ngx_uint_t                         draining; /* unsigned  draining:1; */
 
 } ngx_http_upstream_keepalive_srv_conf_t;
 
@@ -293,6 +294,16 @@ ngx_http_upstream_free_keepalive_peer(ngx_peer_connection_t *pc, void *data,
     u = kp->upstream;
     c = pc->connection;
 
+    /*
+     * Do not cache connections in an upstream being drained: the cache
+     * items, and the upstream itself, may be gone by the time such a
+     * connection is closed.
+     */
+
+    if (kp->conf->draining) {
+        goto invalid;
+    }
+
     if (state & NGX_PEER_FAILED
         || c == NULL
         || c->read->eof
@@ -507,6 +518,7 @@ ngx_http_upstream_keepalive_create_conf(ngx_conf_t *cf)
      *
      *     conf->original_init_peer = NULL;
      *     conf->local = 0;
+     *     conf->draining = 0;
      */
 
     conf->time = NGX_CONF_UNSET_MSEC;
@@ -586,6 +598,60 @@ ngx_http_upstream_keepalive_init(ngx_conf_t *cf,
     uscf->peer.init = ngx_http_upstream_init_keepalive_peer;
 
     return NGX_OK;
+}
+
+
+/*
+ * Drains the keepalive cache of a single upstream.  To be used by modules
+ * which delete upstreams at runtime, before the memory backing the upstream
+ * is released.
+ *
+ * The upstream is first marked as draining, so that connections still held
+ * by active requests are closed instead of being cached once these requests
+ * complete, and then all currently cached connections are closed.
+ *
+ * Connections are closed with ngx_http_upstream_keepalive_close(), which
+ * destroys the connection pool, and hence runs the cleanup handlers
+ * registered in it.
+ */
+
+void
+ngx_http_upstream_keepalive_drain(ngx_http_upstream_srv_conf_t *uscf)
+{
+    ngx_queue_t                             *q;
+    ngx_http_upstream_keepalive_cache_t     *item;
+    ngx_http_upstream_keepalive_srv_conf_t  *kcf;
+
+    if (uscf->srv_conf == NULL) {
+        return;
+    }
+
+    kcf = ngx_http_conf_upstream_srv_conf(uscf,
+                                          ngx_http_upstream_keepalive_module);
+
+    /*
+     * Keepalive was never initialized for this upstream, and the cache
+     * queues were never initialized either, so there is nothing to close
+     * and nothing safe to iterate.
+     */
+
+    if (kcf->original_init_peer == NULL) {
+        return;
+    }
+
+    kcf->draining = 1;
+
+    while (!ngx_queue_empty(&kcf->cache)) {
+
+        q = ngx_queue_head(&kcf->cache);
+        ngx_queue_remove(q);
+
+        item = ngx_queue_data(q, ngx_http_upstream_keepalive_cache_t, queue);
+
+        ngx_http_upstream_keepalive_close(item->connection);
+
+        ngx_queue_insert_head(&kcf->free, q);
+    }
 }
 
 

--- a/src/http/modules/ngx_http_upstream_keepalive_module.c
+++ b/src/http/modules/ngx_http_upstream_keepalive_module.c
@@ -518,14 +518,83 @@ ngx_http_upstream_keepalive_create_conf(ngx_conf_t *cf)
 }
 
 
+/*
+ * Initializes keepalive for a single upstream.  Called for each upstream
+ * from init_main_conf(), and can also be called by modules which create
+ * upstreams after configuration parsing, once such an upstream has been
+ * initialized by its balancer.
+ *
+ * Does nothing if the upstream is already initialized, and leaves the
+ * upstream untouched if initialization fails, so that a failed call cannot
+ * leave peer.init pointing to a keepalive cache which was never built.
+ */
+
+ngx_int_t
+ngx_http_upstream_keepalive_init(ngx_conf_t *cf,
+    ngx_http_upstream_srv_conf_t *uscf)
+{
+    ngx_uint_t                               i;
+    ngx_http_upstream_keepalive_cache_t     *cached;
+    ngx_http_upstream_keepalive_srv_conf_t  *kcf;
+
+    /* skip implicit upstreams */
+    if (uscf->srv_conf == NULL) {
+        return NGX_OK;
+    }
+
+    kcf = ngx_http_conf_upstream_srv_conf(uscf,
+                                          ngx_http_upstream_keepalive_module);
+
+    if (kcf->max_cached == 0) {
+        return NGX_OK;
+    }
+
+    /* keepalive is already initialized for this upstream */
+    if (kcf->original_init_peer != NULL) {
+        return NGX_OK;
+    }
+
+    ngx_conf_init_msec_value(kcf->time, 3600000);
+    ngx_conf_init_msec_value(kcf->timeout, 60000);
+    ngx_conf_init_uint_value(kcf->requests, 1000);
+
+    if (kcf->max_cached == NGX_CONF_UNSET_UINT) {
+        kcf->local = 1;
+        kcf->max_cached = 32;
+    }
+
+    /* allocate cache items and add to free queue */
+
+    cached = ngx_pcalloc(cf->pool,
+                 sizeof(ngx_http_upstream_keepalive_cache_t) * kcf->max_cached);
+    if (cached == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_queue_init(&kcf->cache);
+    ngx_queue_init(&kcf->free);
+
+    for (i = 0; i < kcf->max_cached; i++) {
+        ngx_queue_insert_head(&kcf->free, &cached[i].queue);
+        cached[i].conf = kcf;
+    }
+
+    /* the upstream is wired only once the cache is ready */
+
+    kcf->original_init_peer = uscf->peer.init;
+
+    uscf->peer.init = ngx_http_upstream_init_keepalive_peer;
+
+    return NGX_OK;
+}
+
+
 static char *
 ngx_http_upstream_keepalive_init_main_conf(ngx_conf_t *cf, void *conf)
 {
-    ngx_uint_t                                i, j;
-    ngx_http_upstream_srv_conf_t            **uscfp;
-    ngx_http_upstream_main_conf_t            *umcf;
-    ngx_http_upstream_keepalive_cache_t      *cached;
-    ngx_http_upstream_keepalive_srv_conf_t   *kcf;
+    ngx_uint_t                      i;
+    ngx_http_upstream_srv_conf_t  **uscfp;
+    ngx_http_upstream_main_conf_t  *umcf;
 
     umcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_upstream_module);
 
@@ -533,45 +602,8 @@ ngx_http_upstream_keepalive_init_main_conf(ngx_conf_t *cf, void *conf)
 
     for (i = 0; i < umcf->upstreams.nelts; i++) {
 
-        /* skip implicit upstreams */
-        if (uscfp[i]->srv_conf == NULL) {
-            continue;
-        }
-
-        kcf = ngx_http_conf_upstream_srv_conf(uscfp[i],
-                                            ngx_http_upstream_keepalive_module);
-
-        if (kcf->max_cached == 0) {
-            continue;
-        }
-
-        ngx_conf_init_msec_value(kcf->time, 3600000);
-        ngx_conf_init_msec_value(kcf->timeout, 60000);
-        ngx_conf_init_uint_value(kcf->requests, 1000);
-
-        if (kcf->max_cached == NGX_CONF_UNSET_UINT) {
-            kcf->local = 1;
-            kcf->max_cached = 32;
-        }
-
-        kcf->original_init_peer = uscfp[i]->peer.init;
-
-        uscfp[i]->peer.init = ngx_http_upstream_init_keepalive_peer;
-
-        /* allocate cache items and add to free queue */
-
-        cached = ngx_pcalloc(cf->pool,
-                 sizeof(ngx_http_upstream_keepalive_cache_t) * kcf->max_cached);
-        if (cached == NULL) {
+        if (ngx_http_upstream_keepalive_init(cf, uscfp[i]) != NGX_OK) {
             return NGX_CONF_ERROR;
-        }
-
-        ngx_queue_init(&kcf->cache);
-        ngx_queue_init(&kcf->free);
-
-        for (j = 0; j < kcf->max_cached; j++) {
-            ngx_queue_insert_head(&kcf->free, &cached[j].queue);
-            cached[j].conf = kcf;
         }
     }
 

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -456,6 +456,8 @@ ngx_int_t ngx_http_upstream_hide_headers_hash(ngx_conf_t *cf,
 ngx_int_t ngx_http_upstream_merge_ssl_passwords(ngx_conf_t *cf,
     ngx_http_upstream_conf_t *conf, ngx_http_upstream_conf_t *prev);
 #endif
+ngx_int_t ngx_http_upstream_keepalive_init(ngx_conf_t *cf,
+    ngx_http_upstream_srv_conf_t *uscf);
 
 
 #define ngx_http_conf_upstream_srv_conf(uscf, module)                         \

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -458,6 +458,7 @@ ngx_int_t ngx_http_upstream_merge_ssl_passwords(ngx_conf_t *cf,
 #endif
 ngx_int_t ngx_http_upstream_keepalive_init(ngx_conf_t *cf,
     ngx_http_upstream_srv_conf_t *uscf);
+void ngx_http_upstream_keepalive_drain(ngx_http_upstream_srv_conf_t *uscf);
 
 
 #define ngx_http_conf_upstream_srv_conf(uscf, module)                         \


### PR DESCRIPTION
## Problem

Since 1.29.7, per-upstream keepalive wiring happens in the keepalive module's
`init_main_conf()`, which walks `umcf->upstreams` once during configuration
parsing. Upstreams created after that point, by modules that allocate an
`ngx_http_upstream_srv_conf_t` and replay the `init_upstream` chain at runtime,
are never wired for keepalive and proxy without it.

There is also no way to close an upstream's cached connections when such a
module deletes it. The cache items are allocated from the deleted upstream's
pool, but the connections are held open by ongoing traffic, so they outlive the
memory describing them. A module that tracks upstream liveness with a cleanup
handler on each connection pool never sees those handlers run, and retains the
upstream, its peers and its cache permanently, one copy per deletion. See #1650
for the full report and production numbers.

## Solution

Two commits:

1. Splits the per-upstream body of `init_main_conf()` into
   `ngx_http_upstream_keepalive_init(cf, uscf)`, so it can be called for a
   single upstream once that upstream has been initialized by its balancer. It
   is called for every upstream from `init_main_conf()` as before. Because it
   runs after the balancer's `init()` rather than from a directive handler,
   directive order inside the `upstream` block does not matter, and an upstream
   with no explicit `keepalive` directive still picks up the 1.29.7 default.

   Two things differ from the code as it stood in `init_main_conf()`. The cache
   is built before `peer.init` is redirected, so a failed allocation leaves the
   upstream untouched instead of wrapped around queues that were never
   initialized; the old order was harmless there because `NGX_CONF_ERROR`
   aborts startup, but a runtime caller gets `NGX_ERROR` and may keep running.
   And a repeat call for the same upstream returns early, since re-running the
   wiring would point `original_init_peer` at the keepalive peer initializer
   itself.

2. Adds `ngx_http_upstream_keepalive_drain(uscf)`, which marks the upstream as
   draining so connections still held by active requests are closed rather than
   cached when those requests complete, then closes the already-cached
   connections. Closing goes through `ngx_http_upstream_keepalive_close()` so
   connection pools, and any cleanup handlers registered in them, are
   destroyed. Draining an upstream for which keepalive was never initialized
   does nothing, as its cache queues were never initialized either.

Prototypes are in `src/http/ngx_http_upstream.h` for lack of a keepalive module
header. I can move them if there is a better home.

## Testing

Builds clean with `-Wall -Wextra -Werror`. The nginx-tests upstream and
keepalive set passes: 27 files, 549 tests, including `upstream_keepalive.t`,
`proxy_keepalive.t` and `proxy_ssl_keepalive.t`.

Also exercised with a patched ngx_http_dyups_module, which calls `_init()` on
each upstream it rebuilds and `_drain()` when it tears one down. Under 60
concurrent requests with one upstream update per second for 180 seconds:
638,445 requests, 0 non-200, deleted upstreams freed rather than accumulating.
With the `_drain()` call removed, the same run leaves 30 deleted
upstreams unfreed within 45 seconds.


Neither commit adds a test. The first has no observable behavior change; the
second can only be triggered by a module that deletes upstreams, which stock
nginx cannot do.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

Fixes #1650

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

No user-visible change for stock nginx. Restores keepalive for third-party
modules that create upstreams at runtime, and lets them release cached
connections when deleting an upstream.
