### PR TITLE
fix(http): reject header lines without colon as invalid

### DIFF
--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -990,18 +990,13 @@ ngx_http_parse_header_line(ngx_http_request_t *r, ngx_buf_t *b,
             }
 
             if (ch == CR) {
-                r->header_name_end = p;
-                r->header_start = p;
                 r->header_end = p;
-                state = sw_almost_done;
-                break;
+                return NGX_HTTP_PARSE_INVALID_HEADER;
             }
 
             if (ch == LF) {
-                r->header_name_end = p;
-                r->header_start = p;
                 r->header_end = p;
-                goto done;
+                return NGX_HTTP_PARSE_INVALID_HEADER;
             }
 
             /* IIS may send the duplicate "HTTP/1.1 ..." lines */


### PR DESCRIPTION
Header lines that terminate in CR or LF before a colon delimiter are currently
accepted as valid headers by the sw_name state in
ngx_http_parse_header_line() (src/http/ngx_http_parse.c). RFC 7230 section 3.2
requires a colon between the field name and the field value; a bare
"Name<CR><LF>" or "Name<LF>" line has no colon and should not parse as a
valid header.

In the current sw_name handling, CR and LF seen before a colon fall through
to sw_almost_done / done, so the malformed line is passed through instead of
failing the parse. This change returns NGX_HTTP_PARSE_INVALID_HEADER for
both cases, setting r->header_end for context, matching how other invalid
characters in this state (ch <= 0x20 / 0x7f, a few lines below) are already
rejected. The existing IIS duplicate "HTTP/1.1 ..." workaround is checked
earlier in the same state and is unaffected.

On the client side this turns a previously-accepted malformed header line
into a 400. On proxied responses, an upstream that sends such a line will
now be treated as returning an invalid response rather than having the
header-less line passed through.

I have not reproduced this against a specific real-world client or upstream
sending this pattern, and have not run it against the nginx-tests suite yet.
Flagging that gap rather than claiming coverage that isn't there; happy to
follow up with either if that's what's needed to move this forward.
