### PR TITLE
Backport guard-clause fixes from freenginx

### DIFF
--- a/src/core/ngx_open_file_cache.c
+++ b/src/core/ngx_open_file_cache.c
@@ -227,15 +227,15 @@ ngx_open_cached_file(ngx_open_file_cache_t *cache, ngx_str_t *name,
             goto add_event;
         }
 
-        if (file->use_event
-            || (file->event == NULL
-                && (of->uniq == 0 || of->uniq == file->uniq)
-                && now - file->created < of->valid
+        if ((file->use_event
+             || (file->event == NULL
+                 && (of->uniq == 0 || of->uniq == file->uniq)
+                 && now - file->created < of->valid))
 #if (NGX_HAVE_OPENAT)
-                && of->disable_symlinks == file->disable_symlinks
-                && of->disable_symlinks_from == file->disable_symlinks_from
+            && of->disable_symlinks == file->disable_symlinks
+            && of->disable_symlinks_from == file->disable_symlinks_from
 #endif
-            ))
+            )
         {
             if (file->err == 0) {
 

--- a/src/core/ngx_resolver.c
+++ b/src/core/ngx_resolver.c
@@ -1774,7 +1774,7 @@ ngx_resolver_process_response(ngx_resolver_t *r, u_char *buf, size_t n,
                    (response->nar_hi << 8) + response->nar_lo);
 
     /* response to a standard query */
-    if ((flags & 0xf870) != 0x8000 || (trunc && tcp)) {
+    if ((flags & 0xf850) != 0x8000 || (trunc && tcp)) {
         ngx_log_error(r->log_level, r->log, 0,
                       "invalid %s DNS response %ui fl:%04Xi",
                       tcp ? "TCP" : "UDP", ident, flags);

--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -3215,6 +3215,12 @@ ngx_ssl_write(ngx_connection_t *c, u_char *data, size_t size)
     }
 #endif
 
+    if (c->ssl->last == NGX_ERROR) {
+        c->write->ready = 0;
+        c->write->error = 1;
+        return NGX_ERROR;
+    }
+
     ngx_ssl_clear_error(c->log);
 
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL to write: %uz", size);
@@ -3322,6 +3328,12 @@ ngx_ssl_write_early(ngx_connection_t *c, u_char *data, size_t size)
     int        n, sslerr;
     size_t     written;
     ngx_err_t  err;
+
+    if (c->ssl->last == NGX_ERROR) {
+        c->write->ready = 0;
+        c->write->error = 1;
+        return NGX_ERROR;
+    }
 
     ngx_ssl_clear_error(c->log);
 

--- a/src/event/ngx_event_openssl_stapling.c
+++ b/src/event/ngx_event_openssl_stapling.c
@@ -1647,6 +1647,10 @@ ngx_ssl_ocsp_write_handler(ngx_event_t *wev)
     if (!wev->timer_set && ctx->timeout) {
         ngx_add_timer(wev, ctx->timeout);
     }
+
+    if (ngx_handle_write_event(wev, 0) != NGX_OK) {
+        ngx_ssl_ocsp_error(ctx);
+    }
 }
 
 

--- a/src/http/modules/ngx_http_auth_request_module.c
+++ b/src/http/modules/ngx_http_auth_request_module.c
@@ -419,7 +419,8 @@ ngx_http_auth_request_set(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return NGX_CONF_ERROR;
     }
 
-    v = ngx_http_add_variable(cf, &value[1], NGX_HTTP_VAR_CHANGEABLE);
+    v = ngx_http_add_variable(cf, &value[1],
+                              NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_WEAK);
     if (v == NULL) {
         return NGX_CONF_ERROR;
     }

--- a/src/http/modules/ngx_http_charset_filter_module.c
+++ b/src/http/modules/ngx_http_charset_filter_module.c
@@ -438,6 +438,7 @@ ngx_http_source_charset(ngx_http_request_t *r, ngx_str_t *name)
 
     if (charset == NGX_HTTP_CHARSET_OFF) {
         name->len = 0;
+        name->data = NULL;
         return charset;
     }
 

--- a/src/http/modules/ngx_http_dav_module.c
+++ b/src/http/modules/ngx_http_dav_module.c
@@ -539,7 +539,7 @@ static ngx_int_t
 ngx_http_dav_copy_move_handler(ngx_http_request_t *r)
 {
     u_char                    *p, *host, *last, ch;
-    size_t                     len, root;
+    size_t                     len, root, alias;
     ngx_err_t                  err;
     ngx_int_t                  rc, depth;
     ngx_uint_t                 overwrite, slash, dir, flags;
@@ -649,15 +649,19 @@ destination_done:
     }
 
     clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+    alias = clcf->alias;
 
-    if (clcf->alias
-        && clcf->alias != NGX_MAX_SIZE_T_VALUE
-        && duri.len < clcf->alias)
-    {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                      "client sent invalid \"Destination\" header: \"%V\"",
-                      &dest->value);
-        return NGX_HTTP_BAD_REQUEST;
+    if (alias && alias != NGX_MAX_SIZE_T_VALUE) {
+
+        if (alias > duri.len
+            || ngx_filename_cmp(duri.data, r->uri.data, alias) != 0)
+        {
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                          "\"Destination\" URI \"%V\" must be "
+                          "within location prefix when using \"alias\"",
+                          &dest->value);
+            return NGX_HTTP_BAD_REQUEST;
+        }
     }
 
     depth = ngx_http_dav_depth(r, NGX_HTTP_DAV_INFINITY_DEPTH);

--- a/src/http/modules/ngx_http_dav_module.c
+++ b/src/http/modules/ngx_http_dav_module.c
@@ -654,6 +654,7 @@ destination_done:
     if (alias && alias != NGX_MAX_SIZE_T_VALUE) {
 
         if (alias > duri.len
+            || alias > r->uri.len
             || ngx_filename_cmp(duri.data, r->uri.data, alias) != 0)
         {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -1342,6 +1342,8 @@ ngx_http_grpc_reinit_request(ngx_http_request_t *r)
     ctx->in = NULL;
     ctx->busy = NULL;
     ctx->out = NULL;
+    ctx->pings = 0;
+    ctx->settings = 0;
 
     return NGX_OK;
 }

--- a/src/http/modules/ngx_http_gzip_filter_module.c
+++ b/src/http/modules/ngx_http_gzip_filter_module.c
@@ -891,6 +891,7 @@ ngx_http_gzip_filter_deflate_end(ngx_http_request_t *r,
     }
 
     ngx_pfree(r->pool, ctx->preallocated);
+    ctx->preallocated = NULL;
 
     cl = ngx_alloc_chain_link(r->pool);
     if (cl == NULL) {

--- a/src/http/modules/ngx_http_mp4_module.c
+++ b/src/http/modules/ngx_http_mp4_module.c
@@ -3460,6 +3460,13 @@ ngx_http_mp4_update_stsz_atom(ngx_http_mp4_file_t *mp4,
         data->pos += trak->start_sample * sizeof(uint32_t);
         end = (uint32_t *) data->pos;
 
+        if (trak->start_chunk_samples > trak->start_sample) {
+            ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                          "too many mp4 start chunk samples in \"%s\"",
+                          mp4->file.name.data);
+            return NGX_ERROR;
+        }
+
         for (pos = end - trak->start_chunk_samples; pos < end; pos++) {
             trak->start_chunk_samples_size += ngx_mp4_get_32value(pos);
         }
@@ -3486,6 +3493,13 @@ ngx_http_mp4_update_stsz_atom(ngx_http_mp4_file_t *mp4,
             entries = trak->end_sample - trak->start_sample;
             data->last = data->pos + entries * sizeof(uint32_t);
             end = (uint32_t *) data->last;
+
+            if (trak->end_chunk_samples > entries) {
+                ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                              "too many mp4 end chunk samples in \"%s\"",
+                              mp4->file.name.data);
+                return NGX_ERROR;
+            }
 
             for (pos = end - trak->end_chunk_samples; pos < end; pos++) {
                 trak->end_chunk_samples_size += ngx_mp4_get_32value(pos);
@@ -3653,7 +3667,9 @@ ngx_http_mp4_update_stco_atom(ngx_http_mp4_file_t *mp4,
 
     if (mp4->length) {
 
-        if (trak->end_chunk > trak->chunks) {
+        if (trak->end_chunk - trak->start_chunk
+            > trak->chunks - trak->start_chunk)
+        {
             ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
                           "end time is out mp4 stco chunks in \"%s\"",
                           mp4->file.name.data);
@@ -3866,8 +3882,10 @@ ngx_http_mp4_update_co64_atom(ngx_http_mp4_file_t *mp4,
 
     if (mp4->length) {
 
-        if (trak->end_chunk > trak->chunks) {
-            ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+        if (trak->end_chunk - trak->start_chunk
+            > trak->chunks - trak->start_chunk)
+        {
+            ngx_log_error(NGX_LOG_ALERT, mp4->file.log, 0,
                           "end time is out mp4 co64 chunks in \"%s\"",
                           mp4->file.name.data);
             return NGX_ERROR;

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -1307,6 +1307,9 @@ ngx_http_proxy_create_request(ngx_http_request_t *r)
         ctx->internal_body_length = -1;
         ctx->internal_chunked = 1;
 
+    } else if (r->discard_body) {
+        ctx->internal_body_length = 0;
+
     } else {
         ctx->internal_body_length = r->headers_in.content_length_n;
     }

--- a/src/http/modules/ngx_http_scgi_module.c
+++ b/src/http/modules/ngx_http_scgi_module.c
@@ -1986,7 +1986,12 @@ ngx_http_scgi_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
+
     clcf->handler = ngx_http_scgi_handler;
+
+    if (clcf->name.len && clcf->name.data[clcf->name.len - 1] == '/') {
+        clcf->auto_redirect = 1;
+    }
 
     value = cf->args->elts;
 
@@ -2021,10 +2026,6 @@ ngx_http_scgi_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     scf->upstream.upstream = ngx_http_upstream_add(cf, &u, 0);
     if (scf->upstream.upstream == NULL) {
         return NGX_CONF_ERROR;
-    }
-
-    if (clcf->name.len && clcf->name.data[clcf->name.len - 1] == '/') {
-        clcf->auto_redirect = 1;
     }
 
     return NGX_CONF_OK;

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -2312,7 +2312,12 @@ ngx_http_uwsgi_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
+
     clcf->handler = ngx_http_uwsgi_handler;
+
+    if (clcf->name.len && clcf->name.data[clcf->name.len - 1] == '/') {
+        clcf->auto_redirect = 1;
+    }
 
     value = cf->args->elts;
 
@@ -2370,10 +2375,6 @@ ngx_http_uwsgi_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     uwcf->upstream.upstream = ngx_http_upstream_add(cf, &u, 0);
     if (uwcf->upstream.upstream == NULL) {
         return NGX_CONF_ERROR;
-    }
-
-    if (clcf->name.len && clcf->name.data[clcf->name.len - 1] == '/') {
-        clcf->auto_redirect = 1;
     }
 
     return NGX_CONF_OK;

--- a/src/http/ngx_http.h
+++ b/src/http/ngx_http.h
@@ -65,6 +65,7 @@ struct ngx_http_chunked_s {
     ngx_uint_t           state;
     off_t                size;
     off_t                length;
+    off_t                skipped;
 };
 
 

--- a/src/http/ngx_http_copy_filter_module.c
+++ b/src/http/ngx_http_copy_filter_module.c
@@ -83,6 +83,7 @@ static ngx_int_t
 ngx_http_copy_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
     ngx_int_t                     rc;
+    ngx_chain_t                  *cl;
     ngx_connection_t             *c;
     ngx_output_chain_ctx_t       *ctx;
     ngx_http_core_loc_conf_t     *clcf;
@@ -132,9 +133,14 @@ ngx_http_copy_filter(ngx_http_request_t *r, ngx_chain_t *in)
             ctx->thread_handler = ngx_http_copy_thread_handler;
         }
 #endif
+    }
 
-        if (in && in->buf && ngx_buf_size(in->buf)) {
-            r->request_output = 1;
+    if (!r->request_output) {
+        for (cl = in; cl; cl = cl->next) {
+            if (ngx_buf_size(cl->buf)) {
+                r->request_output = 1;
+                break;
+            }
         }
     }
 

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1972,6 +1972,12 @@ ngx_http_map_uri_to_path(ngx_http_request_t *r, ngx_str_t *path,
         return NULL;
     }
 
+    if (alias > r->uri.len && alias != NGX_MAX_SIZE_T_VALUE) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                      "URI shorter than aliased URI part");
+        return NULL;
+    }
+
     if (clcf->root_lengths == NULL) {
 
         *root_length = clcf->root.len;

--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -5074,6 +5074,8 @@ ngx_http_core_error_page(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 static char *
 ngx_http_core_open_file_cache(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
+#if (NGX_HAVE_PREAD || NGX_WIN32)
+
     ngx_http_core_loc_conf_t *clcf = conf;
 
     time_t       inactive;
@@ -5141,11 +5143,17 @@ ngx_http_core_open_file_cache(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     clcf->open_file_cache = ngx_open_file_cache_init(cf->pool, max, inactive);
-    if (clcf->open_file_cache) {
-        return NGX_CONF_OK;
+    if (clcf->open_file_cache == NULL) {
+        return NGX_CONF_ERROR;
     }
 
-    return NGX_CONF_ERROR;
+#else
+    ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                       "\"open_file_cache\" is not supported "
+                       "on this platform, ignored");
+#endif
+
+    return NGX_CONF_OK;
 }
 
 

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -2209,6 +2209,7 @@ ngx_http_split_args(ngx_http_request_t *r, ngx_str_t *uri, ngx_str_t *args)
 
     } else {
         args->len = 0;
+        args->data = NULL;
     }
 }
 

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -2326,6 +2326,8 @@ ngx_http_parse_chunked(ngx_http_request_t *r, ngx_buf_t *b,
                 break;
             case LF:
                 goto invalid;
+            default:
+                ctx->skipped++;
             }
             break;
 
@@ -2364,6 +2366,8 @@ ngx_http_parse_chunked(ngx_http_request_t *r, ngx_buf_t *b,
                 break;
             case LF:
                 goto invalid;
+            default:
+                ctx->skipped++;
             }
             break;
 
@@ -2385,6 +2389,7 @@ ngx_http_parse_chunked(ngx_http_request_t *r, ngx_buf_t *b,
             case LF:
                 goto invalid;
             default:
+                ctx->skipped++;
                 state = sw_trailer_header;
             }
             break;
@@ -2402,6 +2407,8 @@ ngx_http_parse_chunked(ngx_http_request_t *r, ngx_buf_t *b,
                 break;
             case LF:
                 goto invalid;
+            default:
+                ctx->skipped++;
             }
             break;
 

--- a/src/http/ngx_http_postpone_filter_module.c
+++ b/src/http/ngx_http_postpone_filter_module.c
@@ -194,13 +194,17 @@ ngx_http_postpone_filter_in_memory(ngx_http_request_t *r, ngx_chain_t *in)
         clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
 
         if (r->headers_out.content_length_n != -1) {
-            len = r->headers_out.content_length_n;
 
-            if (len > clcf->subrequest_output_buffer_size) {
+            if (r->headers_out.content_length_n
+                > (off_t) clcf->subrequest_output_buffer_size)
+            {
                 ngx_log_error(NGX_LOG_ERR, c->log, 0,
-                              "too big subrequest response: %uz", len);
+                              "too big subrequest response: %O",
+                              r->headers_out.content_length_n);
                 return NGX_ERROR;
             }
+
+            len = (size_t) r->headers_out.content_length_n;
 
         } else {
             len = clcf->subrequest_output_buffer_size;

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -307,6 +307,7 @@ ngx_http_do_read_client_request_body(ngx_http_request_t *r)
     c = r->connection;
     rb = r->request_body;
     flush = 1;
+    n = NGX_AGAIN;
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
                    "http read client request body");
@@ -432,7 +433,7 @@ ngx_http_do_read_client_request_body(ngx_http_request_t *r)
             break;
         }
 
-        if (!c->read->ready || rb->rest == 0) {
+        if (n == NGX_AGAIN || !c->read->ready || rb->rest == 0) {
 
             clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
             ngx_add_timer(c->read, clcf->client_body_timeout);

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -222,6 +222,7 @@ done:
 
     if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
         r->main->count--;
+        r->read_event_handler = ngx_http_block_reading;
     }
 
     return rc;
@@ -286,6 +287,7 @@ ngx_http_read_client_request_body_handler(ngx_http_request_t *r)
     rc = ngx_http_do_read_client_request_body(r);
 
     if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
+        r->read_event_handler = ngx_http_block_reading;
         ngx_http_finalize_request(r, rc);
     }
 }

--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -1143,6 +1143,17 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
 
                 if (clcf->client_max_body_size
+                    && clcf->client_max_body_size < rb->chunked->skipped)
+                {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "client sent too many chunk extensions");
+
+                    r->lingering_close = 1;
+
+                    return NGX_HTTP_REQUEST_ENTITY_TOO_LARGE;
+                }
+
+                if (clcf->client_max_body_size
                     && clcf->client_max_body_size
                        - r->headers_in.content_length_n < rb->chunked->size)
                 {
@@ -1242,6 +1253,20 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
             }
 
             if (rc == NGX_AGAIN) {
+
+                clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+                if (clcf->client_max_body_size
+                    && clcf->client_max_body_size < rb->chunked->skipped)
+                {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "client sent too many chunk extensions "
+                                  "or trailer headers");
+
+                    r->lingering_close = 1;
+
+                    return NGX_HTTP_REQUEST_ENTITY_TOO_LARGE;
+                }
 
                 /* set rb->rest, amount of data we want to see next time */
 

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -458,6 +458,12 @@ ngx_http_add_variable(ngx_conf_t *cf, ngx_str_t *name, ngx_uint_t flags)
             return NULL;
         }
 
+        if (!(flags & NGX_HTTP_VAR_WEAK) && v->set_handler) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "the duplicate \"%V\" variable", name);
+            return NULL;
+        }
+
         if (!(flags & NGX_HTTP_VAR_WEAK)) {
             v->flags &= ~NGX_HTTP_VAR_WEAK;
         }

--- a/src/http/ngx_http_variables.c
+++ b/src/http/ngx_http_variables.c
@@ -2651,7 +2651,8 @@ ngx_http_regex_compile(ngx_conf_t *cf, ngx_regex_compile_t *rc)
         name.data = &p[2];
         name.len = ngx_strlen(name.data);
 
-        v = ngx_http_add_variable(cf, &name, NGX_HTTP_VAR_CHANGEABLE);
+        v = ngx_http_add_variable(cf, &name,
+                                  NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_WEAK);
         if (v == NULL) {
             return NULL;
         }
@@ -2661,7 +2662,9 @@ ngx_http_regex_compile(ngx_conf_t *cf, ngx_regex_compile_t *rc)
             return NULL;
         }
 
-        v->get_handler = ngx_http_variable_not_found;
+        if (v->get_handler == NULL) {
+            v->get_handler = ngx_http_variable_not_found;
+        }
 
         p += size;
     }

--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -1345,7 +1345,8 @@ ngx_http_v2_state_headers(ngx_http_v2_connection_t *h2c, u_char *pos,
     clcf = ngx_http_get_module_loc_conf(h2c->http_connection->conf_ctx,
                                         ngx_http_core_module);
 
-    if (clcf->keepalive_timeout == 0
+    if (ngx_exiting
+        || clcf->keepalive_timeout == 0
         || h2c->connection->requests >= clcf->keepalive_requests
         || ngx_current_msec - h2c->connection->start_time
            > clcf->keepalive_time)

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -410,6 +410,8 @@ ngx_http_v3_reset_stream(ngx_connection_t *c)
 {
     ngx_http_v3_session_t  *h3c;
 
+    ngx_reusable_connection(c, 0);
+
     h3c = ngx_http_v3_get_session(c);
 
     if (!c->read->eof && !h3c->hq

--- a/src/mail/ngx_mail_auth_http_module.c
+++ b/src/mail/ngx_mail_auth_http_module.c
@@ -883,6 +883,7 @@ ngx_mail_auth_sleep_handler(ngx_event_t *rev)
 
         s->mail_state = 0;
         s->auth_method = NGX_MAIL_AUTH_PLAIN;
+        s->tag.len = 0;
 
         c->log->action = "in auth state";
 

--- a/src/mail/ngx_mail_handler.c
+++ b/src/mail/ngx_mail_handler.c
@@ -750,6 +750,8 @@ ngx_mail_auth_external(ngx_mail_session_t *s, ngx_connection_t *c,
     s->login.len = external.len;
     s->login.data = external.data;
 
+    ngx_str_null(&s->passwd);
+
     ngx_log_debug1(NGX_LOG_DEBUG_MAIL, c->log, 0,
                    "mail auth external: \"%V\"", &s->login);
 

--- a/src/mail/ngx_mail_proxy_module.c
+++ b/src/mail/ngx_mail_proxy_module.c
@@ -255,7 +255,7 @@ ngx_mail_proxy_pop3_handler(ngx_event_t *rev)
         return;
     }
 
-    if (s->proxy->proxy_protocol) {
+    if (s->proxy->proxy_protocol || !c->write->ready) {
         ngx_log_debug0(NGX_LOG_DEBUG_MAIL, c->log, 0, "mail proxy pop3 busy");
 
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
@@ -395,7 +395,7 @@ ngx_mail_proxy_imap_handler(ngx_event_t *rev)
         return;
     }
 
-    if (s->proxy->proxy_protocol) {
+    if (s->proxy->proxy_protocol || !c->write->ready) {
         ngx_log_debug0(NGX_LOG_DEBUG_MAIL, c->log, 0, "mail proxy imap busy");
 
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
@@ -559,7 +559,7 @@ ngx_mail_proxy_smtp_handler(ngx_event_t *rev)
         return;
     }
 
-    if (s->proxy->proxy_protocol) {
+    if (s->proxy->proxy_protocol || !c->write->ready) {
         ngx_log_debug0(NGX_LOG_DEBUG_MAIL, c->log, 0, "mail proxy smtp busy");
 
         if (ngx_handle_read_event(c->read, 0) != NGX_OK) {

--- a/src/stream/ngx_stream_variables.c
+++ b/src/stream/ngx_stream_variables.c
@@ -1099,7 +1099,8 @@ ngx_stream_regex_compile(ngx_conf_t *cf, ngx_regex_compile_t *rc)
         name.data = &p[2];
         name.len = ngx_strlen(name.data);
 
-        v = ngx_stream_add_variable(cf, &name, NGX_STREAM_VAR_CHANGEABLE);
+        v = ngx_stream_add_variable(cf, &name,
+                                NGX_STREAM_VAR_CHANGEABLE|NGX_STREAM_VAR_WEAK);
         if (v == NULL) {
             return NULL;
         }
@@ -1109,7 +1110,9 @@ ngx_stream_regex_compile(ngx_conf_t *cf, ngx_regex_compile_t *rc)
             return NULL;
         }
 
-        v->get_handler = ngx_stream_variable_not_found;
+        if (v->get_handler == NULL) {
+            v->get_handler = ngx_stream_variable_not_found;
+        }
 
         p += size;
     }

--- a/src/stream/ngx_stream_variables.c
+++ b/src/stream/ngx_stream_variables.c
@@ -182,6 +182,12 @@ ngx_stream_add_variable(ngx_conf_t *cf, ngx_str_t *name, ngx_uint_t flags)
             return NULL;
         }
 
+        if (!(flags & NGX_STREAM_VAR_WEAK) && v->set_handler) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "the duplicate \"%V\" variable", name);
+            return NULL;
+        }
+
         if (!(flags & NGX_STREAM_VAR_WEAK)) {
             v->flags &= ~NGX_STREAM_VAR_WEAK;
         }


### PR DESCRIPTION
## Summary

This PR backports **26 defensive guard-clause fixes** from freenginx (plus one
follow-up hardening commit), each a small conditional that prevents a concrete
malfunction: a crash, hang, memory-safety issue, resource leak, DoS vector, or
security bypass.

It is the result of a full audit of **every freenginx changeset since the fork**
(345 changesets, nginx 1.25.4 / Feb 2024 through freenginx 1.31.4). Changes were
included only when they (a) prevent a concrete failure mode, (b) are absent from
current nginx (including semantically equivalent fixes), (c) guard code that
exists in nginx (fixes for freenginx-only regressions were excluded), and (d)
apply with at most trivial adaptation.

Each commit is one upstream changeset with the original author, date, and commit
message preserved, an `Origin:` trailer linking the freenginx changeset, and the
backporter's `Signed-off-by:`. Commits whose patches required adaptation
additionally carry a `Co-authored-by:` trailer and document the deviation in the
commit body — see **Changes not present in freenginx** below for the explicit
list.

## Highlights

- **DoS**: unbounded chunked extensions / trailer headers now capped via
  `client_max_body_size` (reported by Bartek Nowotarski)
- **Memory safety**: mp4 out-of-bounds reads on crafted stsc data (bug present
  since 1.5.13); HTTP/3 recursion -> stack overflow / stack use-after-free during
  connection reuse; gzip double `ngx_pfree()`; uninitialized pointer use
- **Security bypass**: `disable_symlinks` ignored for cached entries with
  `open_file_cache_events`; DAV COPY/MOVE `Destination` escaping the `alias`
  directory (strengthens the check from 9739e755b8dd) plus a
  `ngx_http_map_uri_to_path()` sanity check
- **Hangs / leaks / lifecycle**: mail proxy backend readiness errors on Windows;
  `limit_conn` shared-memory counter leak on allocation errors; stalled OCSP
  requests after partial writes; HTTP/2 connections lingering through graceful
  shutdown
- **Config-time guards**: duplicate-variable redefinition with `set_handler`
  rejected (the `map $x $limit_rate` segfault class, ticket #1238), with the
  `auth_request_set` and named-captures companions included

## Changes not present in freenginx

Two commits contain functional changes beyond the freenginx originals. Both
address flaws that are still present in freenginx itself and are candidates for
an upstream report there:

- [`4f039db74`](https://github.com/dekobon/nginx/commit/4f039db747b681cc755201b57b1f73f91bcb5313)
  **Dav: fixed out-of-bounds read in destination validation.** Entirely
  original work (`Adaptation-Commit-For:` trailer, no freenginx counterpart).
  The backported Destination check compares the first `clcf->alias` bytes of
  `r->uri`, but `r->uri` can be shorter than the location prefix if it was
  changed by a rewrite; such requests are now rejected before
  `ngx_filename_cmp()` is called.
- [`c0df646b1`](https://github.com/dekobon/nginx/commit/c0df646b1660ab3c4f66d8fa0ffec88bb48dc57a)
  **Request body: limited chunk extensions and trailer headers.** Beyond
  adapting the patch to nginx's chunked parser states, this commit adds a
  `ctx->skipped` increment in the `sw_trailer` state. The original freenginx
  patch never charges minimal trailer lines (`a` CRLF) against the new limit,
  so an endless stream of them bypasses the cap entirely; with this change
  every trailer line costs at least one byte of budget.

Three further commits are mechanical adaptations with no intended behavioral
difference from their freenginx changesets, each documented in its commit
body:

- [`e9abcb601`](https://github.com/dekobon/nginx/commit/e9abcb60166425ea2d2f16edceca7e2d1d005601)
  **HTTP/3: protection from recursion during connection reuse.** — the
  one-line fix was placed by hand; the surrounding context differs (nginx does
  not carry the freenginx `max_table_capacity` changes).
- [`58ea3d04e`](https://github.com/dekobon/nginx/commit/58ea3d04efb144b19e739aa2b4133d9cfd3ad644)
  **gRPC: reinitialization of ping and settings limits.** — the `ctx->pings` /
  `ctx->settings` resets were appended to nginx's larger
  `ngx_http_grpc_reinit_request()` block.
- [`8b6386be6`](https://github.com/dekobon/nginx/commit/8b6386be69a39daf5099bea8338910650a0a36d8)
  **Dav: destination validation for COPY and MOVE with "alias".** — replaces
  nginx's own earlier length-only Destination check (from 9739e755b8dd) with
  the stronger location prefix comparison.

The remaining 22 backports are byte-for-byte identical to the freenginx
changesets in their added/removed lines.

## Compatibility note

Configs that redefine variables having a set handler (`$limit_rate`, `$args`)
via map-like directives (`map`, `geo`, `split_clients`, ...) now fail at startup
with `the duplicate "..." variable`. Such configs were latently broken - the
get/set handler state they produced was inconsistent. `set` and
`auth_request_set` continue to work.

## Known limitations (faithful to upstream freenginx)

- The chunk-extension cap counts trailer-header bytes against
  `client_max_body_size` and does not extend to the discard-body path.
- The discarded-body zero Content-Length fix covers the proxy module only;
  fastcgi/uwsgi/scgi/grpc are follow-up candidates.
- The post-error `SSL_write()` guard does not cover the `SSL_sendfile()` (kTLS)
  path.

## Testing

- Clean `-Werror` build with SSL, HTTP/2, HTTP/3/QUIC, mail, stream, mp4, dav,
  threads enabled during the audit; the rewritten branch was rebuilt after the
  two mail pipelining backports were removed.
- Full nginx-tests suite was run during the audit before the mail pipelining
  backports were removed.
- Accompanying freenginx-tests changes were backported as the companion PR
  nginx/nginx-tests#112 (4 commits on a matching
  `cherry/freenginx-guard-clauses` branch: chunked extensions/trailers, IMAP
  EXTERNAL auth, SSI stub, proxy SSL password inheritance); all four files
  pass against this branch (75/75). As a
  deviation from the freenginx originals, their fork version guards were
  retargeted to mainline versioning rather than removed, so the new
  assertions TODO/skip instead of failing hard when the suite is run against
  an nginx without these fixes. Notably, the suite caught a real integration
  gap during the audit (`auth_request_set` + duplicate-variable rejection),
  which is why the `auth_request_set` companion changeset is included.

