### PR TITLE
Stream, mail: custom PROXY protocol v2 TLVs to backends.

### DIFF
--- a/src/core/ngx_proxy_protocol.c
+++ b/src/core/ngx_proxy_protocol.c
@@ -92,12 +92,6 @@ typedef struct {
 } ngx_proxy_protocol_tlv_entry_t;
 
 
-typedef struct {
-    ngx_uint_t                              type;
-    ngx_str_t                               value;
-} ngx_proxy_protocol_tlv_value_t;
-
-
 static u_char *ngx_proxy_protocol_read_addr(ngx_connection_t *c, u_char *p,
     u_char *last, ngx_str_t *addr);
 static u_char *ngx_proxy_protocol_read_port(u_char *p, u_char *last,
@@ -675,9 +669,38 @@ ngx_proxy_protocol_lookup_tlv(ngx_connection_t *c, ngx_str_t *tlvs,
 }
 
 
+ngx_int_t
+ngx_proxy_protocol_v2_tlv_type(ngx_str_t *s, ngx_uint_t *type)
+{
+    ngx_int_t  n;
+
+    /*
+     * the only accepted form is a lowercase "0x" prefix followed by
+     * exactly two hexadecimal digits
+     */
+
+    if (s->len != 4 || s->data[0] != '0' || s->data[1] != 'x') {
+        return NGX_ERROR;
+    }
+
+    n = ngx_hextoi(s->data + 2, 2);
+
+    if (n == NGX_ERROR
+        || n < NGX_PROXY_PROTOCOL_TLV_USER_MIN
+        || n > NGX_PROXY_PROTOCOL_TLV_USER_MAX)
+    {
+        return NGX_ERROR;
+    }
+
+    *type = (ngx_uint_t) n;
+
+    return NGX_OK;
+}
+
+
 u_char *
 ngx_proxy_protocol_v2_write(ngx_connection_t *c, u_char *buf, u_char *last,
-    ngx_array_t *tlvs /* reserved */ )
+    ngx_array_t *tlvs)
 {
     u_char                          *p;
     uint32_t                         verify;
@@ -738,6 +761,18 @@ ngx_proxy_protocol_v2_write(ngx_connection_t *c, u_char *buf, u_char *last,
                                             verify);
         if (p == NULL) {
             return NULL;
+        }
+    }
+
+    if (tlvs) {
+        tlv = tlvs->elts;
+
+        for (i = 0; i < tlvs->nelts; i++) {
+            p = ngx_proxy_protocol_v2_write_tlv(c, p, last, tlv[i].type,
+                                                &tlv[i].value);
+            if (p == NULL) {
+                return NULL;
+            }
         }
     }
 

--- a/src/core/ngx_proxy_protocol.h
+++ b/src/core/ngx_proxy_protocol.h
@@ -16,6 +16,15 @@
 #define NGX_PROXY_PROTOCOL_V1_MAX_HEADER  107
 #define NGX_PROXY_PROTOCOL_MAX_HEADER     4096
 
+/*
+ * TLV types reserved by the PROXY protocol specification for use by
+ * applications: 0xe0 - 0xef custom, 0xf0 - 0xf7 experimental,
+ * 0xf8 - 0xff future.
+ */
+
+#define NGX_PROXY_PROTOCOL_TLV_USER_MIN   0xe0
+#define NGX_PROXY_PROTOCOL_TLV_USER_MAX   0xff
+
 
 struct ngx_proxy_protocol_s {
     ngx_str_t           src_addr;
@@ -26,6 +35,12 @@ struct ngx_proxy_protocol_s {
 };
 
 
+typedef struct {
+    ngx_uint_t          type;
+    ngx_str_t           value;
+} ngx_proxy_protocol_tlv_value_t;
+
+
 u_char *ngx_proxy_protocol_read(ngx_connection_t *c, u_char *buf,
     u_char *last);
 u_char *ngx_proxy_protocol_write(ngx_connection_t *c, u_char *buf,
@@ -34,6 +49,7 @@ u_char *ngx_proxy_protocol_v2_write(ngx_connection_t *c, u_char *buf,
     u_char *last, ngx_array_t *tlvs);
 ngx_int_t ngx_proxy_protocol_get_tlv(ngx_connection_t *c, ngx_str_t *name,
     ngx_str_t *value);
+ngx_int_t ngx_proxy_protocol_v2_tlv_type(ngx_str_t *s, ngx_uint_t *type);
 
 
 #endif /* _NGX_PROXY_PROTOCOL_H_INCLUDED_ */

--- a/src/mail/ngx_mail_proxy_module.c
+++ b/src/mail/ngx_mail_proxy_module.c
@@ -13,13 +13,14 @@
 
 
 typedef struct {
-    ngx_flag_t  enable;
-    ngx_flag_t  pass_error_message;
-    ngx_flag_t  xclient;
-    ngx_flag_t  smtp_auth;
-    ngx_uint_t  proxy_protocol;
-    size_t      buffer_size;
-    ngx_msec_t  timeout;
+    ngx_flag_t    enable;
+    ngx_flag_t    pass_error_message;
+    ngx_flag_t    xclient;
+    ngx_flag_t    smtp_auth;
+    ngx_uint_t    proxy_protocol;
+    ngx_array_t  *proxy_protocol_v2_tlvs;
+    size_t        buffer_size;
+    ngx_msec_t    timeout;
 } ngx_mail_proxy_conf_t;
 
 
@@ -38,6 +39,8 @@ static void ngx_mail_proxy_close_session(ngx_mail_session_t *s);
 static void *ngx_mail_proxy_create_conf(ngx_conf_t *cf);
 static char *ngx_mail_proxy_merge_conf(ngx_conf_t *cf, void *parent,
     void *child);
+static char *ngx_mail_proxy_protocol_v2_tlv(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
 
 
 static ngx_conf_enum_t  ngx_mail_proxy_protocol_versions[] = {
@@ -98,6 +101,13 @@ static ngx_command_t  ngx_mail_proxy_commands[] = {
       NGX_MAIL_SRV_CONF_OFFSET,
       offsetof(ngx_mail_proxy_conf_t, proxy_protocol),
       &ngx_mail_proxy_protocol_versions },
+
+    { ngx_string("proxy_protocol_v2_tlv"),
+      NGX_MAIL_MAIN_CONF|NGX_MAIL_SRV_CONF|NGX_CONF_TAKE2,
+      ngx_mail_proxy_protocol_v2_tlv,
+      NGX_MAIL_SRV_CONF_OFFSET,
+      0,
+      NULL },
 
       ngx_null_command
 };
@@ -914,11 +924,12 @@ ngx_mail_proxy_write_handler(ngx_event_t *wev)
 static ngx_int_t
 ngx_mail_proxy_send_proxy_protocol(ngx_mail_session_t *s)
 {
-    u_char            *p;
-    size_t             size;
-    ssize_t            n;
-    ngx_connection_t  *c;
-    static u_char      buf[NGX_PROXY_PROTOCOL_MAX_HEADER];
+    u_char                 *p;
+    size_t                  size;
+    ssize_t                 n;
+    ngx_connection_t       *c;
+    ngx_mail_proxy_conf_t  *pcf;
+    static u_char           buf[NGX_PROXY_PROTOCOL_MAX_HEADER];
 
     s->connection->log->action = "sending PROXY protocol header to upstream";
 
@@ -926,8 +937,10 @@ ngx_mail_proxy_send_proxy_protocol(ngx_mail_session_t *s)
                    "mail proxy send PROXY protocol header");
 
     if (s->proxy->proxy_protocol == 2) {
-        p = ngx_proxy_protocol_v2_write(s->connection, buf,
-                                        buf + sizeof(buf), NULL);
+        pcf = ngx_mail_get_module_srv_conf(s, ngx_mail_proxy_module);
+
+        p = ngx_proxy_protocol_v2_write(s->connection, buf, buf + sizeof(buf),
+                                        pcf->proxy_protocol_v2_tlvs);
 
     } else {
         p = ngx_proxy_protocol_write(s->connection, buf,
@@ -1402,6 +1415,7 @@ ngx_mail_proxy_create_conf(ngx_conf_t *cf)
     pcf->xclient = NGX_CONF_UNSET;
     pcf->smtp_auth = NGX_CONF_UNSET;
     pcf->proxy_protocol = NGX_CONF_UNSET_UINT;
+    pcf->proxy_protocol_v2_tlvs = NGX_CONF_UNSET_PTR;
     pcf->buffer_size = NGX_CONF_UNSET_SIZE;
     pcf->timeout = NGX_CONF_UNSET_MSEC;
 
@@ -1420,9 +1434,61 @@ ngx_mail_proxy_merge_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->xclient, prev->xclient, 1);
     ngx_conf_merge_value(conf->smtp_auth, prev->smtp_auth, 0);
     ngx_conf_merge_uint_value(conf->proxy_protocol, prev->proxy_protocol, 0);
+    ngx_conf_merge_ptr_value(conf->proxy_protocol_v2_tlvs,
+                             prev->proxy_protocol_v2_tlvs, NULL);
     ngx_conf_merge_size_value(conf->buffer_size, prev->buffer_size,
                               (size_t) ngx_pagesize);
     ngx_conf_merge_msec_value(conf->timeout, prev->timeout, 24 * 60 * 60000);
+
+    return NGX_CONF_OK;
+}
+
+
+static char *
+ngx_mail_proxy_protocol_v2_tlv(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_mail_proxy_conf_t *pcf = conf;
+
+    ngx_str_t                       *value;
+    ngx_uint_t                       i, type;
+    ngx_proxy_protocol_tlv_value_t  *tlv;
+
+    value = cf->args->elts;
+
+    if (ngx_proxy_protocol_v2_tlv_type(&value[1], &type) != NGX_OK) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid PROXY protocol v2 TLV type \"%V\", "
+                           "expected a two-digit hexadecimal number "
+                           "from \"0xe0\" to \"0xff\"", &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    if (pcf->proxy_protocol_v2_tlvs == NGX_CONF_UNSET_PTR) {
+        pcf->proxy_protocol_v2_tlvs = ngx_array_create(cf->pool, 4,
+                                       sizeof(ngx_proxy_protocol_tlv_value_t));
+        if (pcf->proxy_protocol_v2_tlvs == NULL) {
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    tlv = pcf->proxy_protocol_v2_tlvs->elts;
+
+    for (i = 0; i < pcf->proxy_protocol_v2_tlvs->nelts; i++) {
+        if (tlv[i].type == type) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "duplicate PROXY protocol v2 TLV type \"%V\"",
+                               &value[1]);
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    tlv = ngx_array_push(pcf->proxy_protocol_v2_tlvs);
+    if (tlv == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    tlv->type = type;
+    tlv->value = value[2];
 
     return NGX_CONF_OK;
 }

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -20,6 +20,12 @@ typedef struct {
 
 
 typedef struct {
+    ngx_uint_t                       type;
+    ngx_stream_complex_value_t       value;
+} ngx_stream_proxy_tlv_t;
+
+
+typedef struct {
     ngx_msec_t                       connect_timeout;
     ngx_msec_t                       timeout;
     ngx_msec_t                       next_upstream_timeout;
@@ -31,6 +37,7 @@ typedef struct {
     ngx_uint_t                       next_upstream_tries;
     ngx_flag_t                       next_upstream;
     ngx_uint_t                       proxy_protocol;
+    ngx_array_t                     *proxy_protocol_v2_tlvs;
     ngx_flag_t                       half_close;
     ngx_stream_upstream_local_t     *local;
     ngx_flag_t                       socket_keepalive;
@@ -70,6 +77,8 @@ static ngx_int_t ngx_stream_proxy_eval(ngx_stream_session_t *s,
 static ngx_int_t ngx_stream_proxy_set_local(ngx_stream_session_t *s,
     ngx_stream_upstream_t *u, ngx_stream_upstream_local_t *local);
 static void ngx_stream_proxy_connect(ngx_stream_session_t *s);
+static ngx_int_t ngx_stream_proxy_protocol_v2_tlvs(ngx_stream_session_t *s,
+    ngx_array_t **tlvs);
 static void ngx_stream_proxy_init_upstream(ngx_stream_session_t *s);
 static void ngx_stream_proxy_resolve_handler(ngx_resolver_ctx_t *ctx);
 static void ngx_stream_proxy_upstream_handler(ngx_event_t *ev);
@@ -94,6 +103,8 @@ static char *ngx_stream_proxy_pass(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static char *ngx_stream_proxy_bind(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+static char *ngx_stream_proxy_protocol_v2_tlv(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
 
 #if (NGX_STREAM_SSL)
 
@@ -280,6 +291,13 @@ static ngx_command_t  ngx_stream_proxy_commands[] = {
       NGX_STREAM_SRV_CONF_OFFSET,
       offsetof(ngx_stream_proxy_srv_conf_t, proxy_protocol),
       &ngx_stream_proxy_protocol_versions },
+
+    { ngx_string("proxy_protocol_v2_tlv"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE2,
+      ngx_stream_proxy_protocol_v2_tlv,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      0,
+      NULL },
 
     { ngx_string("proxy_half_close"),
       NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_FLAG,
@@ -851,11 +869,58 @@ ngx_stream_proxy_connect(ngx_stream_session_t *s)
 }
 
 
+static ngx_int_t
+ngx_stream_proxy_protocol_v2_tlvs(ngx_stream_session_t *s, ngx_array_t **tlvs)
+{
+    ngx_uint_t                       i, n;
+    ngx_array_t                     *a;
+    ngx_stream_proxy_tlv_t          *t;
+    ngx_stream_proxy_srv_conf_t     *pscf;
+    ngx_proxy_protocol_tlv_value_t  *tlv;
+
+    *tlvs = NULL;
+
+    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+
+    if (pscf->proxy_protocol_v2_tlvs == NULL) {
+        return NGX_OK;
+    }
+
+    n = pscf->proxy_protocol_v2_tlvs->nelts;
+
+    a = ngx_array_create(s->connection->pool, n,
+                         sizeof(ngx_proxy_protocol_tlv_value_t));
+    if (a == NULL) {
+        return NGX_ERROR;
+    }
+
+    t = pscf->proxy_protocol_v2_tlvs->elts;
+
+    for (i = 0; i < n; i++) {
+        tlv = ngx_array_push(a);
+        if (tlv == NULL) {
+            return NGX_ERROR;
+        }
+
+        tlv->type = t[i].type;
+
+        if (ngx_stream_complex_value(s, &t[i].value, &tlv->value) != NGX_OK) {
+            return NGX_ERROR;
+        }
+    }
+
+    *tlvs = a;
+
+    return NGX_OK;
+}
+
+
 static void
 ngx_stream_proxy_init_upstream(ngx_stream_session_t *s)
 {
     u_char                       *p;
     size_t                        size;
+    ngx_array_t                  *tlvs;
     ngx_chain_t                  *cl;
     ngx_connection_t             *c, *pc;
     ngx_log_handler_pt            handler;
@@ -967,7 +1032,12 @@ ngx_stream_proxy_init_upstream(ngx_stream_session_t *s)
                        "stream proxy add PROXY protocol header");
 
         if (u->proxy_protocol == 2) {
-            p = ngx_proxy_protocol_v2_write(c, buf, buf + sizeof(buf), NULL);
+            if (ngx_stream_proxy_protocol_v2_tlvs(s, &tlvs) != NGX_OK) {
+                ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+                return;
+            }
+
+            p = ngx_proxy_protocol_v2_write(c, buf, buf + sizeof(buf), tlvs);
 
         } else {
             p = ngx_proxy_protocol_write(c, buf, buf + sizeof(buf));
@@ -1032,6 +1102,7 @@ ngx_stream_proxy_send_proxy_protocol(ngx_stream_session_t *s)
     u_char                       *p;
     size_t                        size;
     ssize_t                       n;
+    ngx_array_t                  *tlvs;
     ngx_connection_t             *c, *pc;
     ngx_stream_upstream_t        *u;
     ngx_stream_proxy_srv_conf_t  *pscf;
@@ -1045,7 +1116,12 @@ ngx_stream_proxy_send_proxy_protocol(ngx_stream_session_t *s)
     u = s->upstream;
 
     if (u->proxy_protocol == 2) {
-        p = ngx_proxy_protocol_v2_write(c, buf, buf + sizeof(buf), NULL);
+        if (ngx_stream_proxy_protocol_v2_tlvs(s, &tlvs) != NGX_OK) {
+            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+            return NGX_ERROR;
+        }
+
+        p = ngx_proxy_protocol_v2_write(c, buf, buf + sizeof(buf), tlvs);
 
     } else {
         p = ngx_proxy_protocol_write(c, buf, buf + sizeof(buf));
@@ -2428,6 +2504,7 @@ ngx_stream_proxy_create_srv_conf(ngx_conf_t *cf)
     conf->next_upstream_tries = NGX_CONF_UNSET_UINT;
     conf->next_upstream = NGX_CONF_UNSET;
     conf->proxy_protocol = NGX_CONF_UNSET_UINT;
+    conf->proxy_protocol_v2_tlvs = NGX_CONF_UNSET_PTR;
     conf->local = NGX_CONF_UNSET_PTR;
     conf->socket_keepalive = NGX_CONF_UNSET;
     conf->socket_rcvbuf = NGX_CONF_UNSET_SIZE;
@@ -2487,6 +2564,9 @@ ngx_stream_proxy_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->next_upstream, prev->next_upstream, 1);
 
     ngx_conf_merge_uint_value(conf->proxy_protocol, prev->proxy_protocol, 0);
+
+    ngx_conf_merge_ptr_value(conf->proxy_protocol_v2_tlvs,
+                             prev->proxy_protocol_v2_tlvs, NULL);
 
     ngx_conf_merge_ptr_value(conf->local, prev->local, NULL);
 
@@ -2898,6 +2978,68 @@ ngx_stream_proxy_bind(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
                                "invalid parameter \"%V\"", &value[2]);
             return NGX_CONF_ERROR;
         }
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+static char *
+ngx_stream_proxy_protocol_v2_tlv(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_stream_proxy_srv_conf_t *pscf = conf;
+
+    ngx_str_t                          *value;
+    ngx_uint_t                          i, type;
+    ngx_stream_proxy_tlv_t             *tlv;
+    ngx_stream_compile_complex_value_t  ccv;
+
+    value = cf->args->elts;
+
+    if (ngx_proxy_protocol_v2_tlv_type(&value[1], &type) != NGX_OK) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid PROXY protocol v2 TLV type \"%V\", "
+                           "expected a two-digit hexadecimal number "
+                           "from \"0xe0\" to \"0xff\"", &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    if (pscf->proxy_protocol_v2_tlvs == NGX_CONF_UNSET_PTR) {
+        pscf->proxy_protocol_v2_tlvs = ngx_array_create(cf->pool, 4,
+                                          sizeof(ngx_stream_proxy_tlv_t));
+        if (pscf->proxy_protocol_v2_tlvs == NULL) {
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    tlv = pscf->proxy_protocol_v2_tlvs->elts;
+
+    for (i = 0; i < pscf->proxy_protocol_v2_tlvs->nelts; i++) {
+        if (tlv[i].type == type) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "duplicate PROXY protocol v2 TLV type \"%V\"",
+                               &value[1]);
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    tlv = ngx_array_push(pscf->proxy_protocol_v2_tlvs);
+    if (tlv == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    ngx_memzero(tlv, sizeof(ngx_stream_proxy_tlv_t));
+
+    tlv->type = type;
+
+    ngx_memzero(&ccv, sizeof(ngx_stream_compile_complex_value_t));
+
+    ccv.cf = cf;
+    ccv.value = &value[2];
+    ccv.complex_value = &tlv->value;
+
+    if (ngx_stream_compile_complex_value(&ccv) != NGX_OK) {
+        return NGX_CONF_ERROR;
     }
 
     return NGX_CONF_OK;


### PR DESCRIPTION
## Problem

Since 1.31.4 nginx can now speak proxy protocol v2 to upstreams in Stream and Mail ([#1204](https://github.com/nginx/nginx/pull/1204)). But setting custom TLS has not been yet implemented

## Solution

Add `proxy_protocol_v2_tlv <type> <value>;` directive in both stream and mail proxy module:
* `type` can only be set in hexadecimal format from 0xE0 to 0xFF
* in stream the value is evaluated while not in mail

The code has been done using claude.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [X] Manual Testing
- [X] Functional Testing (https://github.com/nginx/nginx-tests/pull/110) 

## Checklist

Before submitting this PR, please confirm:

- [X] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [X] I have added tests (if applicable) to validate my changes
- [X] All existing tests pass
- [X] I have updated documentation where necessary --> https://github.com/nginx/nginx.org/pull/312
- [X] My branch is rebased on the latest master
- [X] This PR targets the master branch from my fork
- [X] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes