### PR TITLE
Core: refuse to resume a JSON parse inside a token

### DIFF
--- a/src/core/ngx_json_parse.c
+++ b/src/core/ngx_json_parse.c
@@ -52,6 +52,7 @@ ngx_json_ctx_init(ngx_json_ctx_t *ctx, ngx_pool_t *pool)
     ctx->stack = NULL;
 
     ctx->in_key = 0;
+    ctx->incomplete = 0;
 }
 
 
@@ -68,6 +69,18 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
     }
 
     if (data == NULL) {
+        return NGX_ERROR;
+    }
+
+    /*
+     * A token is emitted as a pointer into the buffer it was read from, so
+     * the previous call must not have ended inside one: "start" would refer
+     * to a buffer that is no longer ours, and the length computed against
+     * the new buffer would be meaningless.  Refuse instead of emitting a
+     * token the caller cannot use.
+     */
+
+    if (ctx->incomplete) {
         return NGX_ERROR;
     }
 
@@ -653,6 +666,19 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
         }
 
         state = ngx_json_done;
+
+        /*
+         * The number was terminated by the end of the buffer rather than by
+         * a delimiter, so it is only complete if this was the whole input.
+         * Mark the context so that a caller that has more to feed is told
+         * the value it just received was truncated.
+         */
+
+        ctx->incomplete = 1;
+    }
+
+    if (ngx_json_in_token(state)) {
+        ctx->incomplete = 1;
     }
 
     ctx->state = state;

--- a/src/core/ngx_json_parse.h
+++ b/src/core/ngx_json_parse.h
@@ -41,6 +41,14 @@ typedef enum {
     ngx_json_object_value_separator,
     ngx_json_array_value_separator,
     ngx_json_array,
+
+    /*
+     * All states from here on are "inside a token", that is, the parser
+     * holds a pointer into the caller's buffer (the local "start") that it
+     * will need later to emit the token.  ngx_json_in_token() below relies
+     * on that; keep new token states after this point.
+     */
+
     ngx_json_string,
     ngx_json_number_minus,
     ngx_json_number_int,
@@ -99,7 +107,19 @@ struct ngx_json_ctx_s {
     void                  *data;
 
     unsigned               in_key; /* unsigned in_key:1 */
+
+    /*
+     * Set when the previous ngx_json_parse_ctx() call ended in the middle
+     * of a token.  A token is emitted as a pointer into the buffer it was
+     * read from, so it cannot span two calls; resuming would emit a token
+     * pointing into a buffer the caller may already have released.
+     */
+
+    unsigned               incomplete:1;
 };
+
+
+#define ngx_json_in_token(state)   ((state) >= ngx_json_string)
 
 
 void ngx_json_ctx_init(ngx_json_ctx_t *ctx, ngx_pool_t *pool);


### PR DESCRIPTION
### Problem

`ngx_json_parse_ctx()` stores everything needed to resume a parse in
`ngx_json_ctx_t` — except the offset where the current token started, which is a
local (`start`) reset to `NULL` on entry. If a call returns with the parser
inside a token, the next call computes the token as `p - NULL`.

The handler is then invoked with `data = NULL` and a length of roughly 88 TB,
and the parser returns `NGX_OK` — so a caller has no way to tell that the value
it just received is not a value.

### Reachability

Not reachable from the tree today: `ngx_json_parse()`, the only in-tree caller,
hands over the whole document in one call, and `ngx_http_json_module` goes
through it.

It is an API-level defect rather than a live bug, and I am proposing it on that
basis. `ngx_json_parse_ctx()` is exported specifically for incremental use, and
the natural first such caller — streaming a request body through the parser —
hits this on the first token that straddles two buffers. Closing it before that
caller exists seemed better than after.

### Fix

One bit in the context, set when a call ends inside a token, checked on entry.
Resuming into a token returns `NGX_ERROR` instead of emitting a token that
points into a buffer the caller may already have released.

The token states are already contiguous at the end of the state enum, so the
test is a single comparison; I added a comment there so the property is not
broken by a later insertion.

### Testing

- Differential test against the unpatched parser over 4025 documents / 124 733
  events: output byte-identical, so single-buffer behaviour is unchanged.
- The nginx test suite passes.
- A harness that feeds a document in `n`-byte chunks reports `NGX_ERROR` at the
  first split token with the patch, and the `NULL` / 88 TB token without it.
