### PR TITLE
HTTP/3: avoid undefined behaviour with empty encoder field values

### DIFF
--- a/src/http/v3/ngx_http_v3_parse.c
+++ b/src/http/v3/ngx_http_v3_parse.c
@@ -1543,7 +1543,7 @@ ngx_http_v3_parse_field_inr(ngx_connection_t *c,
 
             st->literal.length = st->pint.value;
             if (st->literal.length == 0) {
-                st->value.len = 0;
+                ngx_str_set(&st->value, "");
                 goto done;
             }
 
@@ -1667,7 +1667,7 @@ ngx_http_v3_parse_field_iln(ngx_connection_t *c,
 
             st->literal.length = st->pint.value;
             if (st->literal.length == 0) {
-                st->value.len = 0;
+                ngx_str_set(&st->value, "");
                 goto done;
             }
 


### PR DESCRIPTION
### Problem

Five places in `ngx_http_v3_parse.c` short-circuit a field whose value length is
zero. Three of them set `st->value.data`; two set only `st->value.len`:

```c
/* _lri, _l, _lpbi -- request field lines */
    if (st->literal.length == 0) {
        st->value.data = (u_char *) "";
        goto done;
    }

/* _inr, _iln -- QPACK encoder stream */
    if (st->literal.length == 0) {
        st->value.len = 0;
        goto done;
    }
```

Each half relies on the other member already being right. On the request path
that holds, because `ngx_http_v3_parse_field_rep()` does
`ngx_memzero(&st->field, sizeof(ngx_http_v3_parse_field_t))` before every field
representation. `ngx_http_v3_parse_encoder()` has no such line — field state
persists across instructions on the encoder stream — so there `st->value.data`
is whatever the previous instruction left, and `NULL` on the first one.

It reaches `ngx_http_v3_table.c:258`:

```c
    ngx_memcpy(field->value.data, value->data, value->len);
```

### Impact

Low, and I would rather state it precisely than dress it up. No memory is
touched, because the length is zero, and there is no subsequent `NULL` check for
a compiler to delete. What it does cost:

- `memcpy(dst, NULL, 0)` is undefined behaviour (C11 7.24.1p2 requires valid
  pointers regardless of `n`), and glibc declares `memcpy` `nonnull` — so anyone
  running nginx under UBSan (CI, hardened distro builds, fuzzing) gets a report
  from ordinary HTTP/3 traffic.
- The five sites disagree with each other, and the two that are wrong are
  exactly the two whose caller does not zero the state. Any later change that
  reads `st->value` on the encoder path, or that copies the encoder-stream
  shortcut, inherits a stale or `NULL` pointer.

Reachable by any HTTP/3 client with no unusual configuration: open the QPACK
encoder stream and send an insert instruction with a zero-length value.

### Fix

Set the value on the two encoder-stream paths, using `ngx_str_set()` so that
both members are set in one place:

```c
    if (st->literal.length == 0) {
        ngx_str_set(&st->value, "");
        goto done;
    }
```

The three request-path sites are left alone: their caller zeroes the field
state, so neither member is stale there.

Both members matter on the encoder path. `.data` is the fix; the length must
stay 0 so that a length inherited from a previous instruction cannot turn the
empty string literal into an out-of-bounds read of `.rodata`. `ngx_str_set()`
sets the two together, which is why it is the right form here rather than two
assignments that can be separately mistaken for redundant.

### Reproducing

A minimal encoder stream that triggers it — stream type 2, set capacity, then
"Insert With Literal Name" with a zero-length value:

```
02                stream type: QPACK encoder
3f 21             Set Dynamic Table Capacity = 64
63 63 63 ff       Insert With Literal Name, 3-byte Huffman name, value len 0
```

Against an ASan+UBSan build, before the patch:

```
src/http/v3/ngx_http_v3_table.c:258:5: runtime error: null pointer passed as
    argument 2, which is declared to never be null
    #0 ngx_http_v3_insert          ngx_http_v3_table.c:258:5
    #1 ngx_http_v3_parse_field_iln ngx_http_v3_parse.c:1695:10
    #2 ngx_http_v3_parse_encoder   ngx_http_v3_parse.c:1432:18
    #3 ngx_http_v3_parse_uni       ngx_http_v3_parse.c:1954:20
```

Silent with the patch. Found with a libFuzzer harness over
`ngx_http_v3_parse_uni()`.

