### PR TITLE
Core: avoid signed overflow when assembling DNS TTLs

### DIFF
--- a/src/core/ngx_resolver.c
+++ b/src/core/ngx_resolver.c
@@ -2194,8 +2194,10 @@ ngx_resolver_process_a(ngx_resolver_t *r, u_char *buf, size_t n,
         type = (an->type_hi << 8) + an->type_lo;
         class = (an->class_hi << 8) + an->class_lo;
         len = (an->len_hi << 8) + an->len_lo;
-        ttl = (an->ttl[0] << 24) + (an->ttl[1] << 16)
-            + (an->ttl[2] << 8) + (an->ttl[3]);
+        ttl = (int32_t) (((uint32_t) an->ttl[0] << 24)
+                         + ((uint32_t) an->ttl[1] << 16)
+                         + ((uint32_t) an->ttl[2] << 8)
+                         + an->ttl[3]);
 
         if (class != 1) {
             ngx_log_error(r->log_level, r->log, 0,
@@ -2356,8 +2358,10 @@ ngx_resolver_process_a(ngx_resolver_t *r, u_char *buf, size_t n,
 
             if (type == NGX_RESOLVE_A) {
 
-                addr[j] = htonl((buf[i] << 24) + (buf[i + 1] << 16)
-                                + (buf[i + 2] << 8) + (buf[i + 3]));
+                addr[j] = htonl(((uint32_t) buf[i] << 24)
+                                + ((uint32_t) buf[i + 1] << 16)
+                                + ((uint32_t) buf[i + 2] << 8)
+                                + buf[i + 3]);
 
                 if (++j == naddrs) {
 
@@ -2736,8 +2740,10 @@ ngx_resolver_process_srv(ngx_resolver_t *r, u_char *buf, size_t n,
         type = (an->type_hi << 8) + an->type_lo;
         class = (an->class_hi << 8) + an->class_lo;
         len = (an->len_hi << 8) + an->len_lo;
-        ttl = (an->ttl[0] << 24) + (an->ttl[1] << 16)
-            + (an->ttl[2] << 8) + (an->ttl[3]);
+        ttl = (int32_t) (((uint32_t) an->ttl[0] << 24)
+                         + ((uint32_t) an->ttl[1] << 16)
+                         + ((uint32_t) an->ttl[2] << 8)
+                         + an->ttl[3]);
 
         if (class != 1) {
             ngx_log_error(r->log_level, r->log, 0,
@@ -3301,8 +3307,10 @@ valid:
         type = (an->type_hi << 8) + an->type_lo;
         class = (an->class_hi << 8) + an->class_lo;
         len = (an->len_hi << 8) + an->len_lo;
-        ttl = (an->ttl[0] << 24) + (an->ttl[1] << 16)
-            + (an->ttl[2] << 8) + (an->ttl[3]);
+        ttl = (int32_t) (((uint32_t) an->ttl[0] << 24)
+                         + ((uint32_t) an->ttl[1] << 16)
+                         + ((uint32_t) an->ttl[2] << 8)
+                         + an->ttl[3]);
 
         if (class != 1) {
             ngx_log_error(r->log_level, r->log, 0,


### PR DESCRIPTION
### Problem

Four places in `ngx_resolver.c` assemble a 32-bit value from four response bytes
without making the arithmetic unsigned:

```c
    ttl = (an->ttl[0] << 24) + (an->ttl[1] << 16)
        + (an->ttl[2] << 8) + (an->ttl[3]);
```

`an->ttl[0]` is a `u_char` and promotes to `int`, so any TTL with the top bit set
shifts a value of at least 128 left by 24 places — undefined behaviour per C11
6.5.7p4, not implementation-defined. The A record address is built the same way,
so any address in `128.0.0.0/1` reaches it too.

| file:line | function | reached via |
|---|---|---|
| `ngx_resolver.c:2197` | `ngx_resolver_process_a` | TTL of any A/AAAA answer |
| `ngx_resolver.c:2359` | `ngx_resolver_process_a` | A record in `128.0.0.0/1` |
| `ngx_resolver.c:2739` | `ngx_resolver_process_srv` | TTL of any SRV answer |
| `ngx_resolver.c:3304` | `ngx_resolver_process_ptr` | TTL of any PTR answer |

Present in any configuration with a `resolver` directive. These are old —
`git log -L` dates the first to bec516bec (2011) and the other three to 2015.

### Why fix it

**I am not claiming a working exploit, and on the compilers nginx ships against
today the behaviour is correct.** gcc and clang wrap, `ttl` comes out negative,
and the `ttl < 0` guard immediately below catches it.

The reason to fix it is that guard. The only way `ttl` can be negative is
through the overflow the standard says cannot happen, so a compiler doing
value-range propagation is entitled to conclude `ttl >= 0` and delete the check.
That is the canonical VRP transformation, not a hypothetical one.

If the check goes, the value flows straight into the cache lifetime:

```
  :901   rn->ttl = NGX_MAX_UINT32_VALUE;
  :2210  rn->ttl = ngx_min(rn->ttl, (uint32_t) ttl);
  :2445  rn->valid = ngx_time() + (r->valid ? r->valid : (time_t) rn->ttl);
```

A TTL of `0x80000000` becomes `-2147483648`; `(uint32_t)` of that is
`2147483648`; `ngx_min()` keeps it — an entry trusted for about 68 years. So the
guard is load-bearing for how long a resolver answer is believed, and it is
reachable only through undefined behaviour. That makes this hardening.

### Fix

Make the arithmetic unsigned, which is what the rest of the tree already does —
`ngx_inet.c:510`, `ngx_stream_geo_module.c:194`, `ngx_stream_access_module.c:147`
all write `(in_addr_t) p[12] << 24`, and `ngx_http_grpc_module.c` writes
`(ngx_uint_t) ch << 24`. A sweep of every `<< 24` in the tree finds no other
uncast site: the eight hits in `ngx_http_parse.c` are the method-matching
macros, whose operands are ASCII constants below 128. The resolver is the only
place that departs from the convention.

Converting back to `int32_t` for a value above `INT32_MAX` is
implementation-defined rather than undefined, and gcc and clang define it as the
wrap that happens today — so the `ttl < 0` guard keeps firing on exactly the
same inputs and observable behaviour is unchanged, but the compiler can no
longer reason it away.

For the address the cast is the whole fix, since `htonl()` takes a `uint32_t`.

### Testing

- Found with a libFuzzer harness driving `ngx_resolver_process_response()` under
  UBSan. Before: `left shift of 185 by 24 places cannot be represented in type
  'int'` at :2197, and the same at :2359 and :2739. After: silent over a further
  6.4M executions, no crash.
- Coverage is unchanged at 1202 edges, so the fix does not close off any path.
- `resolver.t`, `upstream_resolver.t`, `upstream_resolve.t`,
  `upstream_resolve_reload.t`, `stream_resolver.t`, `proxy_ssl_name.t` — 60
  tests, all pass, no sanitizer output.

`ngx_resolver_process_ptr` at :3304 is the same expression on the same input and
was not separately triggered by the corpus, since the PTR path needs a matching
entry in the address rbtree.
