### PR TITLE
JSON: reject CR and LF in a decoded json_set value

### DIFF
--- a/src/http/modules/ngx_http_json_module.c
+++ b/src/http/modules/ngx_http_json_module.c
@@ -915,6 +915,30 @@ ngx_http_json_store(ngx_http_json_state_t *state, ngx_http_json_node_t *node,
         if (unescape && ngx_json_unescape_string(&val) != NGX_OK) {
             return NGX_ERROR;
         }
+
+        /*
+         * A decoded JSON string may contain raw CR or LF, written either as the
+         * two-character escapes or as the \u000d / \u000a forms.  Unlike
+         * $http_* or $arg_*, whose sources the request parser keeps CRLF-free,
+         * such a value would inject into the header block if the json_set
+         * variable is used in add_header or proxy_set_header.  Refuse those
+         * bytes here: the variable resolves as not found rather than carrying
+         * the CRLF onward.
+         */
+        if (ngx_strlchr(val.data, val.data + val.len, CR) != NULL
+            || ngx_strlchr(val.data, val.data + val.len, LF) != NULL)
+        {
+            ngx_log_error(NGX_LOG_INFO, state->r->connection->log, 0,
+                          "json_set: rejected CR/LF in decoded value");
+
+            for (i = 0; i < node->ndests; i++) {
+                slot = &state->values[node->dests[i]];
+                slot->valid = 0;
+                slot->not_found = 1;
+            }
+
+            return NGX_OK;
+        }
     }
 
     for (i = 0; i < node->ndests; i++) {


### PR DESCRIPTION
### Problem

`ngx_http_json_store()` unescapes a JSON string and hands the result straight to
the variable machinery:

```c
        if (unescape && ngx_json_unescape_string(&val) != NGX_OK) {
            return NGX_ERROR;
        }
    }

    for (i = 0; i < node->ndests; i++) {
        slot = &state->values[node->dests[i]];
        ...
        slot->len = val.len;
        slot->data = val.data;
    }
```

A JSON string may contain CR and LF — as the two-character escapes, or as the
six-character Unicode escape forms for U+000D and U+000A. The unescaper turns
those into raw `0x0d` / `0x0a` bytes, and nothing filters them out.

So a `json_set` variable can carry CRLF. That makes it different from every other
attacker-influenced variable source in nginx: `$http_*`, `$arg_*` and
`$request_*` all come through the request parser, which makes an embedded CR or
LF impossible. Code downstream of a variable is entitled to assume what the rest
of the tree guarantees.

### Impact

Put such a variable into a header-producing directive and it splits the header
block. Reshaping JSON into headers is the module's headline use, so both sinks
are realistic:

- **Into the client response** (`add_header $v`, `return`) — response splitting:
  everything after the double CRLF is attacker-controlled body. Reflected XSS on
  the site's origin, cache poisoning if a CDN or `proxy_cache` stores the split
  response, injected `Set-Cookie`, or a weakened CSP / `Access-Control-Allow-Origin`.
- **Into the upstream request** (`proxy_set_header X $v`, `fastcgi_param`) —
  header injection towards the backend: spoofing `X-Forwarded-For` or an identity
  header the backend trusts because it came from the proxy, or injecting a
  `Content-Length` / `Transfer-Encoding` to desync nginx and the upstream.

The request is entirely printable ASCII — the payload lives in JSON escapes — so
no control byte appears on the wire, and a WAF grepping for raw CRLF does not see
it.

**Nothing released is affected**, which is why this is an ordinary pull request
and not a security report: `ngx_http_json_module` and `ngx_json_unescape.c` are
not in `release-1.31.4` or any earlier tag, and `json_set` does not exist in any
released nginx. This is worth closing before the module ships, not after.

### Proof of concept

```nginx
location /t {
    json_set $inj $http_x_json .x;
    add_header X-Echo $inj;
    return 200 "ok";
}
```

Sending a JSON value of `legit`, CRLF, `Injected-Header: pwned`, CRLF CRLF (all
written as JSON escapes) in the `X-Json` request header, against the stock
module:

```
  b'HTTP/1.1 200 OK'
  ...
  b'X-Echo: legit'
  b'Injected-Header: pwned'      <-- attacker's own header line
```

`Injected-Header` comes out as a distinct header line. With the patch there is no
`X-Echo` and no injected line, and the log shows
`json_set: rejected CR/LF in decoded value`.

### Fix, and the alternatives

The patch rejects CR/LF in `ngx_http_json_store()` after unescaping: the
destination variables are marked not found, so the value is not carried onward.

I want to be explicit that this is a policy choice, and I do not assume it is the
one you want. Rejecting at the parser is arguably wrong for a `json_set` value
that is *not* header-bound — a value extracted for a log field or a request body
can legitimately contain newlines. Three defensible resolutions:

1. **Document the constraint** — state that a `json_set` variable, unlike
   `$http_*`, may contain CR/LF, so using one in a header without an intermediate
   check is unsafe. Least surprising, and matches how nginx treats this class
   elsewhere.
2. **Reject at the sink** — filter when a variable is emitted into a header. The
   correct layer, but a larger change touching the header filters.
3. **Reject at the source** — this patch. Simplest, closes the common case, at
   the cost of the non-header uses above.

I implemented 3 because it is the smallest concrete thing to review. The finding
stands whichever you pick, and I am happy to redo it as 1 or 2.

### Testing

- The proof of concept above, before and after the patch.
- Build with `--with-http_json_module` under `-Werror`, and an ASan+UBSan build.
- The nginx test suite passes.
