### PR TITLE
Core: scan runs of ordinary bytes in the JSON parser

### DIFF
--- a/src/core/ngx_json_parse.c
+++ b/src/core/ngx_json_parse.c
@@ -20,8 +20,11 @@
 #define NGX_JSON_NOT_SKIPPING  (ngx_uint_t) -1
 #define ngx_json_skipping(d)   ((d) != NGX_JSON_NOT_SKIPPING)
 #define ngx_json_ws(c)  ((c) == ' ' || (c) == '\t' || (c) == CR || (c) == LF)
+#define ngx_json_digit(c)  ((c) >= '0' && (c) <= '9')
 
 
+static ngx_inline u_char *ngx_json_skip_ws(u_char *p, u_char *last);
+static ngx_inline u_char *ngx_json_skip_digits(u_char *p, u_char *last);
 static ngx_inline ngx_int_t ngx_json_end_number(ngx_json_ctx_t *ctx,
     u_char *start, u_char *end, ngx_json_state_e *state);
 static ngx_inline ngx_int_t ngx_json_emit(ngx_json_ctx_t *ctx,
@@ -31,6 +34,66 @@ static ngx_inline ngx_int_t ngx_json_close(ngx_json_ctx_t *ctx,
     ngx_json_event_e event, ngx_json_state_e *state, u_char *p);
 static ngx_int_t ngx_json_push_state(ngx_json_ctx_t *ctx,
     ngx_json_container_e container);
+
+
+/*
+ * Bytes that end a run of ordinary string characters: the closing quote,
+ * the escape character, and the control characters, which RFC 8259 requires
+ * to be escaped.  Everything else is copied through, so a string can be
+ * scanned in bulk rather than one state machine round per byte.
+ */
+
+static const uint8_t  ngx_json_string_stop[256] = {
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  /* 0x00 - 0x0f */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  /* 0x10 - 0x1f */
+    0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 0x20 - 0x2f  "  */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 0x30 - 0x3f */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 0x40 - 0x4f */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,  /* 0x50 - 0x5f  \  */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 0x60 - 0x6f */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 0x70 - 0x7f */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+
+/*
+ * Insignificant whitespace comes in runs (indentation, "key" : value), and
+ * none of it changes the state.  Consume the whole run at the point where a
+ * state has already accepted the first whitespace byte, so that indented
+ * documents do not pay a switch dispatch per space.  The digit runs that
+ * make up the bulk of a number are handled the same way.
+ *
+ * Both look at p[1] and stop before last, so the caller's p++ still lands on
+ * the byte after the run.
+ */
+
+static ngx_inline u_char *
+ngx_json_skip_ws(u_char *p, u_char *last)
+{
+    while (p + 1 < last && ngx_json_ws(p[1])) {
+        p++;
+    }
+
+    return p;
+}
+
+
+static ngx_inline u_char *
+ngx_json_skip_digits(u_char *p, u_char *last)
+{
+    while (p + 1 < last && ngx_json_digit(p[1])) {
+        p++;
+    }
+
+    return p;
+}
 
 
 void
@@ -100,6 +163,7 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
 
         case ngx_json_start:
             if (ngx_json_ws(*p)) {
+                p = ngx_json_skip_ws(p, last);
                 break;
             }
 
@@ -109,6 +173,7 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
 
         case ngx_json_object:
             if (ngx_json_ws(*p)) {
+                p = ngx_json_skip_ws(p, last);
                 break;
             }
 
@@ -125,6 +190,7 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
 
         case ngx_json_object_next:
             if (ngx_json_ws(*p)) {
+                p = ngx_json_skip_ws(p, last);
                 break;
             }
 
@@ -139,6 +205,7 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
 
         case ngx_json_object_name_separator:
             if (ngx_json_ws(*p)) {
+                p = ngx_json_skip_ws(p, last);
                 break;
             }
 
@@ -151,6 +218,7 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
 
         case ngx_json_object_value_separator:
             if (ngx_json_ws(*p)) {
+                p = ngx_json_skip_ws(p, last);
                 break;
             }
 
@@ -172,6 +240,7 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
 
         case ngx_json_array_value_separator:
             if (ngx_json_ws(*p)) {
+                p = ngx_json_skip_ws(p, last);
                 break;
             }
 
@@ -193,6 +262,7 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
 
         case ngx_json_array:
             if (ngx_json_ws(*p)) {
+                p = ngx_json_skip_ws(p, last);
                 break;
             }
 
@@ -209,6 +279,7 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
 
         case ngx_json_value:
             if (ngx_json_ws(*p)) {
+                p = ngx_json_skip_ws(p, last);
                 break;
             }
 
@@ -284,6 +355,22 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
             return NGX_DECLINED;
 
         case ngx_json_string:
+
+            /*
+             * Ordinary characters are the bulk of a string, and none of them
+             * changes the state.  Run over them here instead of paying a
+             * switch dispatch per byte.
+             */
+
+            while (!ngx_json_string_stop[*p] && p + 1 < last) {
+                p++;
+            }
+
+            if (!ngx_json_string_stop[*p]) {
+                /* ordinary character at the end of the buffer */
+                break;
+            }
+
             if (*p == '"') {
 
                 if (ctx->in_key) {
@@ -444,7 +531,8 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
             break;
 
         case ngx_json_number_int:
-            if (*p >= '0' && *p <= '9') {
+            if (ngx_json_digit(*p)) {
+                p = ngx_json_skip_digits(p, last);
                 break;
             }
 
@@ -477,7 +565,8 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
             return NGX_DECLINED;
 
         case ngx_json_number_frac_digit:
-            if (*p >= '0' && *p <= '9') {
+            if (ngx_json_digit(*p)) {
+                p = ngx_json_skip_digits(p, last);
                 break;
             }
 
@@ -517,7 +606,8 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
             return NGX_DECLINED;
 
         case ngx_json_number_exp_digit:
-            if (*p >= '0' && *p <= '9') {
+            if (ngx_json_digit(*p)) {
+                p = ngx_json_skip_digits(p, last);
                 break;
             }
 
@@ -630,6 +720,7 @@ ngx_json_parse_ctx(ngx_json_ctx_t *ctx, u_char *data, size_t len)
 
         case ngx_json_done:
             if (ngx_json_ws(*p)) {
+                p = ngx_json_skip_ws(p, last);
                 break;
             }
 


### PR DESCRIPTION
### What

`ngx_json_parse_ctx()` runs its `switch` once per input byte. That is the right
shape for the bytes that actually drive the state machine — braces, commas,
quotes — but those are a small minority of a JSON document. String contents,
indentation and digits do not change the state, and each one currently pays a
loop iteration, a bounds test, a reload of `ctx->skip_until_depth`, a switch
dispatch and two to four comparisons.

Three groups of states consume runs: `ngx_json_string`, the nine states that
accept insignificant whitespace, and the three that accept digits. Consuming the
whole run where the state has already accepted its first byte removes the
per-byte overhead without changing what the parser accepts or emits.

### Measurements

1 MiB documents, best of 25 runs, `-O2`, pinned to one core. The handler is a
counter, so what is measured is the state machine. Run-to-run spread on this
machine is under 2%.

| document | shape | before | after | |
|---|---|---|---|---|
| `mixed` | API payload: objects, arrays, short strings, numbers, bools | 515 MB/s | **730 MB/s** | 1.42x |
| `strings` | long string values, no escapes | 770 MB/s | **2351 MB/s** | 3.05x |
| `numbers` | array of `-123456.7890123e-12` | 543 MB/s | **738 MB/s** | 1.36x |
| `pretty` | indented, spaces around `:` | 524 MB/s | **1138 MB/s** | 2.17x |
| `escapes` | `\uXXXX`, surrogate pairs, short runs | 454 MB/s | **520 MB/s** | 1.15x |

`escapes` gains least, as expected — it is nearly all state transitions, so there
are no runs to skip. Nothing regresses.

### How

**Strings.** A 256-byte table marks the bytes that end a run of ordinary string
characters: the closing quote, the backslash, and the control characters RFC 8259
requires to be escaped. Everything else is copied through untouched, so the
parser advances over it in a tight loop:

```c
        case ngx_json_string:

            while (!ngx_json_string_stop[*p] && p + 1 < last) {
                p++;
            }

            if (!ngx_json_string_stop[*p]) {
                /* ordinary character at the end of the buffer */
                break;
            }

            if (*p == '"') {
```

The three original branches follow unchanged, and are now reached only for a byte
that is genuinely one of the three. A stop table is the idiom `ngx_http_parse.c`
already uses for the same job.

**Whitespace and digits.** Two macros next to the existing `ngx_json_ws()`,
applied at the nine sites that already accept a whitespace byte and the three
that already accept a digit. Both look at `p[1]` and stop before `last`, so the
outer loop's `p++` still lands on the byte after the run and the end-of-buffer
handling is untouched. Cost is zero when the run has length one, which is why
`escapes` does not regress.

### Correctness

Structural changes to a parser are worth distrusting, so this was checked
differentially rather than by inspection.

A corpus of 4025 documents — 4000 generated from a grammar biased toward the
shapes these paths touch (long strings, escapes and surrogate pairs, deep
nesting, digit runs, indentation) and then randomly mutated to cover invalid
input, plus 25 hand-written edge cases: a lone `"`, an unterminated string, a
control character inside a string, a high surrogate without its low surrogate, a
lone low surrogate, a 5000-byte string value, 60 levels of nesting, `00`, `01`,
`1.`, `1e`, `1e+`, `-0`, `0e0`, and a document with trailing data.

Each document was parsed by both builds under ASan and UBSan, dumping every event
as `name offset length` plus the return code:

```
$ diff /tmp/trace_old.txt /tmp/trace_opt.txt
$
```

124 733 events over the 4025 documents, byte-identical, including the offsets —
so not just the same tokens but the same positions and the same accept/reject
verdict on every malformed document. No ASan or UBSan report from either build.

`ngx_http_json_module` was additionally fuzzed through a live ASan worker after
the change: 480 000 requests, no crash, no sanitizer report.

### Note

This is independent in intent from #1700, but both touch `ngx_json_parse.c`.
Whichever lands second may need a trivial rebase, and I am happy to do it. #1700
is the correctness fix and should go first if you take both.
