### PR TITLE
Core: release the write lock atomically in rwlock downgrade

### DIFF
--- a/src/core/ngx_rwlock.c
+++ b/src/core/ngx_rwlock.c
@@ -101,7 +101,7 @@ void
 ngx_rwlock_downgrade(ngx_atomic_t *lock)
 {
     if (*lock == NGX_RWLOCK_WLOCK) {
-        *lock = 1;
+        (void) ngx_atomic_cmp_set(lock, NGX_RWLOCK_WLOCK, 1);
     }
 }
 


### PR DESCRIPTION
### What

`ngx_rwlock_downgrade()` releases the write lock and re-acquires it as a read
lock with a plain store:

```c
void
ngx_rwlock_downgrade(ngx_atomic_t *lock)
{
    if (*lock == NGX_RWLOCK_WLOCK) {
        *lock = 1;
    }
}
```

Every other exit from this lock goes through an atomic:

```c
ngx_rwlock_unlock():   (void) ngx_atomic_cmp_set(lock, NGX_RWLOCK_WLOCK, 0);
                       (void) ngx_atomic_fetch_add(lock, -1);
```

Under the generic `__sync_*` backend those are full barriers. `downgrade()` is
the one path that mutates the lock word with a plain, unordered store.

### Why it matters

A thread holding the write lock has, by definition, written data under it.
`downgrade()` is meant to keep that data visible as the thread transitions to a
reader and lets *other* readers in. With a plain store and no release barrier, on
a weakly ordered architecture — ARM64 and POWER, both supported nginx targets —
the compiler or CPU may make `*lock = 1` visible to another core before the
writes performed under the write lock. A reader that then observes the lock as
read-held can proceed on stale data.

On x86-64 this is masked: TSO gives every store release semantics, so the plain
store happens to be correct there. That is what makes it easy to miss — it passes
all testing on the common developer architecture.

### Status

Latent, not a live bug. `ngx_rwlock_downgrade()` has no callers anywhere in the
tree, so nothing is broken today. It is declared in `ngx_rwlock.h`, so the hazard
is loaded for the first caller — plausibly a future upstream-zone or shared-cache
path that wants a write-then-read critical section without dropping the lock.

Deleting the unused function is the obvious alternative; I kept and fixed it
because it preserves the API, but I have no attachment to that choice.

### Fix

`ngx_atomic_cmp_set()` is the same full-barrier primitive `ngx_rwlock_unlock()`
already uses for the write-unlock case, so the downgrade gets the same release
ordering as every other exit from the lock, with no new machinery.

### The codegen difference

Not practically triggerable — a weak-memory reordering window with no in-tree
caller — so the argument is by inspection, by consistency with the rest of the
file, and by the generated aarch64 code
(`clang --target=aarch64-linux-gnu -O2 -S`):

```
plain   *lock = 1;                 ->   str    x8, [x0]      ; plain store, no ordering
patched ngx_atomic_cmp_set()       ->   ldaxr  x9, [x0]      ; acquire
                                        stlxr  w9, x8, [x0]  ; store-RELEASE
```

The plain path emits `str`, with no release semantics. The patched path emits the
exclusive pair whose `stlxr` is a store-release. On x86-64 both lower to an
ordered store, which is why the defect is invisible there.
