### PR TITLE
Upstream: turn the round-robin lock wrappers into functions

### DIFF
--- a/src/http/ngx_http_upstream_round_robin.h
+++ b/src/http/ngx_http_upstream_round_robin.h
@@ -132,36 +132,51 @@ struct ngx_http_upstream_rr_peers_s {
 
 #if (NGX_HTTP_UPSTREAM_ZONE)
 
-#define ngx_http_upstream_rr_peers_rlock(peers)                               \
-                                                                              \
-    if (peers->shpool) {                                                      \
-        ngx_rwlock_rlock(&peers->rwlock);                                     \
+static ngx_inline void
+ngx_http_upstream_rr_peers_rlock(ngx_http_upstream_rr_peers_t *peers)
+{
+    if (peers->shpool) {
+        ngx_rwlock_rlock(&peers->rwlock);
     }
-
-#define ngx_http_upstream_rr_peers_wlock(peers)                               \
-                                                                              \
-    if (peers->shpool) {                                                      \
-        ngx_rwlock_wlock(&peers->rwlock);                                     \
-    }
-
-#define ngx_http_upstream_rr_peers_unlock(peers)                              \
-                                                                              \
-    if (peers->shpool) {                                                      \
-        ngx_rwlock_unlock(&peers->rwlock);                                    \
-    }
+}
 
 
-#define ngx_http_upstream_rr_peer_lock(peers, peer)                           \
-                                                                              \
-    if (peers->shpool) {                                                      \
-        ngx_rwlock_wlock(&peer->lock);                                        \
+static ngx_inline void
+ngx_http_upstream_rr_peers_wlock(ngx_http_upstream_rr_peers_t *peers)
+{
+    if (peers->shpool) {
+        ngx_rwlock_wlock(&peers->rwlock);
     }
+}
 
-#define ngx_http_upstream_rr_peer_unlock(peers, peer)                         \
-                                                                              \
-    if (peers->shpool) {                                                      \
-        ngx_rwlock_unlock(&peer->lock);                                       \
+
+static ngx_inline void
+ngx_http_upstream_rr_peers_unlock(ngx_http_upstream_rr_peers_t *peers)
+{
+    if (peers->shpool) {
+        ngx_rwlock_unlock(&peers->rwlock);
     }
+}
+
+
+static ngx_inline void
+ngx_http_upstream_rr_peer_lock(ngx_http_upstream_rr_peers_t *peers,
+    ngx_http_upstream_rr_peer_t *peer)
+{
+    if (peers->shpool) {
+        ngx_rwlock_wlock(&peer->lock);
+    }
+}
+
+
+static ngx_inline void
+ngx_http_upstream_rr_peer_unlock(ngx_http_upstream_rr_peers_t *peers,
+    ngx_http_upstream_rr_peer_t *peer)
+{
+    if (peers->shpool) {
+        ngx_rwlock_unlock(&peer->lock);
+    }
+}
 
 
 #define ngx_http_upstream_rr_peer_ref(peers, peer)                            \

--- a/src/stream/ngx_stream_upstream_round_robin.h
+++ b/src/stream/ngx_stream_upstream_round_robin.h
@@ -115,36 +115,51 @@ struct ngx_stream_upstream_rr_peers_s {
 
 #if (NGX_STREAM_UPSTREAM_ZONE)
 
-#define ngx_stream_upstream_rr_peers_rlock(peers)                             \
-                                                                              \
-    if (peers->shpool) {                                                      \
-        ngx_rwlock_rlock(&peers->rwlock);                                     \
+static ngx_inline void
+ngx_stream_upstream_rr_peers_rlock(ngx_stream_upstream_rr_peers_t *peers)
+{
+    if (peers->shpool) {
+        ngx_rwlock_rlock(&peers->rwlock);
     }
-
-#define ngx_stream_upstream_rr_peers_wlock(peers)                             \
-                                                                              \
-    if (peers->shpool) {                                                      \
-        ngx_rwlock_wlock(&peers->rwlock);                                     \
-    }
-
-#define ngx_stream_upstream_rr_peers_unlock(peers)                            \
-                                                                              \
-    if (peers->shpool) {                                                      \
-        ngx_rwlock_unlock(&peers->rwlock);                                    \
-    }
+}
 
 
-#define ngx_stream_upstream_rr_peer_lock(peers, peer)                         \
-                                                                              \
-    if (peers->shpool) {                                                      \
-        ngx_rwlock_wlock(&peer->lock);                                        \
+static ngx_inline void
+ngx_stream_upstream_rr_peers_wlock(ngx_stream_upstream_rr_peers_t *peers)
+{
+    if (peers->shpool) {
+        ngx_rwlock_wlock(&peers->rwlock);
     }
+}
 
-#define ngx_stream_upstream_rr_peer_unlock(peers, peer)                       \
-                                                                              \
-    if (peers->shpool) {                                                      \
-        ngx_rwlock_unlock(&peer->lock);                                       \
+
+static ngx_inline void
+ngx_stream_upstream_rr_peers_unlock(ngx_stream_upstream_rr_peers_t *peers)
+{
+    if (peers->shpool) {
+        ngx_rwlock_unlock(&peers->rwlock);
     }
+}
+
+
+static ngx_inline void
+ngx_stream_upstream_rr_peer_lock(ngx_stream_upstream_rr_peers_t *peers,
+    ngx_stream_upstream_rr_peer_t *peer)
+{
+    if (peers->shpool) {
+        ngx_rwlock_wlock(&peer->lock);
+    }
+}
+
+
+static ngx_inline void
+ngx_stream_upstream_rr_peer_unlock(ngx_stream_upstream_rr_peers_t *peers,
+    ngx_stream_upstream_rr_peer_t *peer)
+{
+    if (peers->shpool) {
+        ngx_rwlock_unlock(&peer->lock);
+    }
+}
 
 
 #define ngx_stream_upstream_rr_peer_ref(peers, peer)                          \


### PR DESCRIPTION
### What

The `ngx_http_upstream_rr_peers_rlock()`, `_wlock()` and `_unlock()` wrappers, and
the `rr_peer_lock()` / `rr_peer_unlock()` pair, are function-like macros expanding
to a bare `if`:

```c
#define ngx_http_upstream_rr_peers_rlock(peers)                               \
                                                                              \
    if (peers->shpool) {                                                      \
        ngx_rwlock_rlock(&peers->rwlock);                                     \
    }
```

A bare `if { }` is not a single statement, so the expansion depends on the caller
placing it where a compound statement is accepted. That holds at every call site
in the tree today — the coding style requires braces on controlled statements —
but the wrappers do not have to depend on it.

This converts the five wrappers to `static ngx_inline` functions, on both the
HTTP and the stream side.

### Why this shape

This replaces an earlier revision of this PR that wrapped the macros in
`do { } while (0)`. That was the wrong fix for this tree, for the reasons
@ac000 laid out: the coding style already prevents the hazard, `do { } while (0)`
appears in no header in `src/`, and the stream side has the identical pattern and
would have been left inconsistent.

Inline functions avoid all three objections and are already the local idiom —
`ngx_http_upstream_rr_peer_free_locked()`, `ngx_http_upstream_rr_peer_free()` and
`ngx_http_upstream_rr_peer_unref()` sit a few lines below in this same header and
are all `static ngx_inline`. So this makes the file more uniform rather than
less, and adds argument type checking that neither macro form had.

### Scope

- Five wrappers in `src/http/ngx_http_upstream_round_robin.h`.
- The same five in `src/stream/ngx_stream_upstream_round_robin.h`.

Deliberately not touched:

- **The non-zone (`#else`) variants stay empty macros.** Without
  `NGX_HTTP_UPSTREAM_ZONE` the peers structure has no `shpool` member, so there
  is no body to write. Their trailing `;` at a call site is a harmless null
  statement, as before.
- **`ngx_http_upstream_rr_peer_ref()` stays a macro.** It has the same
  trailing-`;` shape, but its `peers` argument is unused, so an inline function
  would have to name a parameter it does not read. Converting it is a separate
  question; say the word and I will fold it in.

### Testing

No behaviour change — same lock calls under the same condition, now behind a call
the compiler inlines.

Built with `-Werror` in both configurations, so both sides of the `#if` are
covered:

```
./auto/configure --with-stream --with-threads
./auto/configure --with-stream --with-threads \
    --without-http_upstream_zone_module --without-stream_upstream_zone_module
```

Both build clean, which also exercises every call site in
`ngx_http_upstream.c`, `ngx_http_upstream_round_robin.c`, the sticky, keepalive
and zone modules, and their stream counterparts — the type checking is new, so a
mismatched argument anywhere would now be a compile error rather than silently
accepted.
