### PR TITLE
Core: fix accept error logging

### DIFF
--- a/src/core/ngx_connection.c
+++ b/src/core/ngx_connection.c
@@ -755,6 +755,8 @@ ngx_configure_listening_sockets(ngx_cycle_t *cycle)
     for (i = 0; i < cycle->listening.nelts; i++) {
 
         ls[i].log = *ls[i].logp;
+        ls[i].log.data = &ls[i].addr_text;
+        ls[i].log.handler = ngx_accept_log_error;
 
         if (ls[i].rcvbuf != -1) {
             if (setsockopt(ls[i].fd, SOL_SOCKET, SO_RCVBUF,

--- a/src/http/ngx_http.c
+++ b/src/http/ngx_http.c
@@ -1887,8 +1887,6 @@ ngx_http_add_listening(ngx_conf_t *cf, ngx_http_conf_addr_t *addr)
     clcf = cscf->ctx->loc_conf[ngx_http_core_module.ctx_index];
 
     ls->logp = clcf->error_log;
-    ls->log.data = &ls->addr_text;
-    ls->log.handler = ngx_accept_log_error;
 
 #if (NGX_WIN32)
     {

--- a/src/mail/ngx_mail.c
+++ b/src/mail/ngx_mail.c
@@ -329,8 +329,6 @@ ngx_mail_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
             cscf = addr->opt.ctx->srv_conf[ngx_mail_core_module.ctx_index];
 
             ls->logp = cscf->error_log;
-            ls->log.data = &ls->addr_text;
-            ls->log.handler = ngx_accept_log_error;
 
             ls->protocol = addr[i].opt.protocol;
             ls->backlog = addr[i].opt.backlog;

--- a/src/stream/ngx_stream.c
+++ b/src/stream/ngx_stream.c
@@ -1006,8 +1006,6 @@ ngx_stream_add_listening(ngx_conf_t *cf, ngx_stream_conf_addr_t *addr)
     cscf = addr->default_server;
 
     ls->logp = cscf->error_log;
-    ls->log.data = &ls->addr_text;
-    ls->log.handler = ngx_accept_log_error;
 
     ls->type = addr->opt.type;
     ls->protocol = addr->opt.protocol;


### PR DESCRIPTION
## Problem
  
  The accept log handler and its data are set when listening sockets are created:
https://github.com/nginx/nginx/blob/5f54125dde0d144476155d8964f6ec3d449f578d/src/http/ngx_http.c#L1890-L1891

  However, `ngx_configure_listening_sockets()` later copies the configured error log over the
  entire listening socket log
https://github.com/nginx/nginx/blob/5f54125dde0d144476155d8964f6ec3d449f578d/src/core/ngx_connection.c#L757

  This overwrites both fields, making their earlier initialization ineffective. As a result,
  errors reported while accepting connections do not include the listening socket address.

  Also, although the IOCP event module does not appear to be used in practice,
  enabling it would install `ngx_acceptex_log_error()` while `log->data` remained NULL,
  potentially causing a crash when an AcceptEx() error was logged.

## Solution

  Initialize the accept log handler and its data immediately after copying the configured
  error log in `ngx_configure_listening_sockets()`.

  This preserves the configured log destination and level while ensuring that accept errors
  include the listening socket address. The ineffective assignments are removed from the
  HTTP, Mail, and Stream modules.

## Notes

  This also activates the existing handler for UDP listeners, where “accepting new connection”
  is slightly imprecise for `recvmsg()`. This seems acceptable and consistent with the existing
  intent, since the protocol modules already assigned the same handler regardless of socket
  type.

  Third-party modules creating listening sockets also receive the common handler. A handler
  assigned directly to `ls->log` during configuration was already overwritten by the configured
  error log copy. Modules requiring a different listener context can override it later during
  initialization.

## Testing

  The issue can be reproduced by attaching strace to an nginx worker and injecting
  ECONNABORTED into its first accept4() call:
```
  strace -e inject=accept4:error=ECONNABORTED:when=1 -p $worker_pid
```
  After attaching, initiate a connection to the listening socket.

  Before:
```
  2026/08/28 01:02:03 [error] 111#111: accept4() failed (103: Software caused connection
  abort)
```
  After:
```
  2026/08/28 02:03:04 [error] 222#222: accept4() failed (103: Software caused connection
  abort) while accepting new connection on 127.0.0.1:80
```
- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))


## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] ~~I have added tests (if applicable) to validate my changes~~
- [x] All existing tests pass
- [x] ~~I have updated documentation where necessary~~
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

  Accept errors now include the address of the listening socket on which the error occurred.