### PR TITLE
Events: avoided undefined debug values after IOCP timeout.

### DIFF
--- a/src/event/modules/ngx_iocp_module.c
+++ b/src/event/modules/ngx_iocp_module.c
@@ -263,9 +263,6 @@ ngx_iocp_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
         ngx_time_update();
     }
 
-    ngx_log_debug4(NGX_LOG_DEBUG_EVENT, cycle->log, 0,
-                   "iocp: %d b:%d k:%d ov:%p", rc, bytes, key, ovlp);
-
     if (timer != INFINITE) {
         delta = ngx_current_msec - delta;
 
@@ -294,6 +291,8 @@ ngx_iocp_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
         return NGX_ERROR;
     }
 
+    ngx_log_debug4(NGX_LOG_DEBUG_EVENT, cycle->log, 0,
+                   "iocp: %d b:%d k:%d ov:%p", rc, bytes, key, ovlp);
 
     ev = ovlp->event;
 


### PR DESCRIPTION
### Fix

Move the detailed IOCP completion log after the error and no-operation
checks. At that point `bytes`, `key`, and `ovlp` belong to a dequeued
completion packet and are defined.

### Problem

When `GetQueuedCompletionStatus()` times out without dequeuing a packet,
Windows leaves the byte count and completion key outputs undefined. The
debug log read both outputs before the timeout path returned, which is
undefined behavior in a debug build.

Moving the log avoids extra initialization in the event loop and preserves
the existing completion diagnostics.

### Testing

- Full-feature macOS/Clang build with nginx warning-as-error flags
- `git diff --check`
- nginx commit-message checker

This path is Win32-specific; the upstream nginx-tests suite does not exercise
the IOCP event module.