### PR TITLE
Script: avoided pointer arithmetic on NULL relocation targets.

### DIFF
--- a/src/http/ngx_http_script.c
+++ b/src/http/ngx_http_script.c
@@ -815,7 +815,9 @@ ngx_http_script_add_code(ngx_array_t *codes, size_t size, void *code)
     if (code) {
         if (elts != codes->elts) {
             p = code;
-            *p += (u_char *) codes->elts - elts;
+            if (*p != NULL) {
+                *p += (u_char *) codes->elts - elts;
+            }
         }
     }
 

--- a/src/stream/ngx_stream_script.c
+++ b/src/stream/ngx_stream_script.c
@@ -678,7 +678,9 @@ ngx_stream_script_add_code(ngx_array_t *codes, size_t size, void *code)
     if (code) {
         if (elts != codes->elts) {
             p = code;
-            *p += (u_char *) codes->elts - elts;
+            if (*p != NULL) {
+                *p += (u_char *) codes->elts - elts;
+            }
         }
     }
 


### PR DESCRIPTION
### Fix

Keep NULL optional relocation targets unchanged when HTTP or stream script
code arrays move. Only pointers into the old array need the relocation delta.

### Problem

Ordinary complex-value compilation leaves the optional relocation slot NULL.
When an underlying code array grew, the HTTP and stream script helpers added
the relocation delta to that NULL pointer. This is undefined pointer
arithmetic and generated UBSan errors during configuration in several
existing nginx-tests scenarios.

### Testing

- Full ASan/UBSan HTTP, request-body, HTTP/2, proxy, and gRPC suite:
  161 files, 2,607 tests — all successful
- ASan/UBSan stream suite: 82 files, 733 tests; no script sanitizer errors
  (unrelated OpenSSL 4 expectations and a separately fixed least-time shift
  were the only failures)
- Full-feature macOS/Clang warning-as-error build
- git diff --check
- nginx commit-message checker

The existing nginx-tests cases exercise the HTTP regression. The stream
helper has the same contract and leaves its relocation slot NULL in all
current callers.