### PR TITLE
Upstream: avoided excessive least time decay shifts.

### DIFF
--- a/src/http/modules/ngx_http_upstream_least_time_module.c
+++ b/src/http/modules/ngx_http_upstream_least_time_module.c
@@ -411,7 +411,7 @@ static ngx_uint_t
 ngx_http_upstream_least_time_eta(ngx_http_upstream_lt_peer_data_t *ltp,
     ngx_http_upstream_rr_peer_t *peer)
 {
-    time_t      now;
+    time_t      now, shift;
     ngx_msec_t  rt;
 
     switch (ltp->conf->mode) {
@@ -431,7 +431,14 @@ ngx_http_upstream_least_time_eta(ngx_http_upstream_lt_peer_data_t *ltp,
          * once in fail_timeout make response time of a peer 2 times
          * lower to give chances to slow peers
          */
-        rt >>= (now - peer->checked) / (peer->fail_timeout + 1);
+        shift = (now - peer->checked) / (peer->fail_timeout + 1);
+
+        if (shift < (time_t) (8 * sizeof(rt))) {
+            rt >>= shift;
+
+        } else {
+            rt = 0;
+        }
     }
 
     if (peer->inflight_reqs > 0) {

--- a/src/stream/ngx_stream_upstream_least_time_module.c
+++ b/src/stream/ngx_stream_upstream_least_time_module.c
@@ -397,7 +397,7 @@ static ngx_uint_t
 ngx_stream_upstream_least_time_eta(ngx_stream_upstream_lt_peer_data_t *ltp,
     ngx_stream_upstream_rr_peer_t *peer)
 {
-    time_t      now;
+    time_t      now, shift;
     ngx_msec_t  rt;
 
     switch (ltp->conf->mode) {
@@ -421,7 +421,14 @@ ngx_stream_upstream_least_time_eta(ngx_stream_upstream_lt_peer_data_t *ltp,
          * once in fail_timeout make response time of a peer 2 times
          * lower to give chances to slow peers
          */
-        rt >>= (now - peer->checked) / (peer->fail_timeout + 1);
+        shift = (now - peer->checked) / (peer->fail_timeout + 1);
+
+        if (shift < (time_t) (8 * sizeof(rt))) {
+            rt >>= shift;
+
+        } else {
+            rt = 0;
+        }
     }
 
     if (peer->inflight_reqs > 0) {


### PR DESCRIPTION
### Fix

Bound the right-shift used to decay stale least-time metrics in both the HTTP
and stream upstream balancers. When every bit would be shifted out, assign
zero directly.

### Problem

The decay count is the number of elapsed `fail_timeout` intervals. A peer
that has been unchecked for long enough, or uses `fail_timeout=0`, can
produce a count equal to or larger than the width of `ngx_msec_t`. Right
shifting by that count is undefined behavior.

The intended result is complete decay, so zero is the exact result without an
invalid shift.

### Testing

- Existing `upstream_least_time.t`: 12 tests — successful under ASan/UBSan
- Existing `stream_upstream_least_time.t`: 17 tests — successful under
  ASan/UBSan
- Before the fix, the stream test reports UBSan at
  `ngx_stream_upstream_least_time_module.c:424`
- Full-feature macOS/Clang warning-as-error build
- `git diff --check`

No new nginx-test is needed: the existing least-time regression cases already
exercise the excessive decay count.