### PR TITLE
Control: logged errors from accepted socket setup.

### DIFF
--- a/src/os/unix/ngx_control.c
+++ b/src/os/unix/ngx_control.c
@@ -480,21 +480,21 @@ ngx_control_handle_accept(void)
                        "control accept fd:%d", r->fd);
 
         if (fcntl(r->fd, F_SETFD, FD_CLOEXEC) == -1) {
-            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
+            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, ngx_socket_errno,
                           "control: fcntl(FD_CLOEXEC) failed");
             ngx_close_socket(r->fd);
             continue;
         }
 
         if (fcntl(r->fd, F_SETFL, O_ASYNC|O_NONBLOCK) == -1) {
-            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
+            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, ngx_socket_errno,
                           "control: fcntl(O_ASYNC|O_NONBLOCK) failed");
             ngx_close_socket(r->fd);
             continue;
         }
 
         if (fcntl(r->fd, F_SETOWN, ngx_pid) == -1) {
-            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
+            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, ngx_socket_errno,
                           "control: fcntl(F_SETOWN) failed");
             ngx_close_socket(r->fd);
             continue;


### PR DESCRIPTION
### Fix

Pass `ngx_socket_errno` to the three error logs for accepted control socket
`fcntl()` setup failures.

### Problem

The control listener already preserves the operating-system error for its
socket setup. The corresponding accepted-connection paths passed zero for
`F_SETFD`, `F_SETFL`, and `F_SETOWN` failures, so operators could see
which operation failed but not why.

### Testing

- Full-feature macOS/Clang warning-as-error build
- `git diff --check`

These failure paths require operating-system resource or descriptor failures
and do not have an applicable nginx-test. The change only restores diagnostic
information already captured consistently in the neighboring listener and
inherited-socket paths.