### PR TITLE
Core: avoided signed shift in MurmurHash2.

### DIFF
--- a/src/core/ngx_murmurhash.c
+++ b/src/core/ngx_murmurhash.c
@@ -19,7 +19,7 @@ ngx_murmur_hash2(u_char *data, size_t len)
         k  = data[0];
         k |= data[1] << 8;
         k |= data[2] << 16;
-        k |= data[3] << 24;
+        k |= (uint32_t) data[3] << 24;
 
         k *= 0x5bd1e995;
         k ^= k >> 24;


### PR DESCRIPTION
### Fix

Convert the fourth input byte to `uint32_t` before shifting it into the high
byte of each MurmurHash2 word.

### Problem

`u_char` is promoted to signed `int` for the existing expression. If its
high bit is set, shifting it left by 24 overflows `int`, which is undefined
behavior. UTF-8 and other binary split-clients keys can trigger this during
normal request handling.

The explicit unsigned conversion preserves the intended 32-bit word assembly
and leaves ASCII hashes unchanged.

### Testing

- New UTF-8 split-clients regression: nginx/nginx-tests#113
- Before the fix, the new case reports UBSan at
  `src/core/ngx_murmurhash.c:22`
- After the fix, HTTP and stream split-clients tests pass under ASan/UBSan:
  2 files, 7 tests
- Full-feature macOS/Clang warning-as-error build
- `git diff --check`