### PR TITLE
Win32: closed failed AcceptEx connections.

### DIFF
--- a/src/event/ngx_event_acceptex.c
+++ b/src/event/ngx_event_acceptex.c
@@ -29,7 +29,7 @@ ngx_event_acceptex(ngx_event_t *rev)
     if (rev->ovlp.error) {
         ngx_log_error(NGX_LOG_CRIT, c->log, rev->ovlp.error,
                       "AcceptEx() %V failed", &ls->addr_text);
-        return;
+        goto failed;
     }
 
     /* SO_UPDATE_ACCEPT_CONTEXT is required for shutdown() to work */
@@ -41,8 +41,7 @@ ngx_event_acceptex(ngx_event_t *rev)
         ngx_log_error(NGX_LOG_CRIT, c->log, ngx_socket_errno,
                       "setsockopt(SO_UPDATE_ACCEPT_CONTEXT) failed for %V",
                       &c->addr_text);
-        /* TODO: close socket */
-        return;
+        goto failed;
     }
 
     ngx_getacceptexsockaddrs(c->buffer->pos,
@@ -63,16 +62,14 @@ ngx_event_acceptex(ngx_event_t *rev)
     if (ls->addr_ntop) {
         c->addr_text.data = ngx_pnalloc(c->pool, ls->addr_text_max_len);
         if (c->addr_text.data == NULL) {
-            /* TODO: close socket */
-            return;
+            goto failed;
         }
 
         c->addr_text.len = ngx_sock_ntop(c->sockaddr, c->socklen,
                                          c->addr_text.data,
                                          ls->addr_text_max_len, 0);
         if (c->addr_text.len == 0) {
-            /* TODO: close socket */
-            return;
+            goto failed;
         }
     }
 
@@ -86,6 +83,10 @@ ngx_event_acceptex(ngx_event_t *rev)
 
     return;
 
+failed:
+
+    ngx_close_posted_connection(c);
+    (void) ngx_event_post_acceptex(ls, 1);
 }
 
 
@@ -119,6 +120,11 @@ ngx_event_post_acceptex(ngx_listening_t *ls, ngx_uint_t n)
         c = ngx_get_connection(s, &ls->log);
 
         if (c == NULL) {
+            if (ngx_close_socket(s) == -1) {
+                ngx_log_error(NGX_LOG_ALERT, &ls->log, ngx_socket_errno,
+                              ngx_close_socket_n " failed");
+            }
+
             return NGX_ERROR;
         }
 


### PR DESCRIPTION
### Fix

Close a newly created socket if connection allocation fails. Route all
failures after an accepted connection is created through one cleanup path.
It closes and frees the failed connection, then posts a replacement
`AcceptEx()` request.

### Problem

Posting or completing an `AcceptEx()` request abandoned resources on five
error paths:

- connection allocation failed after socket creation
- completion reported an error
- `SO_UPDATE_ACCEPT_CONTEXT` failed
- address-text allocation failed
- address formatting failed

The first path leaked the newly created socket. The four completed-request
paths leaked the accepted socket and connection pool. All five reduced the
configured pool of posted accepts.

### Testing

- Windows cross-build passed with MinGW-w64 GCC 16.2 and nginx's warnings
  treated as errors
- Audited every return after socket creation in
  `ngx_event_post_acceptex()`
- Audited every pre-handoff return in `ngx_event_acceptex()`
- Matched the raw-socket cleanup to nginx's Unix accept/connect paths
- Verified completed-request cleanup uses the existing
  `ngx_close_posted_connection()` helper
- `git diff --check`

nginx-tests has no way to induce these operating-system/allocation failure
paths.