### PR TITLE
Proxy: retry HTTP/2 requests after GOAWAY with NO_ERROR.

### DIFF
--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -1389,28 +1389,27 @@ ngx_http_grpc_body_output_filter(void *data, ngx_chain_t *in)
 
         ctx->header_sent = 1;
 
+        b = ctx->in->buf;
+        p = b->start + sizeof(ngx_http_grpc_connection_start) - 1;
+
         if (ctx->id != 1) {
             /*
-             * keepalive connection: skip connection preface,
-             * update stream identifiers
+             * keepalive connection: skip connection preface
              */
 
-            b = ctx->in->buf;
-            b->pos += sizeof(ngx_http_grpc_connection_start) - 1;
+            b->pos = p;
+        }
 
-            p = b->pos;
+        while (p < b->last) {
+            f = (ngx_http_grpc_frame_t *) p;
+            p += sizeof(ngx_http_grpc_frame_t);
 
-            while (p < b->last) {
-                f = (ngx_http_grpc_frame_t *) p;
-                p += sizeof(ngx_http_grpc_frame_t);
+            f->stream_id_0 = (u_char) ((ctx->id >> 24) & 0xff);
+            f->stream_id_1 = (u_char) ((ctx->id >> 16) & 0xff);
+            f->stream_id_2 = (u_char) ((ctx->id >> 8) & 0xff);
+            f->stream_id_3 = (u_char) (ctx->id & 0xff);
 
-                f->stream_id_0 = (u_char) ((ctx->id >> 24) & 0xff);
-                f->stream_id_1 = (u_char) ((ctx->id >> 16) & 0xff);
-                f->stream_id_2 = (u_char) ((ctx->id >> 8) & 0xff);
-                f->stream_id_3 = (u_char) (ctx->id & 0xff);
-
-                p += (f->length_0 << 16) + (f->length_1 << 8) + f->length_2;
-            }
+            p += (f->length_0 << 16) + (f->length_1 << 8) + f->length_2;
         }
 
         if (ctx->in->buf->last_buf) {
@@ -1840,7 +1839,9 @@ ngx_http_grpc_process_header(ngx_http_request_t *r)
 
             if (ctx->stream_id < ctx->id) {
 
-                /* TODO: we can retry non-idempotent requests */
+                if (ctx->error == 0) {
+                    return NGX_HTTP_UPSTREAM_RETRY;
+                }
 
                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                               "upstream sent goaway with error %ui",
@@ -2359,7 +2360,9 @@ ngx_http_grpc_filter(void *data, ssize_t bytes)
 
             if (ctx->stream_id < ctx->id) {
 
-                /* TODO: we can retry non-idempotent requests */
+                if (ctx->error == 0) {
+                    return NGX_ERROR;
+                }
 
                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                               "upstream sent goaway with error %ui",

--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -1098,28 +1098,27 @@ ngx_http_proxy_v2_body_output_filter(void *data, ngx_chain_t *in)
 
         ctx->header_sent = 1;
 
+        b = ctx->in->buf;
+        p = b->start + sizeof(ngx_http_proxy_v2_connection_start) - 1;
+
         if (ctx->id != 1) {
             /*
-             * keepalive connection: skip connection preface,
-             * update stream identifiers
+             * keepalive connection: skip connection preface
              */
 
-            b = ctx->in->buf;
-            b->pos += sizeof(ngx_http_proxy_v2_connection_start) - 1;
+            b->pos = p;
+        }
 
-            p = b->pos;
+        while (p < b->last) {
+            f = (ngx_http_proxy_v2_frame_t *) p;
+            p += sizeof(ngx_http_proxy_v2_frame_t);
 
-            while (p < b->last) {
-                f = (ngx_http_proxy_v2_frame_t *) p;
-                p += sizeof(ngx_http_proxy_v2_frame_t);
+            f->stream_id_0 = (u_char) ((ctx->id >> 24) & 0xff);
+            f->stream_id_1 = (u_char) ((ctx->id >> 16) & 0xff);
+            f->stream_id_2 = (u_char) ((ctx->id >> 8) & 0xff);
+            f->stream_id_3 = (u_char) (ctx->id & 0xff);
 
-                f->stream_id_0 = (u_char) ((ctx->id >> 24) & 0xff);
-                f->stream_id_1 = (u_char) ((ctx->id >> 16) & 0xff);
-                f->stream_id_2 = (u_char) ((ctx->id >> 8) & 0xff);
-                f->stream_id_3 = (u_char) (ctx->id & 0xff);
-
-                p += (f->length_0 << 16) + (f->length_1 << 8) + f->length_2;
-            }
+            p += (f->length_0 << 16) + (f->length_1 << 8) + f->length_2;
         }
 
         if (ctx->in->buf->last_buf) {
@@ -1538,6 +1537,10 @@ ngx_http_proxy_v2_process_header(ngx_http_request_t *r)
 
             if (rc == NGX_ERROR) {
                 return NGX_HTTP_UPSTREAM_INVALID_HEADER;
+            }
+
+            if (rc == NGX_HTTP_UPSTREAM_RETRY) {
+                return NGX_HTTP_UPSTREAM_RETRY;
             }
 
             if (rc == NGX_OK) {
@@ -2021,7 +2024,9 @@ ngx_http_proxy_v2_process_control_frame(ngx_http_request_t *r,
 
         if (ctx->stream_id < ctx->id) {
 
-            /* TODO: we can retry non-idempotent requests */
+            if (ctx->error == 0) {
+                return NGX_HTTP_UPSTREAM_RETRY;
+            }
 
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                           "upstream sent goaway with error %ui",
@@ -2307,6 +2312,10 @@ ngx_http_proxy_v2_process_frames(ngx_http_request_t *r,
         }
 
         if (rc == NGX_ERROR) {
+            return NGX_ERROR;
+        }
+
+        if (rc == NGX_HTTP_UPSTREAM_RETRY) {
             return NGX_ERROR;
         }
 

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -1141,7 +1141,10 @@ ngx_http_upstream_cache_send(ngx_http_request_t *r, ngx_http_upstream_t *u)
         return NGX_ERROR;
     }
 
-    if (rc == NGX_AGAIN || rc == NGX_HTTP_UPSTREAM_EARLY_HINTS) {
+    if (rc == NGX_AGAIN
+        || rc == NGX_HTTP_UPSTREAM_EARLY_HINTS
+        || rc == NGX_HTTP_UPSTREAM_RETRY)
+    {
         rc = NGX_HTTP_UPSTREAM_INVALID_HEADER;
     }
 
@@ -2608,6 +2611,12 @@ done:
 
     if (rc == NGX_HTTP_UPSTREAM_INVALID_HEADER) {
         ngx_http_upstream_next(r, u, NGX_HTTP_UPSTREAM_FT_INVALID_HEADER);
+        return;
+    }
+
+    if (rc == NGX_HTTP_UPSTREAM_RETRY) {
+        ngx_http_upstream_next(r, u, NGX_HTTP_UPSTREAM_FT_ERROR
+                                     | NGX_HTTP_UPSTREAM_FT_UNPROCESSED);
         return;
     }
 
@@ -4600,10 +4609,13 @@ ngx_http_upstream_next(ngx_http_request_t *r, ngx_http_upstream_t *u,
     ngx_uint_t ft_type)
 {
     ngx_msec_t  timeout;
-    ngx_uint_t  status, state;
+    ngx_uint_t  status, state, unprocessed;
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http next upstream, %xi", ft_type);
+
+    unprocessed = ft_type & NGX_HTTP_UPSTREAM_FT_UNPROCESSED;
+    ft_type &= ~NGX_HTTP_UPSTREAM_FT_UNPROCESSED;
 
     if (u->peer.sockaddr) {
 
@@ -4611,7 +4623,8 @@ ngx_http_upstream_next(ngx_http_request_t *r, ngx_http_upstream_t *u,
             u->state->bytes_sent = u->peer.connection->sent;
         }
 
-        if (ft_type == NGX_HTTP_UPSTREAM_FT_HTTP_403
+        if (unprocessed
+            || ft_type == NGX_HTTP_UPSTREAM_FT_HTTP_403
             || ft_type == NGX_HTTP_UPSTREAM_FT_HTTP_404)
         {
             state = NGX_PEER_NEXT;
@@ -4633,9 +4646,24 @@ ngx_http_upstream_next(ngx_http_request_t *r, ngx_http_upstream_t *u,
                       "upstream timed out");
     }
 
-    if (u->peer.cached && ft_type == NGX_HTTP_UPSTREAM_FT_ERROR) {
-        /* TODO: inform balancer instead */
-        u->peer.tries++;
+    if (ft_type == NGX_HTTP_UPSTREAM_FT_ERROR) {
+
+        if (unprocessed) {
+
+            /*
+             * Restore one exhausted try so a single peer can be retried on
+             * a new connection.  Do this once to avoid an endless loop.
+             */
+
+            if (u->peer.tries == 0 && !u->unprocessed_retried) {
+                u->peer.tries++;
+                u->unprocessed_retried = 1;
+            }
+
+        } else if (u->peer.cached) {
+            /* TODO: inform balancer instead */
+            u->peer.tries++;
+        }
     }
 
     switch (ft_type) {
@@ -4684,7 +4712,8 @@ ngx_http_upstream_next(ngx_http_request_t *r, ngx_http_upstream_t *u,
 
     timeout = u->conf->next_upstream_timeout;
 
-    if (u->request_sent
+    if (!unprocessed
+        && u->request_sent
         && (r->method & (NGX_HTTP_POST|NGX_HTTP_LOCK|NGX_HTTP_PATCH)))
     {
         ft_type |= NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT;

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -31,6 +31,7 @@
 #define NGX_HTTP_UPSTREAM_FT_BUSY_LOCK       0x00001000
 #define NGX_HTTP_UPSTREAM_FT_MAX_WAITING     0x00002000
 #define NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT  0x00004000
+#define NGX_HTTP_UPSTREAM_FT_UNPROCESSED     0x00008000
 #define NGX_HTTP_UPSTREAM_FT_NOLIVE          0x40000000
 #define NGX_HTTP_UPSTREAM_FT_OFF             0x80000000
 
@@ -44,6 +45,7 @@
 
 #define NGX_HTTP_UPSTREAM_INVALID_HEADER     40
 #define NGX_HTTP_UPSTREAM_EARLY_HINTS        41
+#define NGX_HTTP_UPSTREAM_RETRY              42
 
 
 #define NGX_HTTP_UPSTREAM_IGN_XA_REDIRECT    0x00000002
@@ -423,6 +425,7 @@ struct ngx_http_upstream_s {
     unsigned                         request_body_blocked:1;
     unsigned                         header_sent:1;
     unsigned                         response_received:1;
+    unsigned                         unprocessed_retried:1;
 };
 
 


### PR DESCRIPTION
A GOAWAY with a lower last stream identifier guarantees that the current request was not processed. Retry it without marking the peer failed, while retaining next_upstream policy and permitting buffered non-idempotent requests.

Rewrite prepared frame stream identifiers on every send. This handles retries from keepalive connections, where buffers retain the previous stream identifier but a new connection starts with stream 1.

Closes #1431 on GitHub.

## Problem

Briefly describe the issue or feature being addressed.

## Solution

Explain your approach and any important design decisions.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [ ] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #ISSUE\_NUMBER

## Checklist

Before submitting this PR, please confirm:

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [ ] I have added tests (if applicable) to validate my changes
- [ ] All existing tests pass
- [ ] I have updated documentation where necessary
- [ ] My branch is rebased on the latest master
- [ ] This PR targets the master branch from my fork
- [ ] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

If this change affects users, please add a short note here describing
the impact for release documentation.
