### PR TITLE
Core: propagate variable errors in predicate locations

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1515,7 +1515,11 @@ ngx_http_core_find_location(ngx_http_request_t *r)
 
             vv = ngx_http_get_flushed_variable(r, (*clcfp)->predicate - 1);
 
-            if (vv && vv->len && (vv->len != 1 || vv->data[0] != '0')) {
+            if (vv == NULL) {
+                return NGX_ERROR;
+            }
+
+            if (vv->len && (vv->len != 1 || vv->data[0] != '0')) {
                 r->loc_conf = (*clcfp)->loc_conf;
 
                 /* look up nested locations */


### PR DESCRIPTION
## Problem


`ngx_http_core_find_location()` documents `NGX_ERROR` as the return value for regex or predicate errors.

However, predicate location matching currently checks the evaluated variable with:

    if (vv && vv->len && ...)

`ngx_http_get_flushed_variable()` returns a non-NULL value for ordinary not-found variables. A NULL result indicates that variable evaluation failed, for example when a variable handler returns `NGX_ERROR`.

The current check treats such failures as a false predicate and continues location lookup. This can select a fallback location and hide the variable evaluation error instead of returning HTTP 500.

The issue is reproducible with the bundled Perl module:

    perl_set $broken 'sub { die "broken predicate"; }';

    location $broken {
        return 200 "predicate\n";
    }

    location / {
        return 204;
    }

With the current code, the failing predicate is treated as unmatched and the fallback location is selected.


## Solution

Return `NGX_ERROR` when predicate variable evaluation returns NULL.

Normal not-found variables still return a variable value with the existing false predicate semantics.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing

Built nginx with the default configuration and with the HTTP Perl module. Using a Perl predicate handler that calls `die`, the request now returns:

    HTTP/1.1 500 Internal Server Error

- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))


## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

## Release Notes

Predicate location matching now propagates variable evaluation errors instead of treating them as a non-matching predicate.
