### PR TITLE
Win32: fixed time overflow after 2038

### DIFF
--- a/src/core/ngx_times.c
+++ b/src/core/ngx_times.c
@@ -85,13 +85,13 @@ ngx_time_update(void)
     time_t           sec;
     ngx_uint_t       msec;
     ngx_time_t      *tp;
-    struct timeval   tv;
+    ngx_timeval_t    tv;
 
     if (!ngx_trylock(&ngx_time_lock)) {
         return;
     }
 
-    ngx_gettimeofday(&tv);
+    ngx_gettimeofday64(&tv);
 
     sec = tv.tv_sec;
     msec = tv.tv_usec / 1000;
@@ -218,13 +218,13 @@ ngx_time_sigsafe_update(void)
     ngx_tm_t         tm;
     time_t           sec;
     ngx_time_t      *tp;
-    struct timeval   tv;
+    ngx_timeval_t    tv;
 
     if (!ngx_trylock(&ngx_time_lock)) {
         return;
     }
 
-    ngx_gettimeofday(&tv);
+    ngx_gettimeofday64(&tv);
 
     sec = tv.tv_sec;
 

--- a/src/http/modules/ngx_http_userid_filter_module.c
+++ b/src/http/modules/ngx_http_userid_filter_module.c
@@ -913,9 +913,9 @@ ngx_http_userid_mark(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 static ngx_int_t
 ngx_http_userid_init_worker(ngx_cycle_t *cycle)
 {
-    struct timeval  tp;
+    ngx_timeval_t   tp;
 
-    ngx_gettimeofday(&tp);
+    ngx_gettimeofday64(&tp);
 
     /* use the most significant usec part that fits to 16 bits */
     start_value = (((uint32_t) tp.tv_usec / 20) << 16) | ngx_pid;

--- a/src/os/unix/ngx_time.h
+++ b/src/os/unix/ngx_time.h
@@ -17,6 +17,7 @@ typedef ngx_rbtree_key_t      ngx_msec_t;
 typedef ngx_rbtree_key_int_t  ngx_msec_int_t;
 
 typedef struct tm             ngx_tm_t;
+typedef struct timeval        ngx_timeval_t;
 
 #define ngx_tm_sec            tm_sec
 #define ngx_tm_min            tm_min
@@ -58,7 +59,8 @@ void ngx_localtime(time_t s, ngx_tm_t *tm);
 void ngx_libc_localtime(time_t s, struct tm *tm);
 void ngx_libc_gmtime(time_t s, struct tm *tm);
 
-#define ngx_gettimeofday(tp)  (void) gettimeofday(tp, NULL);
+#define ngx_gettimeofday(tp)    (void) gettimeofday(tp, NULL);
+#define ngx_gettimeofday64(tp)  (void) gettimeofday(tp, NULL);
 #define ngx_msleep(ms)        (void) usleep(ms * 1000)
 #define ngx_sleep(s)          (void) sleep(s)
 

--- a/src/os/win32/ngx_time.c
+++ b/src/os/win32/ngx_time.c
@@ -10,7 +10,7 @@
 
 
 void
-ngx_gettimeofday(struct timeval *tp)
+ngx_gettimeofday64(ngx_timeval_t *tp)
 {
     uint64_t  intervals;
     FILETIME  ft;
@@ -31,10 +31,19 @@ ngx_gettimeofday(struct timeval *tp)
      */
 
     intervals = ((uint64_t) ft.dwHighDateTime << 32) | ft.dwLowDateTime;
-    intervals -= 116444736000000000;
+    ngx_filetime_to_timeval(intervals, tp);
+}
 
-    tp->tv_sec = (long) (intervals / 10000000);
-    tp->tv_usec = (long) ((intervals % 10000000) / 10);
+
+void
+ngx_gettimeofday(struct timeval *tp)
+{
+    ngx_timeval_t  tv;
+
+    ngx_gettimeofday64(&tv);
+
+    tp->tv_sec = (long) tv.tv_sec;
+    tp->tv_usec = tv.tv_usec;
 }
 
 

--- a/src/os/win32/ngx_time.h
+++ b/src/os/win32/ngx_time.h
@@ -19,6 +19,23 @@ typedef ngx_rbtree_key_int_t  ngx_msec_int_t;
 typedef SYSTEMTIME            ngx_tm_t;
 typedef FILETIME              ngx_mtime_t;
 
+typedef struct {
+    time_t                    tv_sec;
+    long                      tv_usec;
+} ngx_timeval_t;
+
+
+#define NGX_WIN32_EPOCH_FILETIME  116444736000000000ULL
+
+static ngx_inline void
+ngx_filetime_to_timeval(uint64_t intervals, ngx_timeval_t *tp)
+{
+    intervals -= NGX_WIN32_EPOCH_FILETIME;
+
+    tp->tv_sec = (time_t) (intervals / 10000000);
+    tp->tv_usec = (long) ((intervals % 10000000) / 10);
+}
+
 #define ngx_tm_sec            wSecond
 #define ngx_tm_min            wMinute
 #define ngx_tm_hour           wHour
@@ -46,6 +63,7 @@ ngx_int_t ngx_gettimezone(void);
 void ngx_libc_localtime(time_t s, struct tm *tm);
 void ngx_libc_gmtime(time_t s, struct tm *tm);
 void ngx_gettimeofday(struct timeval *tp);
+void ngx_gettimeofday64(ngx_timeval_t *tp);
 
 
 #endif /* _NGX_TIME_H_INCLUDED_ */


### PR DESCRIPTION
## Problem

On Windows x64, `ngx_gettimeofday()` stored Unix seconds in `long`.
Windows uses LLP64, so `long` remains 32 bits even when `time_t` and
pointers are 64 bits. Timestamps after `2038-01-19 03:14:07 UTC`
therefore overflowed to negative values. `ngx_gmtime()` subsequently
clamped them to zero, causing cached log timestamps to fall back to
1970.

## Solution

Add an internal `ngx_timeval_t` abstraction. Its Win32 seconds field
uses `time_t`, while Unix continues to use native `struct timeval`.

Add `ngx_gettimeofday64()` and migrate nginx's internal consumers to
it. Keep the existing `ngx_gettimeofday(struct timeval *)` symbol,
prototype, output layout, and legacy semantics for compatibility with
existing Windows modules. This avoids a same-symbol output-size change
when MinGW links nginx with `--export-all-symbols`.

The `FILETIME` conversion helper is `static ngx_inline`. The internal
hot path still performs one `GetSystemTimeAsFileTime()` call and adds
no lock, allocation, system call, or extra function call.

## Testing

The same source change was previously built and runtime-tested against
nginx 1.31.1 as bundled by OpenResty 1.31.1.1 on Windows x64 with GCC
16.1.0/MSYS2 MinGW64. It passed:

- [x] Unix Epoch conversion
- [x] `2038-01-19 03:14:07 UTC`
- [x] `2038-01-19 03:14:08 UTC`
- [x] A 2039 timestamp including microseconds
- [x] Unix timestamp `2^32`
- [x] Full Windows x64 OpenResty build
- [x] 8/8 runtime verification cases
- [x] Access and error log verification after the 2038 boundary
- [x] `-O2` object-code inspection confirming helper inlining

A source comparison found no changes to the five affected files
between the nginx 1.31.1 and 1.31.5 release commits. This exact 1.31.5
checkout received static diff and compatibility review but was not
rebuilt.

- [x] Manual testing using the nginx 1.31.1 validation baseline
- [ ] Functional testing in nginx-tests

**Closes:** #1729

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] The branch targets current nginx master from my fork
- [x] The commit message follows nginx formatting guidance
- [x] The final GitHub issue number has been linked
- [ ] The F5 CLA has been completed if requested by the bot

## Release Notes

Fixed access and error log timestamps after the Year 2038 boundary on
64-bit Windows builds using a 64-bit `time_t`.

## Source Branch

<https://github.com/Hezhongqi/nginx/tree/fix/windows-y2038-time>