### PR TITLE
Proxy: flush control frames after empty HTTP/2 responses.

### DIFF
--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -1684,6 +1684,19 @@ ngx_http_proxy_v2_process_header(ngx_http_request_t *r)
                     return NGX_HTTP_UPSTREAM_EARLY_HINTS;
                 }
 
+                /*
+                 * Flush pending control frames before the upstream is
+                 * finalized for responses without a body.
+                 */
+
+                if (ctx->end_stream && ctx->out) {
+                    if (ngx_http_proxy_v2_body_output_filter(r, NULL)
+                        == NGX_ERROR)
+                    {
+                        return NGX_ERROR;
+                    }
+                }
+
                 if (ctx->end_stream
                     && ctx->in == NULL
                     && ctx->out == NULL


### PR DESCRIPTION
## Problem

As reported in #1726, empty HTTP/2 upstream responses can prevent keepalive reuse. When SETTINGS or PING frames arrive together with an END_STREAM response, their acknowledgements may still be queued when the response is finalized. HEAD, 204, and 304 responses can finalize before the input filter is initialized.

## Solution

Flush pending control output after parsing an END_STREAM response, before the existing header keepalive check. The reuse conditions are unchanged: pending input or output, blocked output, GOAWAY, and unread buffered bytes still prevent caching the connection.

## Testing

Companion regression test: https://github.com/nginx/nginx-tests/pull/114.

- Before the fix, 24 of the new test's 42 assertions fail.
- After the fix, all 42 pass, including ten consecutive runs.
- The HTTP/2 proxy tests, upstream_keepalive.t, and proxy_cache_convert_head.t pass together: 17 files, 292 assertions.
- Built with `make -j2` on macOS arm64, with HTTP/2, SSL, and debug enabled. Linux, sanitizer, and forced socket-send EAGAIN tests have not been run.

- [ ] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** #1726

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] I have added tests to validate my changes
- [ ] All existing tests pass (the targeted 292-assertion suite passed; the full suite was not run)
- [x] I have updated documentation where necessary (no configuration or interface change)
- [x] My branch is based on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards

## Release Notes

Fixed HTTP/2 upstream keepalive reuse for empty responses with pending control-frame acknowledgements.
