### PR TITLE
QUIC: pace output with microsecond event deadlines.

### DIFF
--- a/auto/os/linux
+++ b/auto/os/linux
@@ -56,6 +56,20 @@ if [ $ngx_found = yes ]; then
     EVENT_FOUND=YES
 
 
+    # epoll_pwait2() appeared in Linux 5.11, glibc 2.35
+
+    ngx_feature="epoll_pwait2()"
+    ngx_feature_name="NGX_HAVE_EPOLL_PWAIT2"
+    ngx_feature_run=no
+    ngx_feature_incs="#include <sys/epoll.h>"
+    ngx_feature_path=
+    ngx_feature_libs=
+    ngx_feature_test="struct epoll_event ee;
+                      struct timespec ts = { 0, 0 };
+                      (void) epoll_pwait2(-1, &ee, 1, &ts, NULL)"
+    . auto/feature
+
+
     # EPOLLRDHUP appeared in Linux 2.6.17, glibc 2.8
 
     ngx_feature="EPOLLRDHUP"

--- a/src/core/ngx_times.c
+++ b/src/core/ngx_times.c
@@ -209,6 +209,46 @@ ngx_monotonic_time(time_t sec, ngx_uint_t msec)
 }
 
 
+ngx_usec_t
+ngx_monotonic_usec(void)
+{
+#if (NGX_HAVE_CLOCK_MONOTONIC)
+    struct timespec  ts;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+
+    return (ngx_usec_t) ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
+
+#else
+    ngx_msec_t             msec;
+    ngx_msec_int_t         elapsed;
+    static ngx_msec_t      last;
+    static ngx_usec_t      now;
+    static ngx_uint_t      initialized;
+
+    /* This worker-local clock is used only by the event loop. */
+
+    msec = ngx_current_msec;
+
+    if (!initialized) {
+        last = msec;
+        now = (ngx_usec_t) msec * 1000;
+        initialized = 1;
+    }
+
+    elapsed = (ngx_msec_int_t) (msec - last);
+    last = msec;
+
+    if (elapsed > 0) {
+        now += (ngx_usec_t) elapsed * 1000;
+    }
+
+    return now;
+
+#endif
+}
+
+
 #if !(NGX_WIN32)
 
 void

--- a/src/core/ngx_times.h
+++ b/src/core/ngx_times.h
@@ -13,6 +13,10 @@
 #include <ngx_core.h>
 
 
+typedef uint64_t  ngx_usec_t;
+typedef int64_t   ngx_usec_int_t;
+
+
 typedef struct {
     time_t      sec;
     ngx_uint_t  msec;
@@ -20,6 +24,7 @@ typedef struct {
 } ngx_time_t;
 
 
+ngx_usec_t ngx_monotonic_usec(void);
 void ngx_time_init(void);
 void ngx_time_update(void);
 void ngx_time_sigsafe_update(void);

--- a/src/event/modules/ngx_epoll_module.c
+++ b/src/event/modules/ngx_epoll_module.c
@@ -134,6 +134,10 @@ static int                  ep = -1;
 static struct epoll_event  *event_list;
 static ngx_uint_t           nevents;
 
+#if (NGX_HAVE_EPOLL_PWAIT2)
+static ngx_uint_t           ngx_epoll_pwait2 = 1;
+#endif
+
 #if (NGX_HAVE_EVENTFD)
 static int                  notify_fd = -1;
 static ngx_event_t          notify_event;
@@ -792,12 +796,48 @@ ngx_epoll_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
     ngx_queue_t       *queue;
     ngx_connection_t  *c;
 
+#if (NGX_HAVE_EPOLL_PWAIT2)
+    ngx_usec_t         precise;
+    struct timespec    ts;
+#endif
+
     /* NGX_TIMER_INFINITE == INFTIM */
 
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, cycle->log, 0,
                    "epoll timer: %M", timer);
 
-    events = epoll_wait(ep, event_list, (int) nevents, timer);
+#if (NGX_HAVE_EPOLL_PWAIT2)
+
+    precise = ngx_event_find_precise_timer();
+
+    if (ngx_epoll_pwait2 && precise != NGX_PRECISE_TIMER_INFINITE) {
+        if (timer != NGX_TIMER_INFINITE && timer <= precise / 1000) {
+            ts.tv_sec = timer / 1000;
+            ts.tv_nsec = (timer % 1000) * 1000000;
+
+        } else {
+            ts.tv_sec = precise / 1000000;
+            ts.tv_nsec = (precise % 1000000) * 1000;
+        }
+
+        events = epoll_pwait2(ep, event_list, (int) nevents, &ts, NULL);
+
+        if (events == -1 && (ngx_errno == NGX_ENOSYS || ngx_errno == NGX_EPERM)) {
+            ngx_epoll_pwait2 = 0;
+
+            ngx_log_error(NGX_LOG_NOTICE, cycle->log, ngx_errno,
+                          "epoll_pwait2() unavailable, using epoll_wait()");
+
+            events = epoll_wait(ep, event_list, (int) nevents, timer);
+        }
+
+    } else
+
+#endif
+
+    {
+        events = epoll_wait(ep, event_list, (int) nevents, timer);
+    }
 
     err = (events == -1) ? ngx_errno : 0;
 

--- a/src/event/modules/ngx_kqueue_module.c
+++ b/src/event/modules/ngx_kqueue_module.c
@@ -514,17 +514,28 @@ ngx_kqueue_process_events(ngx_cycle_t *cycle, ngx_msec_t timer,
     ngx_event_t      *ev;
     ngx_queue_t      *queue;
     struct timespec   ts, *tp;
+    ngx_usec_t        precise;
 
     n = (int) nchanges;
     nchanges = 0;
 
-    if (timer == NGX_TIMER_INFINITE) {
+    precise = ngx_event_find_precise_timer();
+
+    if (timer == NGX_TIMER_INFINITE && precise == NGX_PRECISE_TIMER_INFINITE) {
         tp = NULL;
 
     } else {
 
-        ts.tv_sec = timer / 1000;
-        ts.tv_nsec = (timer % 1000) * 1000000;
+        if (precise == NGX_PRECISE_TIMER_INFINITE
+            || (timer != NGX_TIMER_INFINITE && timer <= precise / 1000))
+        {
+            ts.tv_sec = timer / 1000;
+            ts.tv_nsec = (timer % 1000) * 1000000;
+
+        } else {
+            ts.tv_sec = precise / 1000000;
+            ts.tv_nsec = (precise % 1000000) * 1000;
+        }
 
         /*
          * 64-bit Darwin kernel has the bug: kernel level ts.tv_nsec is

--- a/src/event/ngx_event.c
+++ b/src/event/ngx_event.c
@@ -243,6 +243,8 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
         timer = 0;
     }
 
+    timer = ngx_event_timer_timeout(timer);
+
     delta = ngx_current_msec;
 
     (void) ngx_process_events(cycle, timer, flags);

--- a/src/event/ngx_event.h
+++ b/src/event/ngx_event.h
@@ -78,7 +78,11 @@ struct ngx_event_s {
 
 #if (NGX_HAVE_KQUEUE)
     unsigned         kq_vnode:1;
+#endif
 
+    unsigned         timer_precise:1;
+
+#if (NGX_HAVE_KQUEUE)
     /* the pending errno reported by kqueue */
     int              kq_errno;
 #endif

--- a/src/event/ngx_event_timer.c
+++ b/src/event/ngx_event_timer.c
@@ -10,6 +10,14 @@
 #include <ngx_event.h>
 
 
+static void ngx_event_expire_timer_tree(ngx_rbtree_t *tree,
+    ngx_rbtree_key_t now);
+static ngx_int_t ngx_event_timer_tree_empty(ngx_rbtree_t *tree);
+
+
+ngx_rbtree_t              ngx_event_precise_timer_rbtree;
+static ngx_rbtree_node_t  ngx_event_precise_timer_sentinel;
+
 ngx_rbtree_t              ngx_event_timer_rbtree;
 static ngx_rbtree_node_t  ngx_event_timer_sentinel;
 
@@ -23,6 +31,10 @@ ngx_int_t
 ngx_event_timer_init(ngx_log_t *log)
 {
     ngx_rbtree_init(&ngx_event_timer_rbtree, &ngx_event_timer_sentinel,
+                    ngx_rbtree_insert_timer_value);
+
+    ngx_rbtree_init(&ngx_event_precise_timer_rbtree,
+                    &ngx_event_precise_timer_sentinel,
                     ngx_rbtree_insert_timer_value);
 
     return NGX_OK;
@@ -50,16 +62,91 @@ ngx_event_find_timer(void)
 }
 
 
+ngx_usec_t
+ngx_event_find_precise_timer(void)
+{
+    ngx_rbtree_key_int_t   timer;
+    ngx_rbtree_node_t     *node, *root, *sentinel;
+
+    root = ngx_event_precise_timer_rbtree.root;
+    sentinel = ngx_event_precise_timer_rbtree.sentinel;
+
+    if (root == sentinel) {
+        return NGX_PRECISE_TIMER_INFINITE;
+    }
+
+    node = ngx_rbtree_min(root, sentinel);
+    timer = (ngx_rbtree_key_int_t)
+                           (node->key - (ngx_rbtree_key_t) ngx_monotonic_usec());
+
+    return (ngx_usec_t) (timer > 0 ? timer : 0);
+}
+
+
+ngx_msec_t
+ngx_event_timer_timeout(ngx_msec_t timer)
+{
+    ngx_usec_t  precise;
+    ngx_msec_t  rounded;
+
+    precise = ngx_event_find_precise_timer();
+
+    if (precise == NGX_PRECISE_TIMER_INFINITE) {
+        return timer;
+    }
+
+    /* Round up on event backends without sub-millisecond waits. */
+
+    rounded = precise / 1000 + (precise % 1000 != 0);
+
+    return ngx_min(timer, rounded);
+}
+
+
+void
+ngx_event_add_precise_timer(ngx_event_t *ev, ngx_usec_t timer)
+{
+    if (ev->timer_set) {
+        ngx_del_timer(ev);
+    }
+
+    ev->timer.key = ngx_monotonic_usec() + timer;
+
+    ngx_log_debug2(NGX_LOG_DEBUG_EVENT, ev->log, 0,
+                   "event precise timer add: %d: %uL",
+                   ngx_event_ident(ev->data), timer);
+
+    ngx_rbtree_insert(&ngx_event_precise_timer_rbtree, &ev->timer);
+
+    ev->timer_set = 1;
+    ev->timer_precise = 1;
+}
+
+
 void
 ngx_event_expire_timers(void)
+{
+    ngx_event_expire_timer_tree(&ngx_event_timer_rbtree, ngx_current_msec);
+
+    if (ngx_event_precise_timer_rbtree.root
+        != ngx_event_precise_timer_rbtree.sentinel)
+    {
+        ngx_event_expire_timer_tree(&ngx_event_precise_timer_rbtree,
+                                   ngx_monotonic_usec());
+    }
+}
+
+
+static void
+ngx_event_expire_timer_tree(ngx_rbtree_t *tree, ngx_rbtree_key_t now)
 {
     ngx_event_t        *ev;
     ngx_rbtree_node_t  *node, *root, *sentinel;
 
-    sentinel = ngx_event_timer_rbtree.sentinel;
+    sentinel = tree->sentinel;
 
     for ( ;; ) {
-        root = ngx_event_timer_rbtree.root;
+        root = tree->root;
 
         if (root == sentinel) {
             return;
@@ -67,9 +154,9 @@ ngx_event_expire_timers(void)
 
         node = ngx_rbtree_min(root, sentinel);
 
-        /* node->key > ngx_current_msec */
+        /* node->key > now */
 
-        if ((ngx_msec_int_t) (node->key - ngx_current_msec) > 0) {
+        if ((ngx_rbtree_key_int_t) (node->key - now) > 0) {
             return;
         }
 
@@ -79,7 +166,7 @@ ngx_event_expire_timers(void)
                        "event timer del: %d: %M",
                        ngx_event_ident(ev->data), ev->timer.key);
 
-        ngx_rbtree_delete(&ngx_event_timer_rbtree, &ev->timer);
+        ngx_rbtree_delete(tree, &ev->timer);
 
 #if (NGX_DEBUG)
         ev->timer.left = NULL;
@@ -88,6 +175,7 @@ ngx_event_expire_timers(void)
 #endif
 
         ev->timer_set = 0;
+        ev->timer_precise = 0;
 
         ev->timedout = 1;
 
@@ -99,11 +187,22 @@ ngx_event_expire_timers(void)
 ngx_int_t
 ngx_event_no_timers_left(void)
 {
+    if (ngx_event_timer_tree_empty(&ngx_event_timer_rbtree) != NGX_OK) {
+        return NGX_AGAIN;
+    }
+
+    return ngx_event_timer_tree_empty(&ngx_event_precise_timer_rbtree);
+}
+
+
+static ngx_int_t
+ngx_event_timer_tree_empty(ngx_rbtree_t *tree)
+{
     ngx_event_t        *ev;
     ngx_rbtree_node_t  *node, *root, *sentinel;
 
-    sentinel = ngx_event_timer_rbtree.sentinel;
-    root = ngx_event_timer_rbtree.root;
+    sentinel = tree->sentinel;
+    root = tree->root;
 
     if (root == sentinel) {
         return NGX_OK;
@@ -111,7 +210,7 @@ ngx_event_no_timers_left(void)
 
     for (node = ngx_rbtree_min(root, sentinel);
          node;
-         node = ngx_rbtree_next(&ngx_event_timer_rbtree, node))
+         node = ngx_rbtree_next(tree, node))
     {
         ev = ngx_rbtree_data(node, ngx_event_t, timer);
 

--- a/src/event/ngx_event_timer.h
+++ b/src/event/ngx_event_timer.h
@@ -18,14 +18,21 @@
 
 #define NGX_TIMER_LAZY_DELAY  300
 
+#define NGX_PRECISE_TIMER_INFINITE  (ngx_usec_t) -1
+
 
 ngx_int_t ngx_event_timer_init(ngx_log_t *log);
 ngx_msec_t ngx_event_find_timer(void);
+ngx_usec_t ngx_event_find_precise_timer(void);
+ngx_msec_t ngx_event_timer_timeout(ngx_msec_t timer);
+/* Relative precise timers must be at most NGX_MAX_INT_T_VALUE usec. */
+void ngx_event_add_precise_timer(ngx_event_t *ev, ngx_usec_t timer);
 void ngx_event_expire_timers(void);
 ngx_int_t ngx_event_no_timers_left(void);
 
 
 extern ngx_rbtree_t  ngx_event_timer_rbtree;
+extern ngx_rbtree_t  ngx_event_precise_timer_rbtree;
 
 
 static ngx_inline void
@@ -35,7 +42,9 @@ ngx_event_del_timer(ngx_event_t *ev)
                    "event timer del: %d: %M",
                     ngx_event_ident(ev->data), ev->timer.key);
 
-    ngx_rbtree_delete(&ngx_event_timer_rbtree, &ev->timer);
+    ngx_rbtree_delete(ev->timer_precise ? &ngx_event_precise_timer_rbtree
+                                      : &ngx_event_timer_rbtree,
+                      &ev->timer);
 
 #if (NGX_DEBUG)
     ev->timer.left = NULL;
@@ -44,6 +53,7 @@ ngx_event_del_timer(ngx_event_t *ev)
 #endif
 
     ev->timer_set = 0;
+    ev->timer_precise = 0;
 }
 
 
@@ -52,6 +62,10 @@ ngx_event_add_timer(ngx_event_t *ev, ngx_msec_t timer)
 {
     ngx_msec_t      key;
     ngx_msec_int_t  diff;
+
+    if (ev->timer_set && ev->timer_precise) {
+        ngx_del_timer(ev);
+    }
 
     key = ngx_current_msec + timer;
 

--- a/src/event/quic/ngx_event_quic.c
+++ b/src/event/quic/ngx_event_quic.c
@@ -100,8 +100,16 @@ ngx_quic_connstate_dbg(ngx_connection_t *c)
     if (qc) {
 
         if (qc->push.timer_set) {
-            p = ngx_slprintf(p, last, " push:%M",
-                             qc->push.timer.key - ngx_current_msec);
+            if (qc->push.timer_precise) {
+                p = ngx_slprintf(p, last, " push:%uius",
+                      (ngx_rbtree_key_t) (qc->push.timer.key
+                                        - (ngx_rbtree_key_t)
+                                          ngx_monotonic_usec()));
+
+            } else {
+                p = ngx_slprintf(p, last, " push:%M",
+                                 qc->push.timer.key - ngx_current_msec);
+            }
         }
 
         if (qc->pto.timer_set) {

--- a/src/event/quic/ngx_event_quic_connection.h
+++ b/src/event/quic/ngx_event_quic_connection.h
@@ -186,6 +186,14 @@ typedef struct {
 } ngx_quic_congestion_t;
 
 
+typedef struct {
+    size_t                            budget;
+    size_t                            rate;
+    size_t                            fraction;
+    ngx_usec_t                        last;
+} ngx_quic_pacing_t;
+
+
 /*
  * RFC 9000, 12.3.  Packet Numbers
  *
@@ -280,6 +288,7 @@ struct ngx_quic_connection_s {
 
     ngx_quic_streams_t                streams;
     ngx_quic_congestion_t             congestion;
+    ngx_quic_pacing_t                 pacing;
 
     uint64_t                          rst_pnum;    /* first on validated path */
 

--- a/src/event/quic/ngx_event_quic_migration.c
+++ b/src/event/quic/ngx_event_quic_migration.c
@@ -189,6 +189,8 @@ valid:
         qc->congestion.mtu = NGX_QUIC_MIN_INITIAL_SIZE;
         qc->congestion.recovery_start = ngx_current_msec - 1;
 
+        ngx_memzero(&qc->pacing, sizeof(ngx_quic_pacing_t));
+
         ngx_quic_init_rtt(qc);
     }
 

--- a/src/event/quic/ngx_event_quic_output.c
+++ b/src/event/quic/ngx_event_quic_output.c
@@ -12,6 +12,7 @@
 
 #define NGX_QUIC_MAX_UDP_SEGMENT_BUF  65487 /* 65K - IPv6 header */
 #define NGX_QUIC_MAX_SEGMENTS            64 /* UDP_MAX_SEGMENTS */
+#define NGX_QUIC_PACING_MAX_BURST        10
 
 #define NGX_QUIC_RETRY_TOKEN_LIFETIME     3 /* seconds */
 #define NGX_QUIC_NEW_TOKEN_LIFETIME     600 /* seconds */
@@ -44,6 +45,8 @@
                     (pkt)->trunc);
 
 
+static void ngx_quic_pacing_update(ngx_connection_t *c);
+static void ngx_quic_pacing_delay(ngx_connection_t *c);
 static ngx_int_t ngx_quic_create_datagrams(ngx_connection_t *c);
 static void ngx_quic_commit_send(ngx_connection_t *c);
 static void ngx_quic_revert_send(ngx_connection_t *c,
@@ -80,6 +83,12 @@ ngx_quic_output(ngx_connection_t *c)
     qc = ngx_quic_get_connection(c);
     cg = &qc->congestion;
 
+    if (qc->push.timer_set) {
+        ngx_del_timer(&qc->push);
+    }
+
+    ngx_quic_pacing_update(c);
+
     in_flight = cg->in_flight;
 
 #if ((NGX_HAVE_UDP_SEGMENT) && (NGX_HAVE_MSGHDR_MSG_CONTROL))
@@ -95,6 +104,8 @@ ngx_quic_output(ngx_connection_t *c)
         return NGX_ERROR;
     }
 
+    ngx_quic_pacing_delay(c);
+
     if (in_flight == cg->in_flight || qc->closing) {
         /* no ack-eliciting data was sent or we are done */
         return NGX_OK;
@@ -108,6 +119,147 @@ ngx_quic_output(ngx_connection_t *c)
     ngx_quic_set_lost_timer(c);
 
     return NGX_OK;
+}
+
+
+static void
+ngx_quic_pacing_update(ngx_connection_t *c)
+{
+    size_t                  rate, burst, left, credit;
+    ngx_usec_t              now;
+    ngx_usec_int_t          elapsed;
+    ngx_quic_pacing_t      *pace;
+    ngx_quic_congestion_t  *cg;
+    ngx_quic_connection_t  *qc;
+
+    qc = ngx_quic_get_connection(c);
+    cg = &qc->congestion;
+    pace = &qc->pacing;
+
+    rate = cg->window / ngx_max(qc->avg_rtt, 1);
+    rate = ngx_min(rate, NGX_MAX_SIZE_T_VALUE / 2);
+    rate = (cg->window < cg->ssthresh) ? rate * 2 : rate + rate / 4;
+    rate = ngx_max(rate, 1);
+
+    /* Bound accumulated credit, including all GSO batches. */
+
+    burst = ngx_max(rate + qc->path->mtu, 2 * qc->path->mtu);
+    burst = ngx_min(burst, NGX_QUIC_PACING_MAX_BURST * qc->path->mtu);
+
+    if (qc->first_rtt == NGX_TIMER_INFINITE) {
+        /* Do not pace the first flight using the provisional RTT. */
+        burst = 10 * NGX_QUIC_MIN_INITIAL_SIZE;
+    }
+
+    burst = ngx_max(qc->path->mtu, ngx_min(burst, cg->window));
+    now = ngx_monotonic_usec();
+
+    if (pace->rate == 0) {
+        pace->budget = burst;
+        pace->fraction = 0;
+        pace->last = now;
+
+    } else {
+        pace->budget = ngx_min(pace->budget, burst);
+        elapsed = (ngx_usec_int_t) (now - pace->last);
+        left = burst - pace->budget;
+
+        if (left == 0) {
+            pace->fraction = 0;
+
+        } else if (elapsed > 0) {
+            /* Do not apply a rate increase retroactively. */
+            pace->rate = ngx_min(pace->rate, rate);
+
+            /* The bucket holds at most ten QUIC UDP payload sizes. */
+            credit = left * 1000 - pace->fraction;
+
+            if ((ngx_usec_t) elapsed >= credit / pace->rate
+                                         + (credit % pace->rate != 0))
+            {
+                pace->budget = burst;
+                pace->fraction = 0;
+
+            } else {
+                credit = elapsed * pace->rate + pace->fraction;
+                pace->budget += credit / 1000;
+                pace->fraction = credit % 1000;
+            }
+        }
+
+        if (elapsed >= 0) {
+            pace->last = now;
+        }
+    }
+
+    pace->rate = rate;
+}
+
+
+static void
+ngx_quic_pacing_delay(ngx_connection_t *c)
+{
+    size_t                  left;
+    ngx_uint_t              i;
+    ngx_msec_int_t          timer;
+    ngx_usec_t              now, delay, elapsed, remaining;
+    ngx_quic_pacing_t      *pace;
+    ngx_quic_connection_t  *qc;
+
+    qc = ngx_quic_get_connection(c);
+    pace = &qc->pacing;
+
+    if (qc->closing || qc->congestion.in_flight >= qc->congestion.window
+        || pace->budget >= qc->path->mtu)
+    {
+        return;
+    }
+
+    for (i = 0; i < NGX_QUIC_SEND_CTX_LAST; i++) {
+        if (!ngx_queue_empty(&qc->send_ctx[i].frames)) {
+            break;
+        }
+    }
+
+    if (i == NGX_QUIC_SEND_CTX_LAST) {
+        return;
+    }
+
+    left = (qc->path->mtu - pace->budget) * 1000 - pace->fraction;
+    delay = left / pace->rate + (left % pace->rate != 0);
+
+    now = ngx_monotonic_usec();
+    elapsed = now - pace->last;
+
+    if ((ngx_usec_int_t) elapsed > 0) {
+        delay = (elapsed < delay) ? delay - elapsed : 1;
+    }
+
+    if (qc->push.timer_set) {
+        /* ACK and socket retry deadlines remain in milliseconds. */
+#if (NGX_HAVE_CLOCK_MONOTONIC)
+        timer = (ngx_msec_int_t)
+                   (qc->push.timer.key - (ngx_msec_t) (now / 1000));
+#else
+        timer = (ngx_msec_int_t) (qc->push.timer.key - ngx_current_msec);
+#endif
+
+        if (timer <= 0) {
+            return;
+        }
+
+        if ((ngx_usec_t) timer <= delay / 1000 + 1) {
+            remaining = (ngx_usec_t) timer * 1000 - now % 1000;
+
+            if (remaining <= delay) {
+                return;
+            }
+        }
+
+        ngx_del_timer(&qc->push);
+    }
+
+    ngx_event_add_precise_timer(&qc->push, delay);
 }
 
 
@@ -160,7 +312,8 @@ ngx_quic_create_datagrams(ngx_connection_t *c)
             }
 
             n = ngx_quic_output_packet(c, ctx, p, len, min,
-                                       cg->in_flight >= cg->window);
+                                       cg->in_flight >= cg->window
+                                       || qc->pacing.budget < path->mtu);
             if (n == NGX_ERROR) {
                 return NGX_ERROR;
             }
@@ -229,6 +382,7 @@ ngx_quic_commit_send(ngx_connection_t *c)
                 ngx_queue_insert_tail(&ctx->sent, q);
 
                 cg->in_flight += f->plen;
+                qc->pacing.budget -= ngx_min(qc->pacing.budget, f->plen);
 
             } else {
                 ngx_quic_free_frame(c, f);
@@ -310,6 +464,10 @@ ngx_quic_allow_segmentation(ngx_connection_t *c)
     bytes = 0;
     len = ngx_min(qc->path->mtu, NGX_QUIC_MAX_UDP_SEGMENT_BUF);
 
+    if (qc->pacing.budget < len * 3) {
+        return 0;
+    }
+
     for (q = ngx_queue_head(&ctx->frames);
          q != ngx_queue_sentinel(&ctx->frames);
          q = ngx_queue_next(q))
@@ -369,7 +527,9 @@ ngx_quic_create_segments(ngx_connection_t *c)
 
         len = ngx_min(segsize, (size_t) (end - p));
 
-        if (len && cg->in_flight + (p - dst) < cg->window) {
+        if (len && cg->in_flight + (p - dst) < cg->window
+            && (size_t) (p - dst) + len <= qc->pacing.budget)
+        {
 
             n = ngx_quic_output_packet(c, ctx, p, len, len, 0);
             if (n == NGX_ERROR) {


### PR DESCRIPTION
This change adds a connection-wide pacing budget to reduce bursts when queued QUIC output is released. Both normal datagrams and GSO batches consume the same credit, capped at ten path MTUs. Credit accumulates in microseconds with fractional-byte accounting; rates still use the existing congestion window and millisecond average RTT.

A separate event-timer tree supplies precise deadlines. Linux uses epoll_pwait2() when available, with runtime fallback to epoll_wait(); kqueue uses timespec timeouts. Other backends round waits up to milliseconds. Ordinary timers retain their units. Initial-flight handling, ACK-only output, send rollback and existing direct control/probe paths are preserved.

Related to #1498. This does not fully fix or close that issue, and is not a general throughput improvement. The timer API, burst policy and platform support still need review.

### Measurements

Existing measurements, not a rerun for PR preparation. Controlled tests used one worker on a two-vCPU Linux KVM host, isolated network namespaces, one 32-MiB HTTP/3 response, a 1-MiB stream buffer, TLS AES-128-GCM and a 1000-packet queue. Values are medians of three measured transfers after one warmup. RTT below is **added RTT**, not actual RTT; zero still includes stack and scheduling latency.

Each table cell is **stock / pacer**. CPU is server process CPU seconds per 32 MiB, measured at 10-ms granularity, not whole-host utilization.

| Added RTT, ms | GSO off, Mbit/s | GSO on, Mbit/s | CPU off, s | CPU on, s |
|---:|---:|---:|---:|---:|
| 0 | 1192.2 / 1182.4 | 3574.3 / 2292.2 | 0.22 / 0.23 | 0.05 / 0.08 |
| 1 | 1057.1 / 772.6 | 657.0 / 1792.4 | 0.24 / 0.27 | 0.08 / 0.12 |
| 2 | 826.0 / 957.7 | 430.1 / 1806.5 | 0.22 / 0.26 | 0.09 / 0.12 |
| 4 | 654.0 / 930.6 | 231.6 / 1461.3 | 0.24 / 0.25 | 0.08 / 0.11 |
| 8 | 265.0 / 738.7 | 104.6 / 796.1 | 0.34 / 0.28 | 0.09 / 0.14 |
| 16 | 99.5 / 411.5 | 66.9 / 405.1 | 0.37 / 0.25 | 0.11 / 0.20 |
| 32 | 36.3 / 208.3 | 37.3 / 208.2 | 0.30 / 0.38 | 0.10 / 0.24 |

The near-zero-RTT GSO regression is substantial: 3574.3 → 2292.2 Mbit/s with CPU 0.05 → 0.08 s. GSO-off at 1 ms also regresses, 1057.1 → 772.6 Mbit/s. Benefits at larger added RTT do not outweigh these cases automatically; several cells have wide run-to-run ranges.

A separate 250-Mbit/s, 64-packet-queue pass is also mixed:

| Added RTT, ms | GSO off, Mbit/s | GSO on, Mbit/s | CPU off, s | CPU on, s |
|---:|---:|---:|---:|---:|
| 4 | 207.2 / 201.2 | 197.6 / 196.4 | 0.44 / 0.47 | 0.21 / 0.50 |
| 16 | 42.3 / 65.2 | 82.5 / 63.8 | 0.62 / 0.93 | 0.18 / 0.90 |

In particular, 16-ms GSO throughput drops 82.5 → 63.8 Mbit/s while CPU rises 0.18 → 0.90 s. The stock throughput range there was 58.4–210.4 Mbit/s.

A separate quiet WAN comparison using identical curl/QUIC runtime binaries and 16-MiB responses gave native-Linux medians of 295.5 → 297.3 Mbit/s without GSO and 324.7 → 344.8 with GSO. GSO server CPU rose 0.11 → 0.18 s. The Windows/WSL receiver remained slow, including a GSO regression of 98.2 → 86.9 Mbit/s. These are different experiments and are not pooled.

A focused 0/1/2-ms investigation found RTT quantization, but a diagnostic microsecond RTT estimator did not remove the near-zero-RTT GSO regression. The ten-MTU cap and associated batching/wakeup cost dominated that case. Larger diagnostic bursts improved one case but had negative cases elsewhere; neither those bursts nor an RTT-estimator change is included here.

### Production follow-up (2026-09-07)

A manual comparison on the affected Contabo deployment now reports substantially improved Brave download throughput. The server runs nginx 1.31.5 on Ubuntu 24.04 and is capped at 250 Mbit/s. This case is a 1-GiB OpenCloud download proxied by nginx.

Both conditions used the same effective nginx configuration, including:

```nginx
quic_gso on;
http3_stream_buffer_size 1m;
```

| Build | Browser-reported download rate |
|---|---:|
| Original packaged nginx 1.31.5 | approximately 7–8 MB/s |
| This PR, commit `64aafe015` | approximately 17–20 MB/s; peak approximately 25 MB/s |

The packaged and patched binaries were switched on the same host, retaining the configuration byte for byte. Each switch restarted nginx, and the running master/worker binary identities were checked. Server access logs confirm HTTP/3 for both recent download conditions.

This resolves the severe slowdown in my current deployment. This result uses pacing together with the larger stream buffer; an earlier paced run with the default 64-KiB buffer remained slow. The rates above are approximate manual browser observations, separate from the controlled benchmark tables. The access-log format does not contain request durations, and production CPU cost and repeatability have not been quantified. These observations do not establish a general fix for #1498 or remove the regressions documented above.

### Validation and limits

Final sanity checks on this exact source: GCC rebuild and configuration checks with GSO off/on; 6729 timer and 2152 pacing harness checks under ASan/UBSan; h3_congestion_ack.t, h3_pacing_bulk.t, h3_keepalive.t and quic_migration.t passed with GSO off/on (existing TODO/skips retained). The bulk fixture checks exact bytes, multiplexing, subsequent requests and closing queued output.

Earlier validation included GCC/Clang QUIC suites, epoll fallback, real 32-bit timer checks and compilation without GSO or CLOCK_MONOTONIC. Integration sanitizers retain stock alignment and reload-leak findings; no blanket clean sanitizer/full-suite result is claimed.

Kqueue has not been built or run in this work. Coarse backends retain coarse pacing. Timer wakeup jitter, CPU cost with many active connections, GSO microbursts, millisecond RTT quantization and flow-control limits remain. The 1-MiB benchmark stream buffer differs from nginx's 64-KiB default. The production follow-up is limited to the reported deployment; its CPU cost and run-to-run variation remain unmeasured.

Validation sources and detailed retained results: [Companion tests and benchmark evidence](https://github.com/zerox80/nginx/tree/c5e5ede5069348a142c2aac8b2f5fb2fb582346c/pacing-validation).

AI assistance: OpenAI Codex assisted with implementation, tests, measurements and this description.
