### PR TITLE
HTTP: enforce client_max_body_size on discarded chunked bodies

### DIFF
--- a/src/http/ngx_http_request_body.c
+++ b/src/http/ngx_http_request_body.c
@@ -850,6 +850,7 @@ ngx_http_discard_request_body_filter(ngx_http_request_t *r, ngx_buf_t *b)
     ngx_int_t                  rc;
     ngx_http_request_body_t   *rb;
     ngx_http_core_srv_conf_t  *cscf;
+    ngx_http_core_loc_conf_t  *clcf;
 
     if (r->headers_in.chunked) {
 
@@ -878,13 +879,31 @@ ngx_http_discard_request_body_filter(ngx_http_request_t *r, ngx_buf_t *b)
 
                 /* a chunk has been parsed successfully */
 
+                clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+                if (clcf->client_max_body_size
+                    && clcf->client_max_body_size - rb->received
+                       < rb->chunked->size)
+                {
+                    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                                  "client intended to send too large chunked "
+                                  "body: %O+%O bytes",
+                                  rb->received, rb->chunked->size);
+
+                    r->lingering_close = 1;
+
+                    return NGX_HTTP_REQUEST_ENTITY_TOO_LARGE;
+                }
+
                 size = b->last - b->pos;
 
                 if ((off_t) size > rb->chunked->size) {
                     b->pos += (size_t) rb->chunked->size;
+                    rb->received += rb->chunked->size;
                     rb->chunked->size = 0;
 
                 } else {
+                    rb->received += size;
                     rb->chunked->size -= size;
                     b->pos = b->last;
                 }


### PR DESCRIPTION
## Problem

`client_max_body_size` is enforced for a `Content-Length` body (core content-phase check) and for a chunked body actually read by a handler (`ngx_http_request_body_chunked_filter()`), but not for a chunked body that a handler *discards* — `return`, redirects, error/special responses, or any handler that doesn't read the body. `ngx_http_discard_request_body_filter()`'s chunked branch parses and skips every chunk via `ngx_http_parse_chunked()` without ever comparing decoded size against the configured limit. An unauthenticated client can send a chunked body of unbounded decoded size to such an endpoint and nginx will fully drain it and return the normal response instead of 413.

Full writeup and PoC: #1522.

## This fix vs. #1540

#1540 already proposes a fix for this issue, but it has a correctness bug: it accumulates `rb->received += b->last - b->pos` at every `NGX_OK` (chunk-header-parsed) point. `b->last` is the end of the *entire currently buffered read*, not the end of the current chunk — so when more than one chunk's data (or a following chunk's header) sits in the same discard buffer (`NGX_HTTP_DISCARD_BUFFER_SIZE` is 4096 bytes, so this is the common case for any body made of several small chunks), the counted ranges overlap across loop iterations and `rb->received` is overcounted, sometimes drastically.

Verified concretely: `client_max_body_size 2048`, a *legitimate* 2000-byte chunked body sent as 10×200-byte chunks in a single write (so it lands in one discard-filter buffer) —

- **#1540's patch:** wrongly rejected with `413` (first chunk's iteration alone counts most of the remaining buffer, not just its own 200 bytes).
- **This patch:** correctly returns `200`.

Both patches correctly reject the actual over-limit case from #1522 (4096-byte body against a 1–2k limit).

## Fix

Mirror `ngx_http_request_body_chunked_filter()`'s existing (and already-correct) approach exactly, rather than re-deriving the accounting:

- As each chunk header is parsed, compare the *remaining budget* against the chunk's declared size — `clcf->client_max_body_size - rb->received < rb->chunked->size` — and reject with 413 before consuming any of that chunk's data. This also catches a single oversized chunk declaration immediately, without waiting for that many bytes to actually arrive.
- Advance `rb->received` by the amount of chunk data actually consumed in this iteration (`min(available, rb->chunked->size)`), matching the existing `b->pos`/`rb->chunked->size` bookkeeping already in the function.

`rb->received` is an existing, already-zeroed field on `ngx_http_request_body_t`, unused elsewhere on the discard path (`r->headers_in.content_length_n` is already repurposed there as a read-size hint for `NGX_AGAIN`, so it isn't available for this).

## Testing

Manual, against a `--with-debug` build (no `--without-http_rewrite_module` needed; used the static file module, which calls `ngx_http_discard_request_body()` itself, as the discard handler):

- Over-limit chunked body (4096 bytes, `client_max_body_size 2048`): `413` (was `204`/normal response before the fix).
- Legitimate chunked body well under the limit (2000 bytes as 10×200-byte chunks, `client_max_body_size 2048`): `200` — confirms no false-positive regression from the accounting change.
- Same two cases re-run against #1540's patch for direct comparison, reproducing its false-positive on the second case as described above.

- [X] Manual Testing
- [ ] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests)) — not run; happy to run this if requested
- [X] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [X] My branch is rebased on the latest master
- [X] This PR targets the master branch from my fork

Closes #1522

🤖 Generated with [Claude Code](https://claude.com/claude-code)