### PR TITLE
Handle predicate location variable error

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1514,8 +1514,11 @@ ngx_http_core_find_location(ngx_http_request_t *r)
                            "test location: \"%V\"", &(*clcfp)->name);
 
             vv = ngx_http_get_flushed_variable(r, (*clcfp)->predicate - 1);
+            if (vv == NULL) {
+                return NGX_ERROR;
+            }
 
-            if (vv && vv->len && (vv->len != 1 || vv->data[0] != '0')) {
+            if (vv->len && (vv->len != 1 || vv->data[0] != '0')) {
                 r->loc_conf = (*clcfp)->loc_conf;
 
                 /* look up nested locations */


### PR DESCRIPTION
Previously, the error was ignored and the predicate was treated as false.  Now the error leads to the request finalization.