### PR TITLE
Handle nested location lookup error

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1470,7 +1470,7 @@ ngx_http_core_find_location(ngx_http_request_t *r)
         rc = ngx_http_core_find_location(r);
     }
 
-    if (rc == NGX_OK || rc == NGX_DONE) {
+    if (rc == NGX_OK || rc == NGX_DONE || rc == NGX_ERROR) {
         return rc;
     }
 


### PR DESCRIPTION
Previously, when looking up a nested location after an inclusive match, the lookup error was ignored.  Such error could result from regex match fail in a nested regex location.  Now the error leads to the request finalization.