### PR TITLE
Proxy: keep HTTP/2 upstream alive after empty-body responses

### DIFF
--- a/src/http/modules/ngx_http_proxy_v2_module.c
+++ b/src/http/modules/ngx_http_proxy_v2_module.c
@@ -1750,9 +1750,38 @@ ngx_http_proxy_v2_filter_init(void *data)
             return NGX_ERROR;
         }
 
-        u->length = 0;
-        u->pipe->length = 0;
         ctx->done = 1;
+
+        if (ctx->out == NULL
+            && u->buffer.pos == u->buffer.last
+            && u->pipe->preread_size == 0)
+        {
+            /* the response is complete */
+
+            u->length = 0;
+            u->pipe->length = 0;
+
+        } else {
+
+            /*
+             * Control frames were received along with the response headers,
+             * either still unparsed - left in the buffer, or moved to the
+             * pipe as preread data - or already parsed and awaiting a reply,
+             * most commonly an acknowledgement of the peer's initial
+             * SETTINGS.  Keep the length set so that the exchange is
+             * completed in the usual way, by
+             * ngx_http_proxy_v2_process_frames() on the read side and by
+             * ngx_http_proxy_v2_body_output_filter() on the write side,
+             * either of which then resolves keepalive.
+             */
+
+            u->length = 1;
+            u->pipe->length = 1;
+
+            if (ctx->out) {
+                ngx_post_event(u->peer.connection->write, &ngx_posted_events);
+            }
+        }
 
     } else {
         u->length = 1;


### PR DESCRIPTION
When an HTTP/2 upstream response carries END_STREAM in the headers (an empty body, e.g. `Content-Length: 0`), `filter_init()` completed the request immediately by setting the response length to 0. If the same read also delivered connection control frames, the request was finalized before those frames were dealt with, so `u->keepalive` was never set and the connection was closed rather than reused.

There are two orderings. The frames may arrive *after* the response headers and still be unparsed — left in the buffer, or moved to the pipe as preread data. Or they may arrive *before* them, in which case `ngx_http_proxy_v2_process_header()` has already parsed them and left a reply queued in `ctx->out`, most commonly an acknowledgement of the peer's initial SETTINGS. The latter is the common case, and it is self-sustaining: the connection is closed, so the next request opens a new one, which again begins with SETTINGS.

This only takes the immediate-completion shortcut when there is nothing left to read *and* nothing queued to send. Otherwise the length is kept set so the exchange completes in the usual way, via `ngx_http_proxy_v2_process_frames()` on the read side or `ngx_http_proxy_v2_body_output_filter()` on the write side, either of which then resolves keepalive. A write event is posted when frames are queued, as the response has been fully read by that point and nothing else would trigger the flush.

Tested with a raw-frame HTTP/2 origin that deterministically coalesces the server SETTINGS with an empty-body `HEADERS(END_STREAM)` in a single write. 400 requests, 16-way concurrent, `keepalive 8`:

| build | upstream connections | requests |
|---|---|---|
| master | 400 | 400 |
| master + this patch | 13 | 400 |

Also tested with `proxy_buffering` on and off, and with the frames coalesced before the response, after it, and not at all. The SETTINGS and PING acknowledgements required by RFC 9113 §6.5.3 and §6.7 are sent in all cases.

Closes: https://github.com/nginx/nginx/issues/1726
