### PR TITLE
Fixed predicate location test with not found variables

### DIFF
--- a/src/http/ngx_http_core_module.c
+++ b/src/http/ngx_http_core_module.c
@@ -1518,7 +1518,9 @@ ngx_http_core_find_location(ngx_http_request_t *r)
                 return NGX_ERROR;
             }
 
-            if (vv->len && (vv->len != 1 || vv->data[0] != '0')) {
+            if (!vv->not_found
+                && vv->len && (vv->len != 1 || vv->data[0] != '0'))
+            {
                 r->loc_conf = (*clcfp)->loc_conf;
 
                 /* look up nested locations */


### PR DESCRIPTION
A variable value marked as not found was tested by its length, which most variable handlers leave intact.  With non-cacheable variables, a value from an earlier evaluation could be reused during location search, for example after a rewrite dropped the request arguments.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [ ] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)