### PR TITLE
Control API: fixed socket inheritance on binary upgrade

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -289,6 +289,10 @@ main(int argc, char *const *argv)
         return 1;
     }
 
+#if (NGX_CONTROL_API)
+    ngx_control_preinit();
+#endif
+
     if (ngx_preinit_modules() != NGX_OK) {
         return 1;
     }

--- a/src/os/unix/ngx_control.c
+++ b/src/os/unix/ngx_control.c
@@ -77,6 +77,7 @@ static struct pollfd          ngx_control_pollfd[NGX_CTRL_MAX_FD];
 static ngx_uint_t             ngx_control_pollfd_n;
 static char                   ngx_control_unix_path[NGX_UNIX_ADDRSTRLEN];
 static ngx_uint_t             ngx_control_inherited;
+static u_char                *ngx_control_env;
 ngx_uint_t                    ngx_control_api_enabled;
 
 
@@ -129,6 +130,18 @@ static ngx_data_decl_t  ngx_control_config_fields[] = {
 
       ngx_data_null_decl
 };
+
+
+void
+ngx_control_preinit(void)
+{
+    /*
+     * the variable is read before ngx_init_cycle(), which may replace
+     * the environment while parsing configuration
+     */
+
+    ngx_control_env = (u_char *) getenv(NGX_CTRL_ENV);
+}
 
 
 ngx_int_t
@@ -382,7 +395,7 @@ ngx_control_inherit(void)
     u_char    *env;
     ngx_fd_t   fd;
 
-    env = (u_char *) getenv(NGX_CTRL_ENV);
+    env = ngx_control_env;
     if (env == NULL) {
         return NGX_DECLINED;
     }

--- a/src/os/unix/ngx_control.h
+++ b/src/os/unix/ngx_control.h
@@ -12,6 +12,7 @@
 #include <ngx_core.h>
 
 
+void ngx_control_preinit(void);
 ngx_int_t ngx_control_init(u_char *addr);
 void ngx_control_uninit(void);
 void ngx_control_close_sockets(void);


### PR DESCRIPTION
The environment may be replaced while parsing configuration, as it happens with the perl module, which calls ngx_set_environment() when creating an interpreter.  As a result, the control socket was not inherited on binary upgrade.

The variable is now read before ngx_init_cycle(), similarly to inherited listening sockets.

## Testing

--with-control-api --with-http_perl_module
