### PR TITLE
Copy: reliably cast next_body_filter to output_filter

### DIFF
--- a/src/http/ngx_http_copy_filter_module.c
+++ b/src/http/ngx_http_copy_filter_module.c
@@ -15,6 +15,7 @@ typedef struct {
 } ngx_http_copy_filter_conf_t;
 
 
+static ngx_int_t ngx_http_copy_body_output_filter(void *data, ngx_chain_t *in);
 #if (NGX_HAVE_FILE_AIO)
 static void ngx_http_copy_aio_handler(ngx_output_chain_ctx_t *ctx,
     ngx_file_t *file);
@@ -117,8 +118,7 @@ ngx_http_copy_filter(ngx_http_request_t *r, ngx_chain_t *in)
         ctx->bufs = conf->bufs;
         ctx->tag = (ngx_buf_tag_t) &ngx_http_copy_filter_module;
 
-        ctx->output_filter = (ngx_output_chain_filter_pt)
-                                  ngx_http_next_body_filter;
+        ctx->output_filter = ngx_http_copy_body_output_filter;
         ctx->filter_ctx = r;
 
 #if (NGX_HAVE_FILE_AIO)
@@ -155,6 +155,15 @@ ngx_http_copy_filter(ngx_http_request_t *r, ngx_chain_t *in)
                    "http copy filter: %i \"%V?%V\"", rc, &r->uri, &r->args);
 
     return rc;
+}
+
+
+static ngx_int_t
+ngx_http_copy_body_output_filter(void *data, ngx_chain_t *in)
+{
+    ngx_http_request_t  *r = data;
+
+    return ngx_http_next_body_filter(r, in);
 }
 
 


### PR DESCRIPTION
## Problem

ngx_http_copy_filter performs a direct cast between two incompatible function pointer types . 

The C standard states that:
"A pointer to a function of one type may be converted to a pointer to a function of another type and back again; the result shall compare equal to the original pointer. If a converted pointer is used to call a function whose type is not compatible with the referenced type, the behavior is undefined."

Unfortunately, in this case the function types are not compatible (void * vs. ngx_http_request_t *), so calling through a directly cast pointer is UB, which is found by both clang UBSan and CFI sanitizers.

Originally I was collecting nginx coverage after some fuzzing and encountered some weird issue when nginx silently died with non-zero exit code. After a very long and painful investigation, it turned out that UBSan and AFL++ were killing nginx when the output_filter from the copy module is called.

Using CFI with some compilation option tweaks helped to track down the source.

## Solution

The solution is to write a wrapper that returns correct function pointer.

## Testing

After adding wrapper, both UBSan and CFI stopped reporting UB.

Unfortunately, I couldn't reproduce this behaviour without patching nginx exit condition and without compiling it with afl-clang-fast or afl-clang-lto. So it may be caused by the UB, the AFL compiler, and the patch I'm using for fuzzing.

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** No open issue.

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)

