### PR TITLE
phase: skip initialization loop when handlers array is empty

### DIFF
--- a/src/http/ngx_http.c
+++ b/src/http/ngx_http.c
@@ -545,14 +545,15 @@ ngx_http_init_phase_handlers(ngx_conf_t *cf, ngx_http_core_main_conf_t *cmcf)
         default:
             checker = ngx_http_core_generic_phase;
         }
+        if (cmcf->phases[i].handlers.nelts > 0) {
+            n += cmcf->phases[i].handlers.nelts;
 
-        n += cmcf->phases[i].handlers.nelts;
-
-        for (j = cmcf->phases[i].handlers.nelts - 1; j >= 0; j--) {
-            ph->checker = checker;
-            ph->handler = h[j];
-            ph->next = n;
-            ph++;
+            for (j = cmcf->phases[i].handlers.nelts - 1; j >= 0; j--) {
+                ph->checker = checker;
+                ph->handler = h[j];
+                ph->next = n;
+                ph++;
+            }
         }
     }
 

--- a/src/stream/ngx_stream.c
+++ b/src/stream/ngx_stream.c
@@ -371,13 +371,15 @@ ngx_stream_init_phase_handlers(ngx_conf_t *cf,
             checker = ngx_stream_core_generic_phase;
         }
 
-        n += cmcf->phases[i].handlers.nelts;
+        if (cmcf->phases[i].handlers.nelts > 0) {
+            n += cmcf->phases[i].handlers.nelts;
 
-        for (j = cmcf->phases[i].handlers.nelts - 1; j >= 0; j--) {
-            ph->checker = checker;
-            ph->handler = h[j];
-            ph->next = n;
-            ph++;
+            for (j = cmcf->phases[i].handlers.nelts - 1; j >= 0; j--) {
+                ph->checker = checker;
+                ph->handler = h[j];
+                ph->next = n;
+                ph++;
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

If no phase handlers are provided, the loop counter overflows due to (ngx_uint_t)0 - 1 and then overflows again due to (ngx_uint_t)-1 -> (ngx_int_t)j conversion.

## Solution

Add an explicit check for non-zero handler count before iteration, avoiding unnecessary work and preventing potential issues in future.

## Testing

Describe how you tested the change (manual testing, automated tests,
regression tests, etc.).

- [x] Manual Testing
- [x] Functional Testing ([nginx-tests](https://github.com/nginx/nginx-tests))

**Closes:** No existing issue.

## Checklist

Before submitting this PR, please confirm:

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx/blob/master/CONTRIBUTING.md) guidelines
- [x] I have added tests (if applicable) to validate my changes
- [x] All existing tests pass
- [x] I have updated documentation where necessary
- [x] My branch is rebased on the latest master
- [x] This PR targets the master branch from my fork
- [x] My commit message follows NGINX standards (imperative mood, clear
      subject, references related issue if applicable, and contains only
      relevant changes)
