### PR TITLE
Win32: fix the time_t macros for 32-bit builds

### DIFF
--- a/src/os/win32/ngx_win32_config.h
+++ b/src/os/win32/ngx_win32_config.h
@@ -217,18 +217,33 @@ typedef int                 sig_atomic_t;
 #define NGX_PTR_SIZE            8
 #define NGX_SIZE_T_LEN          (sizeof("-9223372036854775808") - 1)
 #define NGX_MAX_SIZE_T_VALUE    9223372036854775807
-#define NGX_TIME_T_LEN          (sizeof("-9223372036854775808") - 1)
-#define NGX_TIME_T_SIZE         8
-#define NGX_MAX_TIME_T_VALUE    9223372036854775807
 
 #else
 
 #define NGX_PTR_SIZE            4
 #define NGX_SIZE_T_LEN          (sizeof("-2147483648") - 1)
 #define NGX_MAX_SIZE_T_VALUE    2147483647
+
+#endif
+
+
+/*
+ * the size of time_t is determined by the C run-time, not by the size of
+ * a pointer: 32-bit builds against a modern CRT have a 64-bit time_t.
+ * _USE_32BIT_TIME_T is the macro the CRT itself keys the typedef off.
+ */
+
+#ifdef _USE_32BIT_TIME_T
+
 #define NGX_TIME_T_LEN          (sizeof("-2147483648") - 1)
 #define NGX_TIME_T_SIZE         4
 #define NGX_MAX_TIME_T_VALUE    2147483647
+
+#else
+
+#define NGX_TIME_T_LEN          (sizeof("-9223372036854775808") - 1)
+#define NGX_TIME_T_SIZE         8
+#define NGX_MAX_TIME_T_VALUE    9223372036854775807
 
 #endif
 


### PR DESCRIPTION

```
Win32: fix the time_t macros for 32-bit builds

NGX_TIME_T_LEN, NGX_TIME_T_SIZE and NGX_MAX_TIME_T_VALUE were derived
from _WIN64, that is, from the size of a pointer.  On Windows though the
width of time_t is decided by the C run-time, not by the size of a
pointer.  The two have been independent since VC2005, where time_t
became 64-bit by default while long remained 32-bit.

So the default 32-bit build gets NGX_TIME_T_SIZE 4 while time_t is
really 8.  Measured with MSVC 19.44 (VS 2022, UCRT):

  build                     sizeof(void *)  sizeof(time_t)  NGX_TIME_T_SIZE
  x86, no special flags                  4               8                4
  x86, /D_USE_32BIT_TIME_T               4               4                4
  x64                                    8               8                8

The most visible effect is that ngx_parse_http_time() keeps its

  #if (NGX_TIME_T_SIZE <= 4)

clamp and so refuses to parse any date beyond 2038 in If-Modified-Since,
If-Unmodified-Since, If-Range, Last-Modified and Expires.  ngx_atotm()
likewise caps at 2^31-1, and the NGX_MAX_TIME_T_VALUE sentinel used for
indefinite OCSP validity becomes a real date rather than an unreachable
one.  NGX_TIME_T_SIZE is also part of NGX_MODULE_SIGNATURE_0, where it
can no longer distinguish builds with differing time_t widths.

Split the time_t macros out of the pointer size block and key them off
_USE_32BIT_TIME_T, the macro the C run-time itself keys the typedef off.
It cannot be defined for 64-bit builds, where it is a hard error, so the
_WIN64 case is unaffected.

Assisted-by: GitHub Copilot:claude-opus-5
```