### PR TITLE
HTTP/3: preserve unknown-frame skipping across body buffers.

### DIFF
--- a/src/http/v3/ngx_http_v3_parse.c
+++ b/src/http/v3/ngx_http_v3_parse.c
@@ -1875,6 +1875,7 @@ ngx_http_v3_parse_data(ngx_connection_t *c, ngx_http_v3_parse_data_t *st,
                 return rc;
             }
 
+            st->length = 0;
             st->state = sw_type;
             break;
         }

--- a/src/http/v3/ngx_http_v3_request.c
+++ b/src/http/v3/ngx_http_v3_request.c
@@ -1602,7 +1602,7 @@ ngx_http_v3_request_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
         while (cl->buf->pos < cl->buf->last) {
 
-            if (st->length == 0) {
+            if (st->length == 0 || st->type != NGX_HTTP_V3_FRAME_DATA) {
                 p = cl->buf->pos;
 
                 rc = ngx_http_v3_parse_data(r->connection, st, cl->buf);


### PR DESCRIPTION
An unknown HTTP/3 frame split across input buffers can have its continuation forwarded as request body. Without Content-Length, those bytes can also bypass the existing client_max_body_size check. A completed skip can leave a stale frame length while the following DATA header is incomplete.

Resume the frame parser whenever the current frame is not DATA, and clear the remaining length after a skip completes. Unknown payload stays out of the body while DATA retains the existing size checks.

This PR contains only the production fix: one commit, two source files, two added lines and one removed line. Functional regression tests are proposed separately in [nginx-tests#120](https://github.com/nginx/nginx-tests/pull/120), using the existing HTTP/3 test client and no new test infrastructure.

### Relationship to #1624

Related to #1624, which clears the length after a completed skip. It does not change the body filter's handling of an unknown payload continued in another buffer. This PR additionally checks the frame type before consuming bytes as body data.

The companion functional test adds 14 assertions for reserved payloads larger than the request-body buffer, before/between/after DATA, and aggregate DATA limits, in buffered and unbuffered modes. Against master f9c4264b6, both stock nginx and #1624 alone fail 10 assertions; this fix passes all of them. Related tests in nginx-tests#96 cover complete reserved frames.

### Validation

- Exact production commit 83ff353582bb61fe39622d1b700135b4259dab18: Linux build passed; all 19 h3_*.t files passed with the companion tests (323 assertions), using CryptX and live QUIC connections.
- Current master f9c4264b6 plus the same patch: the same HTTP/3 suite passed (323 assertions).
- Earlier standalone production-code C harness: 15 cases across 844 buffer/mode/FIN variants passed, including a Clang ASan/UBSan run with UBSAN_OPTIONS=halt_on_error=1. The production source in that tested revision is identical to this commit. The harness is retained as [supplementary validation](https://github.com/zerox80/nginx/tree/b9db030e468ecd6903d563908613f897d56945f3/tests/unit); it and its CI workflow are not part of this PR.

No full nginx-tests-suite pass or non-Linux runtime validation is claimed for this PR commit. Maintainer review is still required.

Originally opened against my own fork by mistake: https://github.com/zerox80/nginx/pull/1. Review belongs here, against nginx/nginx:master.

AI assistance: OpenAI Codex assisted with implementation, regression tests, validation and PR preparation.
